### PR TITLE
Add libyaml to ign-fuel-tools dependencies

### DIFF
--- a/ignition-fuel-tools0.rb
+++ b/ignition-fuel-tools0.rb
@@ -9,6 +9,7 @@ class IgnitionFuelTools0 < Formula
   depends_on "ignition-common0"
   depends_on "jsoncpp"
   depends_on "libzip"
+  depends_on "libyaml"
   depends_on "pkg-config" => :run
 
   def install

--- a/ignition-fuel-tools0.rb
+++ b/ignition-fuel-tools0.rb
@@ -8,8 +8,8 @@ class IgnitionFuelTools0 < Formula
   depends_on "cmake" => :run
   depends_on "ignition-common0"
   depends_on "jsoncpp"
-  depends_on "libzip"
   depends_on "libyaml"
+  depends_on "libzip"
   depends_on "pkg-config" => :run
 
   def install


### PR DESCRIPTION
Being introduced on this PR:

https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/29/

I think this should be the right one, I saw an example here:

https://github.com/Homebrew/homebrew-core/blob/master/Formula/ruby.rb#L32