### PR TITLE
Added patched versuion of protobuf 

### DIFF
--- a/protobuf.rb
+++ b/protobuf.rb
@@ -43,7 +43,9 @@ class Protobuf < Formula
     end
   end
   def patches
-    # http://code.google.com/p/protobuf/issues/detail?id=128
+		# Patch to deal with protobuf problems in MacOsX
+		# Details  : https://bitbucket.org/osrf/release-tools/issue/25
+    # Upstream : http://code.google.com/p/protobuf/issues/detail?id=128
     DATA
   end
 end


### PR DESCRIPTION
Details are described in: https://bitbucket.org/osrf/release-tools/issue/25/homebrew-problem-with-protobuf-and-plugins

I believe that is better hosted in OSRF repository instead of my own account.
