### PR TITLE
bump formulae for boost 1.65

### DIFF
--- a/gazebo8.rb
+++ b/gazebo8.rb
@@ -4,7 +4,7 @@ class Gazebo8 < Formula
   url "http://gazebosim.org/distributions/gazebo/releases/gazebo-8.1.1.tar.bz2"
   sha256 "bca3e36c064d80993a6c4cd53c369e0762c4a8e51e0ee145c20d005fd8d63949"
   version_scheme 1
-  revision 1
+  revision 2
 
   head "https://bitbucket.org/osrf/gazebo", :branch => "default", :using => :hg
 

--- a/gazebo8.rb
+++ b/gazebo8.rb
@@ -10,7 +10,7 @@ class Gazebo8 < Formula
 
   bottle do
     root_url "http://gazebosim.org/distributions/gazebo/releases"
-    sha256 "38ea8899d6ed2c947e4d251ce6073fc878d00176fc4b95faf5e5a58764f38ab2" => :sierra
+    sha256 "3b814c138015dda87142143112e40943b402d552f84ea18f8a9a9956868bd94c" => :sierra
     sha256 "9ccafbd3738389cc059602977a34669310eaafb9132ef8e2ada24b3af2f2cea2" => :el_capitan
     sha256 "0775abe04cf6ebb05d854303a8977cfacea9b7177ae4afa99ba26557f16db042" => :yosemite
   end

--- a/gazebo8.rb
+++ b/gazebo8.rb
@@ -11,7 +11,7 @@ class Gazebo8 < Formula
   bottle do
     root_url "http://gazebosim.org/distributions/gazebo/releases"
     sha256 "38ea8899d6ed2c947e4d251ce6073fc878d00176fc4b95faf5e5a58764f38ab2" => :sierra
-    sha256 "705694dac6d0d55f1513ac85c4dd953adb2cd0fc5779f6c01c09d11bc3b3ce7c" => :el_capitan
+    sha256 "9ccafbd3738389cc059602977a34669310eaafb9132ef8e2ada24b3af2f2cea2" => :el_capitan
     sha256 "b3a90469e54a8e575303be09199cc4465f35613649bcf257d8f77458a58e9ee3" => :yosemite
   end
 

--- a/gazebo8.rb
+++ b/gazebo8.rb
@@ -12,7 +12,7 @@ class Gazebo8 < Formula
     root_url "http://gazebosim.org/distributions/gazebo/releases"
     sha256 "38ea8899d6ed2c947e4d251ce6073fc878d00176fc4b95faf5e5a58764f38ab2" => :sierra
     sha256 "9ccafbd3738389cc059602977a34669310eaafb9132ef8e2ada24b3af2f2cea2" => :el_capitan
-    sha256 "b3a90469e54a8e575303be09199cc4465f35613649bcf257d8f77458a58e9ee3" => :yosemite
+    sha256 "0775abe04cf6ebb05d854303a8977cfacea9b7177ae4afa99ba26557f16db042" => :yosemite
   end
 
   depends_on "cmake" => :build

--- a/ignition-msgs.rb
+++ b/ignition-msgs.rb
@@ -10,7 +10,7 @@ class IgnitionMsgs < Formula
   bottle do
     root_url "http://gazebosim.org/distributions/ign-msgs/releases"
     sha256 "34e13e459480fc745c600645019cf704206466b16bd6459c74cc89524c851195" => :sierra
-    sha256 "7242fc084cb51e89141eeca8999524cdac6c9f824cc956ca1245f72b6e12688e" => :el_capitan
+    sha256 "1e076f9585389af145a99e3e218d4afcaed1594b73dc8af7599b013e64f0bae0" => :el_capitan
     sha256 "5a1f852c9ba390e4a68fd371576d94a50b21d8585ef54fd5c9983af01f5fab10" => :yosemite
   end
 

--- a/ignition-msgs.rb
+++ b/ignition-msgs.rb
@@ -9,7 +9,7 @@ class IgnitionMsgs < Formula
 
   bottle do
     root_url "http://gazebosim.org/distributions/ign-msgs/releases"
-    sha256 "34e13e459480fc745c600645019cf704206466b16bd6459c74cc89524c851195" => :sierra
+    sha256 "694ac60ca0e0aa29169cf9efd6e3f44508023215d607c9e5c59576f001f445b6" => :sierra
     sha256 "1e076f9585389af145a99e3e218d4afcaed1594b73dc8af7599b013e64f0bae0" => :el_capitan
     sha256 "85a1de23b5e95b4480b54444d53de4c524c8937df0615fa53fdd44d226d1894f" => :yosemite
   end

--- a/ignition-msgs.rb
+++ b/ignition-msgs.rb
@@ -11,7 +11,7 @@ class IgnitionMsgs < Formula
     root_url "http://gazebosim.org/distributions/ign-msgs/releases"
     sha256 "34e13e459480fc745c600645019cf704206466b16bd6459c74cc89524c851195" => :sierra
     sha256 "1e076f9585389af145a99e3e218d4afcaed1594b73dc8af7599b013e64f0bae0" => :el_capitan
-    sha256 "5a1f852c9ba390e4a68fd371576d94a50b21d8585ef54fd5c9983af01f5fab10" => :yosemite
+    sha256 "85a1de23b5e95b4480b54444d53de4c524c8937df0615fa53fdd44d226d1894f" => :yosemite
   end
 
   depends_on "cmake" => :run

--- a/ignition-msgs.rb
+++ b/ignition-msgs.rb
@@ -3,7 +3,7 @@ class IgnitionMsgs < Formula
   homepage "https://bitbucket.org/ignitionrobotics/ign-msgs"
   url "http://gazebosim.org/distributions/ign-msgs/releases/ignition-msgs-0.7.0.tar.bz2"
   sha256 "5e749ddad57e3e471e01cfc240a9602595dc095952cf34436c40864add08b9dc"
-  revision 2
+  revision 3
 
   head "https://bitbucket.org/ignitionrobotics/ign-msgs", :branch => "default", :using => :hg
 

--- a/ignition-transport.rb
+++ b/ignition-transport.rb
@@ -12,7 +12,7 @@ class IgnitionTransport < Formula
     cellar :any
     sha256 "946ea884129efa3fc41ea4ba26d2b350129964f4a2db7635d5e6fecd454ef6a5" => :sierra
     sha256 "b03416f0f9c8b1f3ee52c739d3c71094e13be2a808ccd46bf0d4543f729d14b6" => :el_capitan
-    sha256 "ff83f3fd94ec91e2ccf09f7aff2d3b59490c2713beb516eb7e9f3935b55ae722" => :yosemite
+    sha256 "6f4507102b03c5d68eb7e2520d14025ba9fa36d642fb44ab919e95a0c0ff97df" => :yosemite
   end
 
   depends_on "cmake" => :build

--- a/ignition-transport.rb
+++ b/ignition-transport.rb
@@ -11,7 +11,7 @@ class IgnitionTransport < Formula
     root_url "http://gazebosim.org/distributions/ign-transport/releases"
     cellar :any
     sha256 "946ea884129efa3fc41ea4ba26d2b350129964f4a2db7635d5e6fecd454ef6a5" => :sierra
-    sha256 "3fceab90ba1bfb7da79bf11b3df44315dbfb373809f61dcae67a8933ecc6b090" => :el_capitan
+    sha256 "b03416f0f9c8b1f3ee52c739d3c71094e13be2a808ccd46bf0d4543f729d14b6" => :el_capitan
     sha256 "ff83f3fd94ec91e2ccf09f7aff2d3b59490c2713beb516eb7e9f3935b55ae722" => :yosemite
   end
 

--- a/ignition-transport.rb
+++ b/ignition-transport.rb
@@ -10,7 +10,7 @@ class IgnitionTransport < Formula
   bottle do
     root_url "http://gazebosim.org/distributions/ign-transport/releases"
     cellar :any
-    sha256 "946ea884129efa3fc41ea4ba26d2b350129964f4a2db7635d5e6fecd454ef6a5" => :sierra
+    sha256 "e52158becd468f78ffe3910182a2f1cfe4f8ec8c388aa16ac338bbb59fad61af" => :sierra
     sha256 "b03416f0f9c8b1f3ee52c739d3c71094e13be2a808ccd46bf0d4543f729d14b6" => :el_capitan
     sha256 "6f4507102b03c5d68eb7e2520d14025ba9fa36d642fb44ab919e95a0c0ff97df" => :yosemite
   end

--- a/ignition-transport.rb
+++ b/ignition-transport.rb
@@ -3,7 +3,7 @@ class IgnitionTransport < Formula
   homepage "http://ignitionrobotics.org"
   url "http://gazebosim.org/distributions/ign-transport/releases/ignition-transport-1.4.0.tar.bz2"
   sha256 "bc612e9781f9cab81cc4111ed0de07c4838303f67c25bc8b663d394b40a8f5d4"
-  revision 3
+  revision 4
 
   head "https://bitbucket.org/ignitionrobotics/ign-transport", :branch => "ign-transport1", :using => :hg
 

--- a/ignition-transport2.rb
+++ b/ignition-transport2.rb
@@ -3,7 +3,7 @@ class IgnitionTransport2 < Formula
   homepage "http://ignitionrobotics.org"
   url "http://gazebosim.org/distributions/ign-transport/releases/ignition-transport2-2.1.0.tar.bz2"
   sha256 "f1190ee6a880962b9083328efcaf4c8fe4e9f00504da4432cde69820edbc212e"
-  revision 4
+  revision 5
 
   head "https://bitbucket.org/ignitionrobotics/ign-transport", :branch => "default", :using => :hg
 

--- a/ignition-transport2.rb
+++ b/ignition-transport2.rb
@@ -11,7 +11,7 @@ class IgnitionTransport2 < Formula
     root_url "http://gazebosim.org/distributions/ign-transport/releases"
     cellar :any
     sha256 "4520c49eb554240f6e055d87616803a6279ac86877a86a7a4dc7ee1eb5718078" => :sierra
-    sha256 "e7a6e14b919e33b215b27e208561449301caef855d8b9221371f3384471a1b40" => :el_capitan
+    sha256 "befa8a692b5ff0c63caeb5deaf3d1cd34bfbcf68ff91f4a9c046579d97ea266b" => :el_capitan
     sha256 "2232a168cf1f785d0602fc556708bc0ca70f6a75004b468ec64898b251968500" => :yosemite
   end
 

--- a/ignition-transport2.rb
+++ b/ignition-transport2.rb
@@ -10,7 +10,7 @@ class IgnitionTransport2 < Formula
   bottle do
     root_url "http://gazebosim.org/distributions/ign-transport/releases"
     cellar :any
-    sha256 "4520c49eb554240f6e055d87616803a6279ac86877a86a7a4dc7ee1eb5718078" => :sierra
+    sha256 "2e25ee39b8a0c56a8a0e75be0dfdd5166c0fbbd79b7a6e205f8ce4e36ba3a1e2" => :sierra
     sha256 "befa8a692b5ff0c63caeb5deaf3d1cd34bfbcf68ff91f4a9c046579d97ea266b" => :el_capitan
     sha256 "478c58738080932d0ca463b1fdfef1e8c469862b19ecb315962f717ed9bec77d" => :yosemite
   end

--- a/ignition-transport2.rb
+++ b/ignition-transport2.rb
@@ -12,7 +12,7 @@ class IgnitionTransport2 < Formula
     cellar :any
     sha256 "4520c49eb554240f6e055d87616803a6279ac86877a86a7a4dc7ee1eb5718078" => :sierra
     sha256 "befa8a692b5ff0c63caeb5deaf3d1cd34bfbcf68ff91f4a9c046579d97ea266b" => :el_capitan
-    sha256 "2232a168cf1f785d0602fc556708bc0ca70f6a75004b468ec64898b251968500" => :yosemite
+    sha256 "478c58738080932d0ca463b1fdfef1e8c469862b19ecb315962f717ed9bec77d" => :yosemite
   end
 
   depends_on "cmake" => :build

--- a/ignition-transport3.rb
+++ b/ignition-transport3.rb
@@ -11,7 +11,7 @@ class IgnitionTransport3 < Formula
     root_url "http://gazebosim.org/distributions/ign-transport/releases"
     cellar :any
     sha256 "825c52cfbf12bc7ba60a5e46f182fefa3e798434d19d5d6e4f4d0d1a4b41ba4a" => :sierra
-    sha256 "ab37946863e63c51d7d57a8e3b0d33a74e29b9770d37c7cc7100c06507962759" => :el_capitan
+    sha256 "2fd741c74a88e14d3c447a916779678a4f1fc4d438e2b6454481f5521778243c" => :el_capitan
     sha256 "9bcf1632a6a00fbcdded5fd39b2a6fb9a4b55b45dea32597714bb92d1e38ab18" => :yosemite
   end
 

--- a/ignition-transport3.rb
+++ b/ignition-transport3.rb
@@ -12,7 +12,7 @@ class IgnitionTransport3 < Formula
     cellar :any
     sha256 "825c52cfbf12bc7ba60a5e46f182fefa3e798434d19d5d6e4f4d0d1a4b41ba4a" => :sierra
     sha256 "2fd741c74a88e14d3c447a916779678a4f1fc4d438e2b6454481f5521778243c" => :el_capitan
-    sha256 "9bcf1632a6a00fbcdded5fd39b2a6fb9a4b55b45dea32597714bb92d1e38ab18" => :yosemite
+    sha256 "713f8e3d26d07b00ee41fed615795ee26914cb406181809a19fc6e5d6a9ef9ff" => :yosemite
   end
 
   depends_on "cmake" => :build

--- a/ignition-transport3.rb
+++ b/ignition-transport3.rb
@@ -10,7 +10,7 @@ class IgnitionTransport3 < Formula
   bottle do
     root_url "http://gazebosim.org/distributions/ign-transport/releases"
     cellar :any
-    sha256 "825c52cfbf12bc7ba60a5e46f182fefa3e798434d19d5d6e4f4d0d1a4b41ba4a" => :sierra
+    sha256 "96f797c488028117dbbcd888a56037a13bab7727aa8c6e07bdda0e037e72e2ba" => :sierra
     sha256 "2fd741c74a88e14d3c447a916779678a4f1fc4d438e2b6454481f5521778243c" => :el_capitan
     sha256 "713f8e3d26d07b00ee41fed615795ee26914cb406181809a19fc6e5d6a9ef9ff" => :yosemite
   end

--- a/ignition-transport3.rb
+++ b/ignition-transport3.rb
@@ -3,7 +3,7 @@ class IgnitionTransport3 < Formula
   homepage "http://ignitionrobotics.org"
   url "http://gazebosim.org/distributions/ign-transport/releases/ignition-transport3-3.0.1.tar.bz2"
   sha256 "c2b8dd5f391a30f1239893b51d4ea487fd47bfe12ccdb3876a83df192df666be"
-  revision 4
+  revision 5
 
   head "https://bitbucket.org/ignitionrobotics/ign-transport", :branch => "default", :using => :hg
 

--- a/ogre1.9.rb
+++ b/ogre1.9.rb
@@ -8,7 +8,7 @@ class Ogre19 < Formula
 
   bottle do
     root_url "http://gazebosim.org/distributions/ogre/releases"
-    sha256 "6373edc81b7bf3a597fc66818c540b4c2bbc15e74e1628e1cd216017d0767ab5" => :sierra
+    sha256 "999760828472e290c92ad1a3f08b477201482c732ea0dbf6c610b04bc3f43dd4" => :sierra
     sha256 "7f7f66f505e7911c8abb742e33a80801ee0e508543d2627b795a7716f4c01732" => :el_capitan
     sha256 "328c281eddc6a5ee57609d554332bab2d74925f19b483f86fcd56f3c602af3e7" => :yosemite
   end

--- a/ogre1.9.rb
+++ b/ogre1.9.rb
@@ -67,8 +67,8 @@ class Ogre19 < Formula
 
   patch do
     # fix for boost 1.65
-    url "https://bitbucket.org/scpeters/ogre/commits/240c6c3b1d93080b95760033daf38c5ce5da5f18/raw"
-    sha256 "6447e73cf2c3570850dc0daa6b3a8904b787f622f56fe0c93013cbf35fc78c15"
+    url "https://bitbucket.org/scpeters/ogre/commits/8d514c81341a665acf02d87657113053d6f1be74/raw"
+    sha256 "b73af895f6b37a81e4b99e1c442196c52ba4e1a1fad78c70f4f46090f8e8a2ff"
   end
 
   def install

--- a/ogre1.9.rb
+++ b/ogre1.9.rb
@@ -9,7 +9,7 @@ class Ogre19 < Formula
   bottle do
     root_url "http://gazebosim.org/distributions/ogre/releases"
     sha256 "6373edc81b7bf3a597fc66818c540b4c2bbc15e74e1628e1cd216017d0767ab5" => :sierra
-    sha256 "48edc8d1d05f35c35a800eca73046f5c5efe4ce8dee9d0c6f0cd0233099a8b30" => :el_capitan
+    sha256 "7f7f66f505e7911c8abb742e33a80801ee0e508543d2627b795a7716f4c01732" => :el_capitan
     sha256 "32b9c50bc711fcdb642d786dd20028e0b85585f1287a596ce93285cc51ff20f2" => :yosemite
   end
 

--- a/ogre1.9.rb
+++ b/ogre1.9.rb
@@ -65,6 +65,12 @@ class Ogre19 < Formula
     sha256 "7ca6f549fbdff7b7fc334f06da4547e071ec0e3f2733897fc6ef0d2bfa1716a3"
   end
 
+  patch do
+    # fix for boost 1.65
+    url "https://bitbucket.org/scpeters/ogre/commits/240c6c3b1d93080b95760033daf38c5ce5da5f18/raw"
+    sha256 "6447e73cf2c3570850dc0daa6b3a8904b787f622f56fe0c93013cbf35fc78c15"
+  end
+
   def install
     ENV.m64
 

--- a/ogre1.9.rb
+++ b/ogre1.9.rb
@@ -10,7 +10,7 @@ class Ogre19 < Formula
     root_url "http://gazebosim.org/distributions/ogre/releases"
     sha256 "6373edc81b7bf3a597fc66818c540b4c2bbc15e74e1628e1cd216017d0767ab5" => :sierra
     sha256 "7f7f66f505e7911c8abb742e33a80801ee0e508543d2627b795a7716f4c01732" => :el_capitan
-    sha256 "32b9c50bc711fcdb642d786dd20028e0b85585f1287a596ce93285cc51ff20f2" => :yosemite
+    sha256 "328c281eddc6a5ee57609d554332bab2d74925f19b483f86fcd56f3c602af3e7" => :yosemite
   end
 
   option "with-cg"

--- a/ogre1.9.rb
+++ b/ogre1.9.rb
@@ -4,7 +4,7 @@ class Ogre19 < Formula
   url "https://bitbucket.org/sinbad/ogre/get/108ab0bcc69603dba32c0ffd4bbbc39051f421c9.tar.bz2"
   version "1.9-20160714-108ab0bcc69603dba32c0ffd4bbbc39051f421c9"
   sha256 "3ca667b959905b290d782d7f0808e35d075c85db809d3239018e4e10e89b1721"
-  revision 2
+  revision 3
 
   bottle do
     root_url "http://gazebosim.org/distributions/ogre/releases"

--- a/ogre1.9.rb
+++ b/ogre1.9.rb
@@ -67,8 +67,8 @@ class Ogre19 < Formula
 
   patch do
     # fix for boost 1.65
-    url "https://bitbucket.org/scpeters/ogre/commits/8d514c81341a665acf02d87657113053d6f1be74/raw"
-    sha256 "b73af895f6b37a81e4b99e1c442196c52ba4e1a1fad78c70f4f46090f8e8a2ff"
+    url "https://bitbucket.org/sinbad/ogre/commits/0cd739f7551d0aad3329abb42d981e970e074fa7/raw"
+    sha256 "cb22b8703f36596efa13618085b2d1a59522d04386cf7eb6eca42a99d0abe83d"
   end
 
   def install

--- a/sdformat5.rb
+++ b/sdformat5.rb
@@ -12,7 +12,7 @@ class Sdformat5 < Formula
     cellar :any
     sha256 "eafc4554b050f12e423752d78c6e39c5bb1edb751ebe8af6f2fbe19e49e87d46" => :sierra
     sha256 "a9c332e4d50524d3ab55c949466aeb097b735c3ae77bf40fc5590a84661969e5" => :el_capitan
-    sha256 "24579cc4802dfa7c6244ab046456d32b6b32d7e1d263333c2cb7634bdece5a66" => :yosemite
+    sha256 "a4604aff382f727c1e4b6db1f55e765dba2e19bbb58634f450f089c0a1052411" => :yosemite
   end
 
   depends_on "cmake" => :build

--- a/sdformat5.rb
+++ b/sdformat5.rb
@@ -10,7 +10,7 @@ class Sdformat5 < Formula
   bottle do
     root_url "http://gazebosim.org/distributions/sdformat/releases"
     cellar :any
-    sha256 "eafc4554b050f12e423752d78c6e39c5bb1edb751ebe8af6f2fbe19e49e87d46" => :sierra
+    sha256 "84297dcf68b1d9aff157df84001612152a8e8b4af56ba4c6e231db2d0ad1d024" => :sierra
     sha256 "a9c332e4d50524d3ab55c949466aeb097b735c3ae77bf40fc5590a84661969e5" => :el_capitan
     sha256 "a4604aff382f727c1e4b6db1f55e765dba2e19bbb58634f450f089c0a1052411" => :yosemite
   end

--- a/sdformat5.rb
+++ b/sdformat5.rb
@@ -11,7 +11,7 @@ class Sdformat5 < Formula
     root_url "http://gazebosim.org/distributions/sdformat/releases"
     cellar :any
     sha256 "eafc4554b050f12e423752d78c6e39c5bb1edb751ebe8af6f2fbe19e49e87d46" => :sierra
-    sha256 "c2ef934ffb5eb602838839dec4d41a72e2ae912b5e8b662c12f6f8353696a848" => :el_capitan
+    sha256 "a9c332e4d50524d3ab55c949466aeb097b735c3ae77bf40fc5590a84661969e5" => :el_capitan
     sha256 "24579cc4802dfa7c6244ab046456d32b6b32d7e1d263333c2cb7634bdece5a66" => :yosemite
   end
 

--- a/sdformat5.rb
+++ b/sdformat5.rb
@@ -3,6 +3,7 @@ class Sdformat5 < Formula
   homepage "http://sdformat.org"
   url "http://gazebosim.org/distributions/sdformat/releases/sdformat-5.2.0.tar.bz2"
   sha256 "b7ba88275c28c3c26fe245b1ac4aad7337c2fd53d6c1e1c94c04f359f2309d51"
+  revision 1
 
   head "https://bitbucket.org/osrf/sdformat", :branch => "default", :using => :hg
 


### PR DESCRIPTION
boost 1.65 was just released into homebrew: https://github.com/Homebrew/homebrew-core/pull/17122 and it broke our gazebo bottles:

* https://build.osrfoundation.org/job/gazebo-install-one_liner-homebrew-amd64/625/