### PR TITLE
Fix build error of ignition-transport 1.3.0

### DIFF
--- a/ignition-transport.rb
+++ b/ignition-transport.rb
@@ -16,7 +16,7 @@ class IgnitionTransport < Formula
   depends_on "pkg-config" => :run
 
   depends_on "ignition-tools"
-  depends_on "protobuf"
+  depends_on "protobuf260"
   depends_on "protobuf-c" => :build
   depends_on "ossp-uuid"
   depends_on "zeromq"


### PR DESCRIPTION
This patch fix the issue
https://github.com/osrf/homebrew-simulation/issues/120.
ignition-transport depends on protobuf260 and the current protobuf
version in Home brew is 3.0.2. So we have to change the dependency
settings to protobuf260.