### PR TITLE
sdformat4: treat pkg-config as normal dep

### DIFF
--- a/sdformat4.rb
+++ b/sdformat4.rb
@@ -5,6 +5,11 @@ class Sdformat4 < Formula
   sha256 "0f63e446a29073affed2427214aa04d23c1cb8331cdd1bd7d48768d7eee5862a"
   head "https://bitbucket.org/osrf/sdformat", :branch => "default", :using => :hg
 
+  bottle do
+    root_url "http://gazebosim.org/distributions/sdformat/releases"
+    sha256 "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF" => :yosemite
+  end
+
   depends_on "cmake" => :build
 
   depends_on "boost"

--- a/sdformat4.rb
+++ b/sdformat4.rb
@@ -6,11 +6,11 @@ class Sdformat4 < Formula
   head "https://bitbucket.org/osrf/sdformat", :branch => "default", :using => :hg
 
   depends_on "cmake" => :build
-  depends_on "pkg-config" => :run
 
   depends_on "boost"
   depends_on "doxygen"
   depends_on "ignition-math2"
+  depends_on "pkg-config" => :run
   depends_on "ros/deps/urdfdom" => :optional
   depends_on "tinyxml"
 


### PR DESCRIPTION
`pkg-config` is both a build-time and run-time dependency (for the test), so treat it as a normal dependency.