### PR TITLE
Bump all formula versions using protobuf

### DIFF
--- a/gazebo7.rb
+++ b/gazebo7.rb
@@ -11,7 +11,7 @@ class Gazebo7 < Formula
   bottle do
     root_url "http://gazebosim.org/distributions/gazebo/releases"
     sha256 "c0bdafffd5a9bd651875529bfdcefdd0308aaef48ef7f154085f80445d3c456c" => :el_capitan
-    sha256 "cead3a712828172ae6d587f523bf78ea919d307f67bd7f80ec32d0c5a5ab4c1e" => :yosemite
+    sha256 "ccafb3c57926f8391a00a4fc493d79ae50754edd009c816d1820dac0ebbc3208" => :yosemite
   end
 
   depends_on "cmake" => :build

--- a/gazebo7.rb
+++ b/gazebo7.rb
@@ -4,6 +4,8 @@ class Gazebo7 < Formula
   url "http://gazebosim.org/distributions/gazebo/releases/gazebo-7.5.0.tar.bz2"
   sha256 "15d87d0d329ef37ff82e676e7b8b0c8535c40ba635cdebd5b8ee3b5832fa8e56"
 
+  revision 1
+
   head "https://bitbucket.org/osrf/gazebo", :branch => "gazebo7", :using => :hg
 
   bottle do

--- a/gazebo7.rb
+++ b/gazebo7.rb
@@ -10,7 +10,7 @@ class Gazebo7 < Formula
 
   bottle do
     root_url "http://gazebosim.org/distributions/gazebo/releases"
-    sha256 "c0bdafffd5a9bd651875529bfdcefdd0308aaef48ef7f154085f80445d3c456c" => :el_capitan
+    sha256 "faa76768c5fc008efaa68facd0dddd72ecd0585a523d25c5975365770891bf0d" => :el_capitan
     sha256 "ccafb3c57926f8391a00a4fc493d79ae50754edd009c816d1820dac0ebbc3208" => :yosemite
   end
 

--- a/gazebo8.rb
+++ b/gazebo8.rb
@@ -11,7 +11,7 @@ class Gazebo8 < Formula
   bottle do
      root_url "http://gazebosim.org/distributions/gazebo/releases"
      sha256 "dcd2b73f57686e390a7f8eac5493172616a358ac0a88928a84c9ce832379d817" => :el_capitan
-     sha256 "9b730f5bac77a20c11afbe7aed89072afbc4bcd39d92a2f6d3a8125f98f4d85c" => :yosemite
+     sha256 "2659e4b71935c8c2cc61e0b8fa1df197d486b74e3970a64b5e488dec21ff612e" => :yosemite
   end
 
   depends_on "cmake" => :build

--- a/gazebo8.rb
+++ b/gazebo8.rb
@@ -10,7 +10,7 @@ class Gazebo8 < Formula
 
   bottle do
      root_url "http://gazebosim.org/distributions/gazebo/releases"
-     sha256 "dcd2b73f57686e390a7f8eac5493172616a358ac0a88928a84c9ce832379d817" => :el_capitan
+     sha256 "0052c21dfb91a8012984b08db58a50c51c138ed62af16b60a6557b0e26f39fb8" => :el_capitan
      sha256 "2659e4b71935c8c2cc61e0b8fa1df197d486b74e3970a64b5e488dec21ff612e" => :yosemite
   end
 

--- a/gazebo8.rb
+++ b/gazebo8.rb
@@ -6,7 +6,7 @@ class Gazebo8 < Formula
   version_scheme 1
 
   head "https://bitbucket.org/osrf/gazebo", :branch => "default", :using => :hg
-  revision 1
+  revision 2
 
   bottle do
      root_url "http://gazebosim.org/distributions/gazebo/releases"

--- a/haptix-comm.rb
+++ b/haptix-comm.rb
@@ -5,8 +5,6 @@ class HaptixComm < Formula
   sha256 "d495f65e401fc9e3c8fcbdded347313287c2de55f1605f6b76d02a26b893c08d"
   head "https://bitbucket.org/osrf/haptix-comm", :branch => "default", :using => :hg
 
-  revision 1
-
   depends_on "cmake" => :build
   depends_on "doxygen" => [:build, :optional]
   depends_on "pkg-config" => :build

--- a/haptix-comm.rb
+++ b/haptix-comm.rb
@@ -5,6 +5,8 @@ class HaptixComm < Formula
   sha256 "d495f65e401fc9e3c8fcbdded347313287c2de55f1605f6b76d02a26b893c08d"
   head "https://bitbucket.org/osrf/haptix-comm", :branch => "default", :using => :hg
 
+  revision 1
+
   depends_on "cmake" => :build
   depends_on "doxygen" => [:build, :optional]
   depends_on "pkg-config" => :build

--- a/ignition-msgs.rb
+++ b/ignition-msgs.rb
@@ -11,7 +11,7 @@ class IgnitionMsgs < Formula
   bottle do
     root_url "http://gazebosim.org/distributions/ign-msgs/releases"
     sha256 "9a44b85e24123d6a7326be64b00275fe1ff0be96247e1cc02efdefd4e3d69f40" => :el_capitan 
-    sha256 "955b5a180d08d73d9649079fd948c438e88df3b4d1e2dc1e06da0b9d5089cf9c" => :yosemite
+    sha256 "7328afe20f313c0cf2ab187e64c099e7dd290c3c3fdbaa5ad2e6e8793206f610" => :yosemite
   end
 
   depends_on "cmake" => :run

--- a/ignition-msgs.rb
+++ b/ignition-msgs.rb
@@ -10,7 +10,7 @@ class IgnitionMsgs < Formula
 
   bottle do
     root_url "http://gazebosim.org/distributions/ign-msgs/releases"
-    sha256 "9a44b85e24123d6a7326be64b00275fe1ff0be96247e1cc02efdefd4e3d69f40" => :el_capitan 
+    sha256 "1f081bd7b7dfbdb778928f216686420a65d0a5a9e96ef9840df17d05c0e932d7" => :el_capitan 
     sha256 "7328afe20f313c0cf2ab187e64c099e7dd290c3c3fdbaa5ad2e6e8793206f610" => :yosemite
   end
 

--- a/ignition-msgs.rb
+++ b/ignition-msgs.rb
@@ -4,6 +4,8 @@ class IgnitionMsgs < Formula
   url "http://gazebosim.org/distributions/ign-msgs/releases/ignition-msgs-0.7.0.tar.bz2"
   sha256 "5e749ddad57e3e471e01cfc240a9602595dc095952cf34436c40864add08b9dc"
 
+  revision 1
+
   head "https://bitbucket.org/ignitionrobotics/ign-msgs", :branch => "default", :using => :hg
 
   bottle do

--- a/ignition-transport.rb
+++ b/ignition-transport.rb
@@ -3,7 +3,7 @@ class IgnitionTransport < Formula
   homepage "http://ignitionrobotics.org"
   url "http://gazebosim.org/distributions/ign-transport/releases/ignition-transport-1.4.0.tar.bz2"
   sha256 "bc612e9781f9cab81cc4111ed0de07c4838303f67c25bc8b663d394b40a8f5d4"
-  revision 1
+  revision 2
 
   head "https://bitbucket.org/ignitionrobotics/ign-transport", :branch => "ign-transport1", :using => :hg
 

--- a/ignition-transport.rb
+++ b/ignition-transport.rb
@@ -11,7 +11,7 @@ class IgnitionTransport < Formula
     root_url "http://gazebosim.org/distributions/ign-transport/releases"
     cellar :any
     sha256 "3b3e6700c8e3ae337ea2fbac9327282cc9706d23b132c0fc3e946c912b210251" => :el_capitan
-    sha256 "bee72083247413b7ccb888820a5c6e832a549656d70decf9ac9ad86cc7367cdd" => :yosemite
+    sha256 "dd02042ff09da445a4aa0d139f1b673d8f8bf49c025b5cce434938a8ead56d1e" => :yosemite
   end
 
   depends_on "cmake" => :build

--- a/ignition-transport.rb
+++ b/ignition-transport.rb
@@ -10,7 +10,7 @@ class IgnitionTransport < Formula
   bottle do
     root_url "http://gazebosim.org/distributions/ign-transport/releases"
     cellar :any
-    sha256 "3b3e6700c8e3ae337ea2fbac9327282cc9706d23b132c0fc3e946c912b210251" => :el_capitan
+    sha256 "5dd18f7722794e4a21dfd9b7638c1461e5634824daa56f5107384129c6a42917" => :el_capitan
     sha256 "dd02042ff09da445a4aa0d139f1b673d8f8bf49c025b5cce434938a8ead56d1e" => :yosemite
   end
 

--- a/ignition-transport2.rb
+++ b/ignition-transport2.rb
@@ -11,7 +11,7 @@ class IgnitionTransport2 < Formula
     root_url "http://gazebosim.org/distributions/ign-transport/releases"
     cellar :any
     sha256 "f64c09654ded7f2892bd01194772da2da7d28ea10f95924146ac5bd8fa7d0c1b" => :el_capitan
-    sha256 "93d4176688554bcc5f06d92619073bbe67aaa6d21dc1b4d162f0c12c187b9c08" => :yosemite
+    sha256 "882a29956320af8e9b2bcf7de85f47e0a7028630ca0ce01c9900f4d90fce3ad2" => :yosemite
   end
 
   depends_on "cmake" => :build

--- a/ignition-transport2.rb
+++ b/ignition-transport2.rb
@@ -3,7 +3,7 @@ class IgnitionTransport2 < Formula
   homepage "http://ignitionrobotics.org"
   url "http://gazebosim.org/distributions/ign-transport/releases/ignition-transport2-2.1.0.tar.bz2"
   sha256 "f1190ee6a880962b9083328efcaf4c8fe4e9f00504da4432cde69820edbc212e"
-  revision 2
+  revision 3
 
   head "https://bitbucket.org/ignitionrobotics/ign-transport", :branch => "default", :using => :hg
 

--- a/ignition-transport2.rb
+++ b/ignition-transport2.rb
@@ -10,7 +10,7 @@ class IgnitionTransport2 < Formula
   bottle do
     root_url "http://gazebosim.org/distributions/ign-transport/releases"
     cellar :any
-    sha256 "f64c09654ded7f2892bd01194772da2da7d28ea10f95924146ac5bd8fa7d0c1b" => :el_capitan
+    sha256 "c7ac569058c86be50af653d72eedc02beb74a28e64c29a50c408580e246f02a4" => :el_capitan
     sha256 "882a29956320af8e9b2bcf7de85f47e0a7028630ca0ce01c9900f4d90fce3ad2" => :yosemite
   end
 

--- a/ignition-transport3.rb
+++ b/ignition-transport3.rb
@@ -11,7 +11,7 @@ class IgnitionTransport3 < Formula
     root_url "http://gazebosim.org/distributions/ign-transport/releases"
     cellar :any
     sha256 "25dcdbbff041667d3144306c0ce9a91106428429b02191836593a029725e648c" => :el_capitan
-    sha256 "888f6223913a3aa94203c1e8fe7dfec4c68f68b64785268ba852cefb66854b27" => :yosemite
+    sha256 "14653a68db135ea35011557042732b857306be87894e42b2b80912ad0d99d783" => :yosemite
   end
 
   depends_on "cmake" => :build

--- a/ignition-transport3.rb
+++ b/ignition-transport3.rb
@@ -10,7 +10,7 @@ class IgnitionTransport3 < Formula
   bottle do
     root_url "http://gazebosim.org/distributions/ign-transport/releases"
     cellar :any
-    sha256 "25dcdbbff041667d3144306c0ce9a91106428429b02191836593a029725e648c" => :el_capitan
+    sha256 "c1d3149609df635c744c8b821e2acfb25078cfacfb03ce53bb0219554fe6963c" => :el_capitan
     sha256 "14653a68db135ea35011557042732b857306be87894e42b2b80912ad0d99d783" => :yosemite
   end
 

--- a/ignition-transport3.rb
+++ b/ignition-transport3.rb
@@ -5,7 +5,7 @@ class IgnitionTransport3 < Formula
   sha256 "c2b8dd5f391a30f1239893b51d4ea487fd47bfe12ccdb3876a83df192df666be"
 
   head "https://bitbucket.org/ignitionrobotics/ign-transport", :branch => "default", :using => :hg
-  revision 1
+  revision 3
 
   bottle do
     root_url "http://gazebosim.org/distributions/ign-transport/releases"


### PR DESCRIPTION
A protobuf update broke all the bottles using protobuf as a dependency. Bump all revisions to trigger new bottle builds.