### PR TITLE
Add new ign-cmake dependency to fuel-tools.

### DIFF
--- a/ignition-fuel-tools0.rb
+++ b/ignition-fuel-tools0.rb
@@ -13,6 +13,7 @@ class IgnitionFuelTools0 < Formula
   end
 
   depends_on "cmake" => :run
+  depends_on "ignition-cmake0"
   depends_on "ignition-common1"
   depends_on "jsoncpp"
   depends_on "libyaml"


### PR DESCRIPTION
Ignition Fuel Tools will use Ignition CMake when [#34](https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/34) is merged. This pull request adds the new Ignition CMake dependency.

@scpeters , do I need to make more changes here? Disable bottles or update sha's?