### PR TITLE
Make sure that Ogre finds the correct freetype files if X11 is installed...

### DIFF
--- a/ogre.rb
+++ b/ogre.rb
@@ -48,6 +48,7 @@ class Ogre < Formula
 
   def install
     ENV.m64
+    ENV.append "CMAKE_INCLUDE_PATH", ":/usr/local/include/freetype2"
 
     cmake_args = [
       "-DCMAKE_OSX_ARCHITECTURES='x86_64'",


### PR DESCRIPTION
..., as reported in https://github.com/osrf/homebrew-simulation/issues/4 .
