### PR TITLE
Added ignition-cmake1 dependency in ignition-gui

### DIFF
--- a/ignition-gui0.rb
+++ b/ignition-gui0.rb
@@ -20,6 +20,7 @@ class IgnitionGui0 < Formula
   depends_on "qt"
   depends_on "qwt"
   depends_on "tinyxml2"
+  depends_on "ignition-cmake1"
   depends_on "ignition-common1"
   depends_on "ignition-msgs1"
   depends_on "ignition-rendering0"

--- a/ignition-gui0.rb
+++ b/ignition-gui0.rb
@@ -16,6 +16,7 @@ class IgnitionGui0 < Formula
   # end
 
   depends_on "cmake" => :build
+  depends_on "pkg-config"
 
   depends_on "qt"
   depends_on "qwt"
@@ -25,8 +26,6 @@ class IgnitionGui0 < Formula
   depends_on "ignition-msgs1"
   depends_on "ignition-rendering0"
   depends_on "ignition-transport4"
-
-  depends_on "pkg-config" => :run
 
   def install
     ENV.m64


### PR DESCRIPTION
The formula seems to be working without this dependency since it is probably added to the build by `ignition-rendering0`. Explicitly added it here.