### PR TITLE
Point the Ogre download at a specific mirror.

### DIFF
--- a/ogre.rb
+++ b/ogre.rb
@@ -1,6 +1,6 @@
 class Ogre < Formula
   homepage "http://www.ogre3d.org/"
-  url "https://downloads.sourceforge.net/project/ogre/ogre/1.7/ogre_src_v1-7-4.tar.bz2"
+  url "http://ufpr.dl.sourceforge.net/project/ogre/ogre/1.7/ogre_src_v1-7-4.tar.bz2"
   version "1.7.4"
   sha256 "afa475803d9e6980ddf3641dceaa53fcfbd348506ed67893c306766c166a4882"
   head "https://bitbucket.org/sinbad/ogre", :branch => "v1-9", :using => :hg


### PR DESCRIPTION
Bypasses sourceforge's new JS-based redirect dingus that breaks Homebrew.

cf. https://github.com/Homebrew/homebrew/issues/41778#issuecomment-122380024