### PR TITLE
Don't bottle sdformat, sdformat3 any longer

### DIFF
--- a/sdformat.rb
+++ b/sdformat.rb
@@ -7,13 +7,6 @@ class Sdformat < Formula
 
   head "https://bitbucket.org/osrf/sdformat", :branch => "sdf_2.3", :using => :hg
 
-  bottle do
-    root_url "http://gazebosim.org/distributions/sdformat/releases"
-    sha256 "6afe0da70dccb2928de2d6cd352019fb4b9ba2ed559cf1d77b57e7c11afbe6bc" => :sierra
-    sha256 "bd395482c26cf470ebe7cfa147cacf9a352502784b37bce4f2b38afbf18b3700" => :el_capitan
-    sha256 "0856b25803525a85362160cc6b94971278c2c352402fdd6951a8fff9f9e46149" => :yosemite
-  end
-
   depends_on "cmake" => :build
 
   depends_on "boost"

--- a/sdformat3.rb
+++ b/sdformat3.rb
@@ -7,12 +7,6 @@ class Sdformat3 < Formula
 
   head "https://bitbucket.org/osrf/sdformat", :branch => "sdf3", :using => :hg
 
-  bottle do
-    root_url "http://gazebosim.org/distributions/sdformat/releases"
-    sha256 "f404ae8af13c776a753c5e9665b216279ee42e90dd1ea826e09703ae28d22c07" => :el_capitan
-    sha256 "8332c38461e7e6aefd894f4f0258caa799a18249b01cb9183371965ea41c3162" => :yosemite
-  end
-
   depends_on "cmake" => :build
   depends_on "pkg-config" => :run
 


### PR DESCRIPTION
These aren't used by any supported versions of gazebo, so don't build bottles for them any longer.