### PR TITLE
WIP: OS X Sierra Gazebo 7 support

### DIFF
--- a/gazebo7.rb
+++ b/gazebo7.rb
@@ -27,7 +27,7 @@ class Gazebo7 < Formula
   depends_on "ogre"
   depends_on "protobuf"
   depends_on "protobuf-c"
-  depends_on "qt4"
+  depends_on "px4/simulation/qt"
   depends_on "sdformat4"
   depends_on "tbb"
   depends_on "tinyxml"

--- a/gazebo7.rb
+++ b/gazebo7.rb
@@ -27,7 +27,7 @@ class Gazebo7 < Formula
   depends_on "ogre"
   depends_on "protobuf"
   depends_on "protobuf-c"
-  depends_on "qt"
+  depends_on "cartr/qt4"
   depends_on "sdformat4"
   depends_on "tbb"
   depends_on "tinyxml"

--- a/gazebo7.rb
+++ b/gazebo7.rb
@@ -13,7 +13,7 @@ class Gazebo7 < Formula
     rebuild 3
     sha256 "6bcb352bca6d15e333540b10aab93a7f94308c64508951f9b6240313a095425b" => :el_capitan
     sha256 "68274d6c7b1a84ba3cbdabdb4328e3afe8e548cf405252b08176fa0637267588" => :yosemite
-    sha256 "1ec705f1399818ff2fab5eaf1a95ff2223a6b09508a05487d7133d0c6ae975ef" => :sierra
+    sha256 "9a71354010faea9ef546af71e6008f6cfbf863ca1602159ffcc9387bf4cd9794" => :sierra
   end
 
   depends_on "cmake" => :build

--- a/gazebo7.rb
+++ b/gazebo7.rb
@@ -10,6 +10,7 @@ class Gazebo7 < Formula
   bottle do
     #root_url "http://gazebosim.org/distributions/ign-math/releases"
     root_url "http://px4-travis.s3.amazonaws.com/toolchain/bottles"
+    rebuild 1
     sha256 "bf5b7d5aee51abb822f84ef584fbe46daf300c8ab06cdbbb1be822c1df6efdc3" => :el_capitan
     sha256 "68274d6c7b1a84ba3cbdabdb4328e3afe8e548cf405252b08176fa0637267588" => :yosemite
     sha256 "73309c329cf01db849dd195804011589d4e862e9afe996b34e4505c43b286717" => :sierra

--- a/gazebo7.rb
+++ b/gazebo7.rb
@@ -27,7 +27,7 @@ class Gazebo7 < Formula
   depends_on "ogre"
   depends_on "protobuf"
   depends_on "protobuf-c"
-  depends_on "cartr/qt4/qt"
+  depends_on "qt4"
   depends_on "sdformat4"
   depends_on "tbb"
   depends_on "tinyxml"

--- a/gazebo7.rb
+++ b/gazebo7.rb
@@ -10,10 +10,10 @@ class Gazebo7 < Formula
   bottle do
     #root_url "http://gazebosim.org/distributions/ign-math/releases"
     root_url "http://px4-travis.s3.amazonaws.com/toolchain/bottles"
-    rebuild 1
+    rebuild 2
     sha256 "bf5b7d5aee51abb822f84ef584fbe46daf300c8ab06cdbbb1be822c1df6efdc3" => :el_capitan
     sha256 "68274d6c7b1a84ba3cbdabdb4328e3afe8e548cf405252b08176fa0637267588" => :yosemite
-    sha256 "73309c329cf01db849dd195804011589d4e862e9afe996b34e4505c43b286717" => :sierra
+    sha256 "b7e9559955d9a3f1b4873d5b4df5d05c7c99503c8d50e640db1bd679c49af97e" => :sierra
   end
 
   depends_on "cmake" => :build

--- a/gazebo7.rb
+++ b/gazebo7.rb
@@ -10,10 +10,10 @@ class Gazebo7 < Formula
   bottle do
     #root_url "http://gazebosim.org/distributions/ign-math/releases"
     root_url "http://px4-travis.s3.amazonaws.com/toolchain/bottles"
-    rebuild 2
+    rebuild 3
     sha256 "2bf9fca4eabf4c846082a7e8232a9d2b3a5aea695ca6c5d446fb58b2c752fa45" => :el_capitan
     sha256 "68274d6c7b1a84ba3cbdabdb4328e3afe8e548cf405252b08176fa0637267588" => :yosemite
-    sha256 "b7e9559955d9a3f1b4873d5b4df5d05c7c99503c8d50e640db1bd679c49af97e" => :sierra
+    sha256 "1ec705f1399818ff2fab5eaf1a95ff2223a6b09508a05487d7133d0c6ae975ef" => :sierra
   end
 
   depends_on "cmake" => :build

--- a/gazebo7.rb
+++ b/gazebo7.rb
@@ -27,7 +27,7 @@ class Gazebo7 < Formula
   depends_on "ogre"
   depends_on "protobuf"
   depends_on "protobuf-c"
-  depends_on "cartr/qt4"
+  depends_on "cartr/qt4/qt"
   depends_on "sdformat4"
   depends_on "tbb"
   depends_on "tinyxml"

--- a/gazebo7.rb
+++ b/gazebo7.rb
@@ -11,7 +11,7 @@ class Gazebo7 < Formula
     #root_url "http://gazebosim.org/distributions/ign-math/releases"
     root_url "http://px4-travis.s3.amazonaws.com/toolchain/bottles"
     rebuild 2
-    sha256 "bf5b7d5aee51abb822f84ef584fbe46daf300c8ab06cdbbb1be822c1df6efdc3" => :el_capitan
+    sha256 "2bf9fca4eabf4c846082a7e8232a9d2b3a5aea695ca6c5d446fb58b2c752fa45" => :el_capitan
     sha256 "68274d6c7b1a84ba3cbdabdb4328e3afe8e548cf405252b08176fa0637267588" => :yosemite
     sha256 "b7e9559955d9a3f1b4873d5b4df5d05c7c99503c8d50e640db1bd679c49af97e" => :sierra
   end

--- a/gazebo7.rb
+++ b/gazebo7.rb
@@ -11,7 +11,7 @@ class Gazebo7 < Formula
     #root_url "http://gazebosim.org/distributions/ign-math/releases"
     root_url "http://px4-travis.s3.amazonaws.com/toolchain/bottles"
     rebuild 3
-    sha256 "2bf9fca4eabf4c846082a7e8232a9d2b3a5aea695ca6c5d446fb58b2c752fa45" => :el_capitan
+    sha256 "6bcb352bca6d15e333540b10aab93a7f94308c64508951f9b6240313a095425b" => :el_capitan
     sha256 "68274d6c7b1a84ba3cbdabdb4328e3afe8e548cf405252b08176fa0637267588" => :yosemite
     sha256 "1ec705f1399818ff2fab5eaf1a95ff2223a6b09508a05487d7133d0c6ae975ef" => :sierra
   end

--- a/gazebo7.rb
+++ b/gazebo7.rb
@@ -8,9 +8,11 @@ class Gazebo7 < Formula
   head "https://bitbucket.org/osrf/gazebo", :branch => "gazebo7", :using => :hg
 
   bottle do
-    root_url "http://gazebosim.org/distributions/gazebo/releases"
+    #root_url "http://gazebosim.org/distributions/ign-math/releases"
+    root_url "http://px4-travis.s3.amazonaws.com/toolchain/bottles"
     sha256 "bf5b7d5aee51abb822f84ef584fbe46daf300c8ab06cdbbb1be822c1df6efdc3" => :el_capitan
     sha256 "68274d6c7b1a84ba3cbdabdb4328e3afe8e548cf405252b08176fa0637267588" => :yosemite
+    sha256 "73309c329cf01db849dd195804011589d4e862e9afe996b34e4505c43b286717" => :sierra
   end
 
   depends_on "cmake" => :build

--- a/gazebo8.rb
+++ b/gazebo8.rb
@@ -23,7 +23,7 @@ class Gazebo8 < Formula
   depends_on "protobuf"
   depends_on "protobuf-c"
   depends_on "qt"
-  depends_on "osrf/simulation/qwt-qt4"
+  depends_on "qwt"
   depends_on "sdformat4"
   depends_on "tbb"
   depends_on "tinyxml"

--- a/ignition-math2.rb
+++ b/ignition-math2.rb
@@ -8,10 +8,12 @@ class IgnitionMath2 < Formula
   head "https://bitbucket.org/ignitionrobotics/ign-math", :branch => "default", :using => :hg
 
   bottle do
-    root_url "http://gazebosim.org/distributions/ign-math/releases"
+    #root_url "http://gazebosim.org/distributions/ign-math/releases"
+    root_url "http://px4-travis.s3.amazonaws.com/toolchain/bottles"
     cellar :any
     sha256 "098ed08a8d2afb93cfb9e457dc4f82c70ec304f70b8dc375e174116c2c2bce58" => :el_capitan
     sha256 "d18ff2dad5ecf0abb515ef8246ad21d9b21def2dc06ffb7a8f81112ea9f22fc2" => :yosemite
+    sha256 "234032f265c86e508c8ca8019547de75c2f4bac5440f4726faf32cf48b28e729" => :sierra
   end
 
   depends_on "cmake" => :build

--- a/ignition-math2.rb
+++ b/ignition-math2.rb
@@ -11,7 +11,7 @@ class IgnitionMath2 < Formula
     #root_url "http://gazebosim.org/distributions/ign-math/releases"
     root_url "http://px4-travis.s3.amazonaws.com/toolchain/bottles"
     cellar :any
-    sha256 "098ed08a8d2afb93cfb9e457dc4f82c70ec304f70b8dc375e174116c2c2bce58" => :el_capitan
+    sha256 "9d30668a239bae88f66267d74224b5df8b8d2fd6fd348e2b0401335759c910f9" => :el_capitan
     sha256 "d18ff2dad5ecf0abb515ef8246ad21d9b21def2dc06ffb7a8f81112ea9f22fc2" => :yosemite
     sha256 "234032f265c86e508c8ca8019547de75c2f4bac5440f4726faf32cf48b28e729" => :sierra
   end

--- a/ignition-math2.rb
+++ b/ignition-math2.rb
@@ -13,7 +13,8 @@ class IgnitionMath2 < Formula
     cellar :any
     sha256 "9d30668a239bae88f66267d74224b5df8b8d2fd6fd348e2b0401335759c910f9" => :el_capitan
     sha256 "d18ff2dad5ecf0abb515ef8246ad21d9b21def2dc06ffb7a8f81112ea9f22fc2" => :yosemite
-    sha256 "234032f265c86e508c8ca8019547de75c2f4bac5440f4726faf32cf48b28e729" => :sierra
+    rebuild 1
+    sha256 "2f031039a12336934fc6c39c31024bc6f242af35de17639c8a433bb828b84202" => :sierra
   end
 
   depends_on "cmake" => :build

--- a/ignition-transport.rb
+++ b/ignition-transport.rb
@@ -11,7 +11,7 @@ class IgnitionTransport < Formula
     #root_url "http://gazebosim.org/distributions/ign-math/releases"
     root_url "http://px4-travis.s3.amazonaws.com/toolchain/bottles"
     cellar :any
-    sha256 "3b3e6700c8e3ae337ea2fbac9327282cc9706d23b132c0fc3e946c912b210251" => :el_capitan
+    sha256 "78e60436cc225404e2545ba98e759320d4bc99406efb16d1d58c4492b59eee0d" => :el_capitan
     sha256 "bee72083247413b7ccb888820a5c6e832a549656d70decf9ac9ad86cc7367cdd" => :yosemite
     sha256 "f8bf0e21b85d10fe056f49cdc4ffb52c0f3ea53a7a9961a2975f846dcc46a7f4" => :sierra
   end

--- a/ignition-transport.rb
+++ b/ignition-transport.rb
@@ -13,7 +13,8 @@ class IgnitionTransport < Formula
     cellar :any
     sha256 "78e60436cc225404e2545ba98e759320d4bc99406efb16d1d58c4492b59eee0d" => :el_capitan
     sha256 "bee72083247413b7ccb888820a5c6e832a549656d70decf9ac9ad86cc7367cdd" => :yosemite
-    sha256 "f8bf0e21b85d10fe056f49cdc4ffb52c0f3ea53a7a9961a2975f846dcc46a7f4" => :sierra
+    rebuild 1
+    sha256 "ac779bcb5d7fdefd44e69f2e038c98a48f400f7e6bb69bd369b385cd9007894a" => :sierra
   end
 
   depends_on "cmake" => :build

--- a/ignition-transport.rb
+++ b/ignition-transport.rb
@@ -8,10 +8,12 @@ class IgnitionTransport < Formula
   head "https://bitbucket.org/ignitionrobotics/ign-transport", :branch => "ign-transport1", :using => :hg
 
   bottle do
-    root_url "http://gazebosim.org/distributions/ign-transport/releases"
+    #root_url "http://gazebosim.org/distributions/ign-math/releases"
+    root_url "http://px4-travis.s3.amazonaws.com/toolchain/bottles"
     cellar :any
     sha256 "3b3e6700c8e3ae337ea2fbac9327282cc9706d23b132c0fc3e946c912b210251" => :el_capitan
     sha256 "bee72083247413b7ccb888820a5c6e832a549656d70decf9ac9ad86cc7367cdd" => :yosemite
+    sha256 "f8bf0e21b85d10fe056f49cdc4ffb52c0f3ea53a7a9961a2975f846dcc46a7f4" => :sierra
   end
 
   depends_on "cmake" => :build

--- a/ogre.rb
+++ b/ogre.rb
@@ -11,7 +11,7 @@ class Ogre < Formula
   bottle do
     #root_url "http://gazebosim.org/distributions/ogre/releases"
     root_url "http://px4-travis.s3.amazonaws.com/toolchain/bottles"
-    sha256 "6d31ade42664a78b97be8339b86b3ef8ab5d41d36bc9e274cd11fb11874f8b81" => :el_capitan
+    sha256 "b038196ceb3cef0c00f73c88fe9d0279734157880f8017bf75c3411188a2b563" => :el_capitan
     sha256 "677884f99bf5763ff31c49a9977354e032c894bb0658d2e88a8e1c59edf1ddb4" => :yosemite
     sha256 "2cf91dae3a94b6f405cf9a449213f60f005ce661c471af8cf193974d7b558695" => :sierra
   end

--- a/ogre.rb
+++ b/ogre.rb
@@ -9,9 +9,11 @@ class Ogre < Formula
   head "https://bitbucket.org/sinbad/ogre", :branch => "v1-9", :using => :hg
 
   bottle do
-    root_url "http://gazebosim.org/distributions/ogre/releases"
+    #root_url "http://gazebosim.org/distributions/ogre/releases"
+    root_url "http://px4-travis.s3.amazonaws.com/toolchain/bottles"
     sha256 "6d31ade42664a78b97be8339b86b3ef8ab5d41d36bc9e274cd11fb11874f8b81" => :el_capitan
     sha256 "677884f99bf5763ff31c49a9977354e032c894bb0658d2e88a8e1c59edf1ddb4" => :yosemite
+    sha256 "2cf91dae3a94b6f405cf9a449213f60f005ce661c471af8cf193974d7b558695" => :sierra
   end
 
   option "with-cg"

--- a/qt.rb
+++ b/qt.rb
@@ -151,6 +151,7 @@ class Qt < Formula
   bottle do
     root_url "http://px4-travis.s3.amazonaws.com/toolchain/bottles"
     rebuild 1
+    sha256 "c3ba8dbf6e7f1de62cf9a548ae56e0eb8abb376860d31c60d2803eabbcf53681" => :el_capitan
     sha256 "276e8704ea68d534d2bf40987a1f5e67ef26ac4d1a186748e90af36bd5f3ec60" => :sierra
   end
 end

--- a/qt.rb
+++ b/qt.rb
@@ -1,4 +1,4 @@
-class Qt4 < Formula
+class Qt < Formula
   desc "Cross-platform application and UI framework"
   homepage "https://www.qt.io/"
   url "https://download.qt.io/official_releases/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz"

--- a/qt4.rb
+++ b/qt4.rb
@@ -1,4 +1,4 @@
-class Qt < Formula
+class Qt4 < Formula
   desc "Cross-platform application and UI framework"
   homepage "https://www.qt.io/"
   url "https://download.qt.io/official_releases/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz"

--- a/qt4.rb
+++ b/qt4.rb
@@ -1,0 +1,155 @@
+class Qt < Formula
+  desc "Cross-platform application and UI framework"
+  homepage "https://www.qt.io/"
+  url "https://download.qt.io/official_releases/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz"
+  mirror "https://www.mirrorservice.org/sites/download.qt-project.org/official_releases/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz"
+  sha256 "e2882295097e47fe089f8ac741a95fef47e0a73a3f3cdf21b56990638f626ea0"
+  revision 3
+
+  head "https://code.qt.io/qt/qt.git", :branch => "4.8"
+
+  # Backport of Qt5 commit to fix the fatal build error with Xcode 7, SDK 10.11.
+  # https://code.qt.io/cgit/qt/qtbase.git/commit/?id=b06304e164ba47351fa292662c1e6383c081b5ca
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/480b7142c4e2ae07de6028f672695eb927a34875/qt/el-capitan.patch"
+    sha256 "c8a0fa819c8012a7cb70e902abb7133fc05235881ce230235d93719c47650c4e"
+  end
+
+  # Backport of Qt5 patch to fix an issue with null bytes in QSetting strings.
+  patch do
+    url "https://raw.githubusercontent.com/cartr/homebrew-qt4/41669527a2aac6aeb8a5eeb58f440d3f3498910a/patches/qsetting-nulls.patch"
+    sha256 "0deb4cd107853b1cc0800e48bb36b3d5682dc4a2a29eb34a6d032ac4ffe32ec3"
+  end
+
+  option "with-qt3support", "Build with deprecated Qt3Support module support"
+  option "with-docs", "Build documentation"
+  option "without-webkit", "Build without QtWebKit module"
+
+  depends_on "openssl"
+  depends_on "dbus" => :optional
+  depends_on "mysql" => :optional
+  depends_on "postgresql" => :optional
+
+  deprecated_option "qtdbus" => "with-dbus"
+  deprecated_option "with-d-bus" => "with-dbus"
+
+  resource "test-project" do
+    url "https://gist.github.com/tdsmith/f55e7e69ae174b5b5a03.git",
+        :revision => "6f565390395a0259fa85fdd3a4f1968ebcd1cc7d"
+  end
+
+  def install
+    args = %W[
+      -prefix #{prefix}
+      -release
+      -opensource
+      -confirm-license
+      -fast
+      -system-zlib
+      -qt-libtiff
+      -qt-libpng
+      -qt-libjpeg
+      -nomake demos
+      -nomake examples
+      -cocoa
+    ]
+
+    if ENV.compiler == :clang
+      args << "-platform"
+
+      if MacOS.version >= :mavericks
+        args << "unsupported/macx-clang-libc++"
+      else
+        args << "unsupported/macx-clang"
+      end
+    end
+
+    # Phonon is broken on macOS 10.12+ and Xcode 8+ due to QTKit.framework
+    # being removed.
+    args << "-no-phonon" if MacOS.version >= :sierra || MacOS::Xcode.version >= "8.0"
+
+    args << "-openssl-linked"
+    args << "-I" << Formula["openssl"].opt_include
+    args << "-L" << Formula["openssl"].opt_lib
+
+    args << "-plugin-sql-mysql" if build.with? "mysql"
+    args << "-plugin-sql-psql" if build.with? "postgresql"
+
+    if build.with? "dbus"
+      dbus_opt = Formula["dbus"].opt_prefix
+      args << "-I#{dbus_opt}/lib/dbus-1.0/include"
+      args << "-I#{dbus_opt}/include/dbus-1.0"
+      args << "-L#{dbus_opt}/lib"
+      args << "-ldbus-1"
+      args << "-dbus-linked"
+    end
+
+    if build.with? "qt3support"
+      args << "-qt3support"
+    else
+      args << "-no-qt3support"
+    end
+
+    args << "-nomake" << "docs" if build.without? "docs"
+
+    if MacOS.prefer_64_bit?
+      args << "-arch" << "x86_64"
+    else
+      args << "-arch" << "x86"
+    end
+
+    args << "-no-webkit" if build.without? "webkit"
+
+    system "./configure", *args
+    system "make"
+    ENV.j1
+    system "make", "install"
+
+    # what are these anyway?
+    (bin+"pixeltool.app").rmtree
+    (bin+"qhelpconverter.app").rmtree
+    # remove porting file for non-humans
+    (prefix+"q3porting.xml").unlink if build.without? "qt3support"
+
+    # Some config scripts will only find Qt in a "Frameworks" folder
+    frameworks.install_symlink Dir["#{lib}/*.framework"]
+
+    # The pkg-config files installed suggest that headers can be found in the
+    # `include` directory. Make this so by creating symlinks from `include` to
+    # the Frameworks' Headers folders.
+    Pathname.glob("#{lib}/*.framework/Headers") do |path|
+      include.install_symlink path => path.parent.basename(".framework")
+    end
+
+    # Make `HOMEBREW_PREFIX/lib/qt4/plugins` an additional plug-in search path
+    # for Qt Designer to support formulae that provide Qt Designer plug-ins.
+    system "/usr/libexec/PlistBuddy",
+            "-c", "Add :LSEnvironment:QT_PLUGIN_PATH string \"#{HOMEBREW_PREFIX}/lib/qt4/plugins\"",
+           "#{bin}/Designer.app/Contents/Info.plist"
+
+    Pathname.glob("#{bin}/*.app") { |app| mv app, prefix }
+  end
+
+  def caveats; <<-EOS.undent
+    We agreed to the Qt opensource license for you.
+    If this is unacceptable you should uninstall.
+    Qt Designer no longer picks up changes to the QT_PLUGIN_PATH environment
+    variable as it was tweaked to search for plug-ins provided by formulae in
+      #{HOMEBREW_PREFIX}/lib/qt4/plugins
+    Phonon is not supported on macOS Sierra or with Xcode 8.
+    EOS
+  end
+
+  test do
+    Encoding.default_external = "UTF-8" unless RUBY_VERSION.start_with? "1."
+    resource("test-project").stage testpath
+    system bin/"qmake"
+    system "make"
+    assert_match(/GitHub/, pipe_output(testpath/"qtnetwork-test 2>&1", nil, 0))
+  end
+
+  bottle do
+    root_url "http://px4-travis.s3.amazonaws.com/toolchain/bottles"
+    sha256 "276e8704ea68d534d2bf40987a1f5e67ef26ac4d1a186748e90af36bd5f3ec60" => :sierra
+  end
+end

--- a/qt4.rb
+++ b/qt4.rb
@@ -150,6 +150,7 @@ class Qt4 < Formula
 
   bottle do
     root_url "http://px4-travis.s3.amazonaws.com/toolchain/bottles"
+    rebuild 1
     sha256 "276e8704ea68d534d2bf40987a1f5e67ef26ac4d1a186748e90af36bd5f3ec60" => :sierra
   end
 end

--- a/sdformat4.rb
+++ b/sdformat4.rb
@@ -12,7 +12,8 @@ class Sdformat4 < Formula
     root_url "http://px4-travis.s3.amazonaws.com/toolchain/bottles"
     sha256 "41980363d24f72d749322f4a8b3fca3e20223d5fd62df9004ff3eb2a438b8e7c" => :el_capitan
     sha256 "e2d043add111f1729f1c188506a65ebbe390099b0e46d7eb6be1592384d0f045" => :yosemite
-    sha256 "d93b4d90b5ac2166f25a4c1e47904734b5acd1dd4001d72227c88a2bbbf9a300" => :sierra
+    rebuild 1
+    sha256 "48a59606bb6b7ad867c0aaf9202d4c5f0174d378609525b128ea935861e25778" => :sierra
   end
 
   depends_on "cmake" => :build

--- a/sdformat4.rb
+++ b/sdformat4.rb
@@ -19,7 +19,7 @@ class Sdformat4 < Formula
 
   # There is a link error with latest boost
   # dyld: Symbol not found: __ZNK5boost16re_detail_10630031cpp_regex_traits_implementationIcE17transform_primaryEPKcS4_
-  depends_on "boost@1.55"
+  depends_on "boost"
   depends_on "doxygen"
   depends_on "ignition-math2"
   depends_on "pkg-config" => :run

--- a/sdformat4.rb
+++ b/sdformat4.rb
@@ -8,9 +8,11 @@ class Sdformat4 < Formula
   head "https://bitbucket.org/osrf/sdformat", :branch => "default", :using => :hg
 
   bottle do
-    root_url "http://gazebosim.org/distributions/sdformat/releases"
+    #root_url "http://gazebosim.org/distributions/ign-math/releases"
+    root_url "http://px4-travis.s3.amazonaws.com/toolchain/bottles"
     sha256 "0a8de24e849e2a4fbefa6c4916ff2d35ce46be70897899422d006c76c49a295b" => :el_capitan
     sha256 "e2d043add111f1729f1c188506a65ebbe390099b0e46d7eb6be1592384d0f045" => :yosemite
+    sha256 "51a5f9163769b40f78d6b5845ef9c9d42464b89ccd85cd057a06cfcec0bca348" => :sierra
   end
 
   depends_on "cmake" => :build

--- a/sdformat4.rb
+++ b/sdformat4.rb
@@ -17,7 +17,9 @@ class Sdformat4 < Formula
 
   depends_on "cmake" => :build
 
-  depends_on "boost"
+  # There is a link error with latest boost
+  # dyld: Symbol not found: __ZNK5boost16re_detail_10630031cpp_regex_traits_implementationIcE17transform_primaryEPKcS4_
+  depends_on "boost@1.55"
   depends_on "doxygen"
   depends_on "ignition-math2"
   depends_on "pkg-config" => :run

--- a/sdformat4.rb
+++ b/sdformat4.rb
@@ -12,7 +12,7 @@ class Sdformat4 < Formula
     root_url "http://px4-travis.s3.amazonaws.com/toolchain/bottles"
     sha256 "0a8de24e849e2a4fbefa6c4916ff2d35ce46be70897899422d006c76c49a295b" => :el_capitan
     sha256 "e2d043add111f1729f1c188506a65ebbe390099b0e46d7eb6be1592384d0f045" => :yosemite
-    sha256 "51a5f9163769b40f78d6b5845ef9c9d42464b89ccd85cd057a06cfcec0bca348" => :sierra
+    sha256 "d93b4d90b5ac2166f25a4c1e47904734b5acd1dd4001d72227c88a2bbbf9a300" => :sierra
   end
 
   depends_on "cmake" => :build

--- a/sdformat4.rb
+++ b/sdformat4.rb
@@ -10,7 +10,7 @@ class Sdformat4 < Formula
   bottle do
     #root_url "http://gazebosim.org/distributions/ign-math/releases"
     root_url "http://px4-travis.s3.amazonaws.com/toolchain/bottles"
-    sha256 "de4f0b6e8b56050ed0aee2edc0d28556367119764011847b17ccc32bb6fc540b" => :el_capitan
+    sha256 "41980363d24f72d749322f4a8b3fca3e20223d5fd62df9004ff3eb2a438b8e7c" => :el_capitan
     sha256 "e2d043add111f1729f1c188506a65ebbe390099b0e46d7eb6be1592384d0f045" => :yosemite
     sha256 "d93b4d90b5ac2166f25a4c1e47904734b5acd1dd4001d72227c88a2bbbf9a300" => :sierra
   end

--- a/sdformat4.rb
+++ b/sdformat4.rb
@@ -10,7 +10,7 @@ class Sdformat4 < Formula
   bottle do
     #root_url "http://gazebosim.org/distributions/ign-math/releases"
     root_url "http://px4-travis.s3.amazonaws.com/toolchain/bottles"
-    sha256 "ca31f407b1826b3d5b26d85138c17c8a182b200817f0ff4efff4a13c7de87370" => :el_capitan
+    sha256 "de4f0b6e8b56050ed0aee2edc0d28556367119764011847b17ccc32bb6fc540b" => :el_capitan
     sha256 "e2d043add111f1729f1c188506a65ebbe390099b0e46d7eb6be1592384d0f045" => :yosemite
     sha256 "d93b4d90b5ac2166f25a4c1e47904734b5acd1dd4001d72227c88a2bbbf9a300" => :sierra
   end

--- a/sdformat4.rb
+++ b/sdformat4.rb
@@ -10,7 +10,7 @@ class Sdformat4 < Formula
   bottle do
     #root_url "http://gazebosim.org/distributions/ign-math/releases"
     root_url "http://px4-travis.s3.amazonaws.com/toolchain/bottles"
-    sha256 "0a8de24e849e2a4fbefa6c4916ff2d35ce46be70897899422d006c76c49a295b" => :el_capitan
+    sha256 "ca31f407b1826b3d5b26d85138c17c8a182b200817f0ff4efff4a13c7de87370" => :el_capitan
     sha256 "e2d043add111f1729f1c188506a65ebbe390099b0e46d7eb6be1592384d0f045" => :yosemite
     sha256 "d93b4d90b5ac2166f25a4c1e47904734b5acd1dd4001d72227c88a2bbbf9a300" => :sierra
   end

--- a/simbody.rb
+++ b/simbody.rb
@@ -9,7 +9,7 @@ class Simbody < Formula
   bottle do
     #root_url "http://gazebosim.org/distributions/ign-math/releases"
     root_url "http://px4-travis.s3.amazonaws.com/toolchain/bottles"
-    sha256 "e37ea67010f856dbe63b52a8136ad468c3d3dc48eead2ee3e7227abdbb55dd19" => :el_capitan
+    sha256 "93c472a08f9af48d73ff09cbd02acf64a9b001a99057c80f16d58bca69431b99" => :el_capitan
     sha256 "374b70963d6d5336eccaa83427a1acf0c938b97b618a10a7c1181fdcf06f1c09" => :yosemite
     sha256 "10be845ceb87d95413b367e16271c6e624603f75361182b58faeea9ca8ae4d99" => :sierra
   end

--- a/simbody.rb
+++ b/simbody.rb
@@ -7,9 +7,11 @@ class Simbody < Formula
   revision 1
 
   bottle do
-    root_url "http://gazebosim.org/distributions/simbody/releases"
+    #root_url "http://gazebosim.org/distributions/ign-math/releases"
+    root_url "http://px4-travis.s3.amazonaws.com/toolchain/bottles"
     sha256 "e37ea67010f856dbe63b52a8136ad468c3d3dc48eead2ee3e7227abdbb55dd19" => :el_capitan
     sha256 "374b70963d6d5336eccaa83427a1acf0c938b97b618a10a7c1181fdcf06f1c09" => :yosemite
+    sha256 "10be845ceb87d95413b367e16271c6e624603f75361182b58faeea9ca8ae4d99" => :sierra
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
This is for initial feedback only. I will do a proper PR when you have moved the bottle files to your server. Watch the Qt version overlay, which needs to be osrf/simulation/qt (right now px4/simulation/qt).

Test instructions:
```
brew uninstall gazebo7
brew untap osrf/simulation
brew tap px4/simulation
brew update
brew install gazebo7
```

Bottles:
http://px4-travis.s3.amazonaws.com/toolchain/bottles/gazebo7-7.4.0_3.sierra.bottle.2.tar.gz
http://px4-travis.s3.amazonaws.com/toolchain/bottles/ignition-math2-2.6.0_1.sierra.bottle.1.tar.gz
http://px4-travis.s3.amazonaws.com/toolchain/bottles/ignition-transport-1.4.0_1.sierra.bottle.1.tar.gz
http://px4-travis.s3.amazonaws.com/toolchain/bottles/ogre-1.7.4_1.sierra.bottle.1.tar.gz
http://px4-travis.s3.amazonaws.com/toolchain/bottles/qt-4.8.7_3.sierra.bottle.1.tar.gz
http://px4-travis.s3.amazonaws.com/toolchain/bottles/sdformat4-4.2.0_2.sierra.bottle.1.tar.gz
http://px4-travis.s3.amazonaws.com/toolchain/bottles/simbody-3.5.4_1.sierra.bottle.1.tar.gz