### PR TITLE
gazebo78: bump revisions for new bullet

### DIFF
--- a/gazebo7.rb
+++ b/gazebo7.rb
@@ -10,7 +10,7 @@ class Gazebo7 < Formula
 
   bottle do
     root_url "http://gazebosim.org/distributions/gazebo/releases"
-    sha256 "faa76768c5fc008efaa68facd0dddd72ecd0585a523d25c5975365770891bf0d" => :el_capitan
+    sha256 "f6c0cde959641f6ea265488dfed6bd54a04e0cc36956eb684e5162987e5291ff" => :el_capitan
     sha256 "b5a744aca61bf4c14cb579b46c2985005ef4aae46ceb8db075c249a07a2b2ed6" => :yosemite
   end
 

--- a/gazebo7.rb
+++ b/gazebo7.rb
@@ -11,7 +11,7 @@ class Gazebo7 < Formula
   bottle do
     root_url "http://gazebosim.org/distributions/gazebo/releases"
     sha256 "faa76768c5fc008efaa68facd0dddd72ecd0585a523d25c5975365770891bf0d" => :el_capitan
-    sha256 "ccafb3c57926f8391a00a4fc493d79ae50754edd009c816d1820dac0ebbc3208" => :yosemite
+    sha256 "b5a744aca61bf4c14cb579b46c2985005ef4aae46ceb8db075c249a07a2b2ed6" => :yosemite
   end
 
   depends_on "cmake" => :build

--- a/gazebo7.rb
+++ b/gazebo7.rb
@@ -4,7 +4,7 @@ class Gazebo7 < Formula
   url "http://gazebosim.org/distributions/gazebo/releases/gazebo-7.5.0.tar.bz2"
   sha256 "15d87d0d329ef37ff82e676e7b8b0c8535c40ba635cdebd5b8ee3b5832fa8e56"
 
-  revision 1
+  revision 2
 
   head "https://bitbucket.org/osrf/gazebo", :branch => "gazebo7", :using => :hg
 

--- a/gazebo8.rb
+++ b/gazebo8.rb
@@ -11,7 +11,7 @@ class Gazebo8 < Formula
 
   bottle do
      root_url "http://gazebosim.org/distributions/gazebo/releases"
-     sha256 "0052c21dfb91a8012984b08db58a50c51c138ed62af16b60a6557b0e26f39fb8" => :el_capitan
+     sha256 "304b886a041c4afb9e1a81697eaa0933ba5166a38a337ef29b8f05ebd9f45d3a" => :el_capitan
      sha256 "a90e29698a9e499e83b58682c86f101db4c2ca8658c595271c037cc7d1a8b35d" => :yosemite
   end
 

--- a/gazebo8.rb
+++ b/gazebo8.rb
@@ -12,7 +12,7 @@ class Gazebo8 < Formula
   bottle do
      root_url "http://gazebosim.org/distributions/gazebo/releases"
      sha256 "0052c21dfb91a8012984b08db58a50c51c138ed62af16b60a6557b0e26f39fb8" => :el_capitan
-     sha256 "2659e4b71935c8c2cc61e0b8fa1df197d486b74e3970a64b5e488dec21ff612e" => :yosemite
+     sha256 "a90e29698a9e499e83b58682c86f101db4c2ca8658c595271c037cc7d1a8b35d" => :yosemite
   end
 
   depends_on "cmake" => :build

--- a/gazebo8.rb
+++ b/gazebo8.rb
@@ -5,8 +5,9 @@ class Gazebo8 < Formula
   sha256 "ea733be6946ac5c538bf207ba01f3a6d6afa456d0b70455f7066b19d722f0d12"
   version_scheme 1
 
+  revision 3
+
   head "https://bitbucket.org/osrf/gazebo", :branch => "default", :using => :hg
-  revision 2
 
   bottle do
      root_url "http://gazebosim.org/distributions/gazebo/releases"


### PR DESCRIPTION
install build is failing due to updated bullet version:

http://build.osrfoundation.org/job/gazebo-install-one_liner-homebrew-amd64/430/console