### PR TITLE
remove ignition-common deprecated patch

### DIFF
--- a/ignition-common.rb
+++ b/ignition-common.rb
@@ -17,12 +17,6 @@ class IgnitionCommon < Formula
 
   depends_on "pkg-config" => :run
 
-  patch do
-    # Fix for compatibility with boost 1.58
-    url "https://bitbucket.org/ignitionrobotics/ign-common/commits/0b9d89179859291ba082ac0e69c010fb46a153bc/raw"
-    sha256 "ebfc7edaf870a6448d5908b78ca601d85b3a8be6fbc540d299a9277e34d09e61"
-  end
-
   def install
     system "cmake", ".", *std_cmake_args
     system "make", "install"


### PR DESCRIPTION
Merged upstream [here](https://bitbucket.org/ignitionrobotics/ign-common/pull-requests/13). Failing in the [bottle builder job](http://build.osrfoundation.org/view/All/job/generic-release-homebrew_bottle_builder-elcapitan/4/console).