### PR TITLE
Bump revision on gazebo7 due to problems with bullet dependency

### DIFF
--- a/gazebo5.rb
+++ b/gazebo5.rb
@@ -9,7 +9,7 @@ class Gazebo5 < Formula
 
   bottle do
     root_url "http://gazebosim.org/distributions/gazebo/releases"
-    sha256 "d6facb3dfdc3ec0bc527e61179c3c3f738f81526df7ce4a3b55c92b43064f382" => :yosemite
+    sha256 "52c80d40792f3b96c4c6efe6d7c1380cda2f2b173cddbec2e764bdead7e95478" => :yosemite
   end
 
   depends_on "cmake" => :build

--- a/gazebo5.rb
+++ b/gazebo5.rb
@@ -3,7 +3,7 @@ class Gazebo5 < Formula
   homepage "http://gazebosim.org"
   url "http://gazebosim.org/distributions/gazebo/releases/gazebo-5.3.0.tar.bz2"
   sha256 "9355277ea3f20f411fcb664d891c2f409130cbb16fe844a86cd2f9a90c6428de"
-  revision 1
+  revision 2
 
   head "https://bitbucket.org/osrf/gazebo", :branch => "gazebo5", :using => :hg
 

--- a/gazebo6.rb
+++ b/gazebo6.rb
@@ -9,7 +9,7 @@ class Gazebo6 < Formula
 
   bottle do
     root_url "http://gazebosim.org/distributions/gazebo/releases"
-    sha256 "c2bcf7150ad456e70b038f9e32536d96889d1793e87d104e3daa5e412ec8ad4d" => :yosemite
+    sha256 "d6e58282d6943dbc4f49e316009e7ac009beba12bf00843224609baa3840dba4" => :yosemite
   end
 
   depends_on "cmake" => :build

--- a/gazebo6.rb
+++ b/gazebo6.rb
@@ -3,7 +3,7 @@ class Gazebo6 < Formula
   homepage "http://gazebosim.org"
   url "http://gazebosim.org/distributions/gazebo/releases/gazebo-6.6.0.tar.bz2"
   sha256 "0097f694cbcaad8a4508da78472cdf9ccf4cdf7ab20f153beb151b48d7252e96"
-  revision 2
+  revision 3
 
   head "https://bitbucket.org/osrf/gazebo", :branch => "gazebo6", :using => :hg
 

--- a/gazebo7.rb
+++ b/gazebo7.rb
@@ -3,6 +3,7 @@ class Gazebo7 < Formula
   homepage "http://gazebosim.org"
   url "http://gazebosim.org/distributions/gazebo/releases/gazebo-7.4.0.tar.bz2"
   sha256 "a033b2273383f16e5dd5b5bfe597551dc3618b98e64abecfa8a41bdddd6542f7"
+  revision 1
 
   head "https://bitbucket.org/osrf/gazebo", :branch => "gazebo7", :using => :hg
 

--- a/gazebo7.rb
+++ b/gazebo7.rb
@@ -9,7 +9,7 @@ class Gazebo7 < Formula
 
   bottle do
     root_url "http://gazebosim.org/distributions/gazebo/releases"
-    sha256 "3ec0b76c6a88dac79604e58e9e447dd010a9b3cf66a18f8e93c7f6ff2247616a" => :yosemite
+    sha256 "010c6cbaaa7c58f309547127516f4fae72899c1b188abf5a94e94a0ac2b6b003" => :yosemite
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
Bullet recently got updated and it changed library names making
gazebo binary not able to find previous bullet libraries.