### PR TITLE
Bump revision on gazebo7 due to problems with bullet dependency

### DIFF
--- a/gazebo7.rb
+++ b/gazebo7.rb
@@ -3,6 +3,7 @@ class Gazebo7 < Formula
   homepage "http://gazebosim.org"
   url "http://gazebosim.org/distributions/gazebo/releases/gazebo-7.4.0.tar.bz2"
   sha256 "a033b2273383f16e5dd5b5bfe597551dc3618b98e64abecfa8a41bdddd6542f7"
+  revision 1
 
   head "https://bitbucket.org/osrf/gazebo", :branch => "gazebo7", :using => :hg
 


### PR DESCRIPTION
Bullet recently got updated and it changed libraries [name making gazebo binary not able to find previous bullet libraries](http://build.osrfoundation.org/view/All/job/gazebo-install-one_liner-homebrew-amd64/336/consoleFull#-1972803183b8221636-6cd8-440f-bb53-7855dac94d03). 