### PR TITLE
Update sdformat sha

### DIFF
--- a/sdformat.rb
+++ b/sdformat.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Sdformat < Formula
   homepage 'http://gazebosim.org/sdf.html'
   url 'http://gazebosim.org/assets/distributions/sdformat-2.0.1.tar.bz2'
-  sha1 '9738830c021378ed173a179a696d0e3f7489e1de'
+  sha1 '3b61426e07661d42ef6e5938a80f382436013a8f'
   head 'https://bitbucket.org/osrf/sdformat', :branch => 'sdf_2.0', :using => :hg
 
   depends_on 'boost'


### PR DESCRIPTION
Not sure why, but seems like sha in [sdformat is not right](http://build.osrfoundation.org/job/gazebo-any-devel-homebrew_bcn-amd64/121/console). I've updated the formulae to current sha.
