### PR TITLE
Add Travis badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/osrf/homebrew-simulation.svg?branch=master)](https://travis-ci.org/osrf/homebrew-simulation)
+
 homebrew-simulation
 ===================
 


### PR DESCRIPTION
Some bling for the README, this was the first thing I looked for when I saw that a Travis job had failed on a PR.