### PR TITLE
bump revisions for ffmpeg update

### DIFF
--- a/gazebo7.rb
+++ b/gazebo7.rb
@@ -3,6 +3,7 @@ class Gazebo7 < Formula
   homepage "http://gazebosim.org"
   url "http://gazebosim.org/distributions/gazebo/releases/gazebo-7.10.0.tar.bz2"
   sha256 "9c7fe24339aaec0cdf2e7664282dc0982a7110da344316f12d0e673608b52244"
+  revision 1
 
   head "https://bitbucket.org/osrf/gazebo", :branch => "gazebo7", :using => :hg
 

--- a/gazebo9.rb
+++ b/gazebo9.rb
@@ -3,6 +3,7 @@ class Gazebo9 < Formula
   homepage "http://gazebosim.org"
   url "http://gazebosim.org/distributions/gazebo/releases/gazebo-9.0.0.tar.bz2"
   sha256 "2c29955d476c97dc0ccbb1c8295ec6e8ffe203d7bc6047c1f34433a82ab9215e"
+  revision 1
 
   head "https://bitbucket.org/osrf/gazebo", :branch => "default", :using => :hg
 

--- a/ignition-common1.rb
+++ b/ignition-common1.rb
@@ -3,6 +3,7 @@ class IgnitionCommon1 < Formula
   homepage "https://bitbucket.org/ignitionrobotics/ign-common"
   url "http://gazebosim.org/distributions/ign-common/releases/ignition-common-1.0.1.tar.bz2"
   sha256 "fb56178cda1860cbab0c29d93b46a3e0c275cb400383c6e7c5b99e4ae5b1375a"
+  revision 1
 
   head "https://bitbucket.org/ignitionrobotics/ign-common", :branch => "default", :using => :hg
 

--- a/ignition-fuel-tools1.rb
+++ b/ignition-fuel-tools1.rb
@@ -4,7 +4,7 @@ class IgnitionFuelTools1 < Formula
   url "http://gazebosim.org/distributions/ign-fuel-tools/releases/ignition-fuel_tools-1.0.0.tar.bz2"
   sha256 "4266ff5a16db23deffe24a792901c7a28272c198ae9e484b9ec8b2bf6905b5cd"
   version_scheme 1
-  revision 1
+  revision 2
 
   bottle do
     root_url "http://gazebosim.org/distributions/ign-fuel-tools/releases"


### PR DESCRIPTION
bottles broken:

* https://build.osrfoundation.org/view/os_homebrew/job/gazebo-install-one_liner-homebrew-amd64/809/console

because of https://github.com/Homebrew/homebrew-core/pull/23957