### PR TITLE
gazebo[1-6]: update option names for bullet/dart

### DIFF
--- a/gazebo1.rb
+++ b/gazebo1.rb
@@ -20,7 +20,7 @@ class Gazebo1 < Formula
   depends_on "tbb"
   depends_on "tinyxml"
 
-  depends_on "bullet" => [:optional, "with-shared", "with-double-precision"]
+  depends_on "bullet" => [:optional, "with-double-precision"]
   depends_on "ffmpeg" => :optional
   depends_on "gts" => :optional
   depends_on "player" => :optional

--- a/gazebo2.rb
+++ b/gazebo2.rb
@@ -20,7 +20,7 @@ class Gazebo2 < Formula
   depends_on "tbb"
   depends_on "tinyxml"
 
-  depends_on "bullet" => [:optional, "with-shared", "with-double-precision"]
+  depends_on "bullet" => [:optional, "with-double-precision"]
   depends_on "dartsim/dart/dartsim" => [:optional, "core-only"]
   depends_on "ffmpeg" => :optional
   depends_on "gts" => :optional

--- a/gazebo3.rb
+++ b/gazebo3.rb
@@ -20,7 +20,7 @@ class Gazebo3 < Formula
   depends_on "tbb"
   depends_on "tinyxml"
 
-  depends_on "bullet" => [:optional, "with-shared", "with-double-precision"]
+  depends_on "bullet" => [:optional, "with-double-precision"]
   depends_on "dartsim/dart/dartsim" => [:optional, "core-only"]
   depends_on "ffmpeg" => :optional
   depends_on "gts" => :optional

--- a/gazebo4.rb
+++ b/gazebo4.rb
@@ -20,7 +20,7 @@ class Gazebo4 < Formula
   depends_on "tbb"
   depends_on "tinyxml"
 
-  depends_on "bullet" => [:recommended, "with-shared", "with-double-precision"]
+  depends_on "bullet" => [:recommended, "with-double-precision"]
   depends_on "dartsim/dart/dartsim" => [:optional, "core-only"]
   depends_on "ffmpeg" => :optional
   depends_on "gts" => :optional

--- a/gazebo5.rb
+++ b/gazebo5.rb
@@ -22,8 +22,8 @@ class Gazebo5 < Formula
   depends_on "tbb"
   depends_on "tinyxml"
 
-  depends_on "bullet" => [:recommended, "with-shared", "with-double-precision"]
-  depends_on "dartsim/dart/dartsim4" => [:optional, "core-only"]
+  depends_on "bullet" => [:recommended, "with-double-precision"]
+  depends_on "dartsim/dart/dartsim4" => [:optional, "with-core-only"]
   depends_on "ffmpeg" => :optional
   depends_on "gdal" => :optional
   depends_on "gts" => :optional

--- a/gazebo6.rb
+++ b/gazebo6.rb
@@ -23,8 +23,8 @@ class Gazebo6 < Formula
   depends_on "tbb"
   depends_on "tinyxml"
 
-  depends_on "bullet" => [:recommended, "with-shared", "with-double-precision"]
-  depends_on "dartsim/dart/dartsim4" => [:optional, "core-only"]
+  depends_on "bullet" => [:recommended, "with-double-precision"]
+  depends_on "dartsim/dart/dartsim4" => [:optional, "with-core-only"]
   depends_on "ffmpeg" => :optional
   depends_on "gdal" => :optional
   depends_on "gts" => :optional


### PR DESCRIPTION
Remove `with-shared` from bullet and change `core-only` to `with-core-only` for dartsim4