### PR TITLE
Bump ign sensors dependencies to work with gz11 branches

### DIFF
--- a/ignition-rendering1.rb
+++ b/ignition-rendering1.rb
@@ -1,0 +1,51 @@
+class IgnitionRendering1 < Formula
+  desc "Rendering library for robotics applications using gz11 branches"
+  homepage "https://bitbucket.org/ignitionrobotics/ign-rendering"
+  url "https://bitbucket.org/ignitionrobotics/ign-rendering/get/70c0ba0fe42a.tar.gz"
+  version "1.0.0~20180719~70c0ba0"
+  sha256 "e1d5e52b230a8c50dae47174cef14594311b4a4634c67a181f6f4d50cba88656"
+
+  head "https://bitbucket.org/ignitionrobotics/ign-rendering", :branch => "gz11", :using => :hg
+
+  bottle do
+    root_url "http://gazebosim.org/distributions/ign-rendering/releases"
+    sha256 "8b8c253114e3c6af1d6978e79b02c3c10895a5fe276a21570e370eaa4252491d" => :high_sierra
+    sha256 "520b171c51d0415f99ae7c8ecdd955249d166bad89edcad83879b85735c9a80f" => :sierra
+    sha256 "42acd100d3187950a56ec3fde87349feb78368d7c3552a9a1344f0c031511f72" => :el_capitan
+  end
+
+  depends_on "cmake" => :build
+
+  depends_on "freeimage"
+  depends_on "ignition-cmake2"
+  depends_on "ignition-common3"
+  depends_on "ignition-math6"
+  depends_on "ogre1.9"
+  depends_on "pkg-config"
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS
+      #include <ignition/rendering/PixelFormat.hh>
+      int main(int _argc, char** _argv)
+      {
+        ignition::rendering::PixelFormat pf = ignition::rendering::PF_UNKNOWN;
+        return ignition::rendering::PixelUtil::IsValid(pf);
+      }
+    EOS
+    ENV.append_path "PKG_CONFIG_PATH", "#{Formula["qt"].opt_lib}/pkgconfig"
+    system "pkg-config", "ignition-rendering1"
+    cflags   = `pkg-config --cflags ignition-rendering1`.split(" ")
+    ldflags  = `pkg-config --libs ignition-rendering1`.split(" ")
+    system ENV.cc, "test.cpp",
+                   *cflags,
+                   *ldflags,
+                   "-lc++",
+                   "-o", "test"
+    system "./test"
+  end
+end

--- a/ignition-rendering1.rb
+++ b/ignition-rendering1.rb
@@ -1,5 +1,5 @@
 class IgnitionRendering1 < Formula
-  desc "Rendering library for robotics applications using gz11 branches"
+  desc "Rendering library for robotics applications"
   homepage "https://bitbucket.org/ignitionrobotics/ign-rendering"
   url "https://bitbucket.org/ignitionrobotics/ign-rendering/get/8cbb07bef149.tar.gz"
   version "0.999.999~20180720~8cbb07b"

--- a/ignition-rendering1.rb
+++ b/ignition-rendering1.rb
@@ -5,12 +5,12 @@ class IgnitionRendering1 < Formula
   version "0.999.999~20180720~8cbb07b"
   sha256 "d40c67b5e273720a9ec6f7e42d3ab674d464a20f0fcd5e512a2997375c22c6b1"
 
-  bottle do
-    root_url "http://gazebosim.org/distributions/ign-rendering/releases"
-    sha256 "8b8c253114e3c6af1d6978e79b02c3c10895a5fe276a21570e370eaa4252491d" => :high_sierra
-    sha256 "520b171c51d0415f99ae7c8ecdd955249d166bad89edcad83879b85735c9a80f" => :sierra
-    sha256 "42acd100d3187950a56ec3fde87349feb78368d7c3552a9a1344f0c031511f72" => :el_capitan
-  end
+  # bottle do
+  #   root_url "http://gazebosim.org/distributions/ign-rendering/releases"
+  #   sha256 "8b8c253114e3c6af1d6978e79b02c3c10895a5fe276a21570e370eaa4252491d" => :high_sierra
+  #   sha256 "520b171c51d0415f99ae7c8ecdd955249d166bad89edcad83879b85735c9a80f" => :sierra
+  #   sha256 "42acd100d3187950a56ec3fde87349feb78368d7c3552a9a1344f0c031511f72" => :el_capitan
+  # end
 
   depends_on "cmake" => :build
 

--- a/ignition-rendering1.rb
+++ b/ignition-rendering1.rb
@@ -1,9 +1,9 @@
 class IgnitionRendering1 < Formula
   desc "Rendering library for robotics applications using gz11 branches"
   homepage "https://bitbucket.org/ignitionrobotics/ign-rendering"
-  url "https://bitbucket.org/ignitionrobotics/ign-rendering/get/70c0ba0fe42a.tar.gz"
-  version "0.999.999~20180719~70c0ba0"
-  sha256 "e1d5e52b230a8c50dae47174cef14594311b4a4634c67a181f6f4d50cba88656"
+  url "https://bitbucket.org/ignitionrobotics/ign-rendering/get/8cbb07bef149.tar.gz"
+  version "0.999.999~20180720~8cbb07b"
+  sha256 "d40c67b5e273720a9ec6f7e42d3ab674d464a20f0fcd5e512a2997375c22c6b1"
 
   head "https://bitbucket.org/ignitionrobotics/ign-rendering", :branch => "gz11", :using => :hg
 

--- a/ignition-rendering1.rb
+++ b/ignition-rendering1.rb
@@ -2,7 +2,7 @@ class IgnitionRendering1 < Formula
   desc "Rendering library for robotics applications using gz11 branches"
   homepage "https://bitbucket.org/ignitionrobotics/ign-rendering"
   url "https://bitbucket.org/ignitionrobotics/ign-rendering/get/70c0ba0fe42a.tar.gz"
-  version "1.0.0~20180719~70c0ba0"
+  version "0.999.999~20180719~70c0ba0"
   sha256 "e1d5e52b230a8c50dae47174cef14594311b4a4634c67a181f6f4d50cba88656"
 
   head "https://bitbucket.org/ignitionrobotics/ign-rendering", :branch => "gz11", :using => :hg

--- a/ignition-rendering1.rb
+++ b/ignition-rendering1.rb
@@ -5,14 +5,12 @@ class IgnitionRendering1 < Formula
   version "0.999.999~20180720~8cbb07b"
   sha256 "d40c67b5e273720a9ec6f7e42d3ab674d464a20f0fcd5e512a2997375c22c6b1"
 
-  head "https://bitbucket.org/ignitionrobotics/ign-rendering", :branch => "gz11", :using => :hg
-
-  # bottle do
-  #   root_url "http://gazebosim.org/distributions/ign-rendering/releases"
-  #   sha256 "8b8c253114e3c6af1d6978e79b02c3c10895a5fe276a21570e370eaa4252491d" => :high_sierra
-  #   sha256 "520b171c51d0415f99ae7c8ecdd955249d166bad89edcad83879b85735c9a80f" => :sierra
-  #   sha256 "42acd100d3187950a56ec3fde87349feb78368d7c3552a9a1344f0c031511f72" => :el_capitan
-  # end
+  bottle do
+    root_url "http://gazebosim.org/distributions/ign-rendering/releases"
+    sha256 "8b8c253114e3c6af1d6978e79b02c3c10895a5fe276a21570e370eaa4252491d" => :high_sierra
+    sha256 "520b171c51d0415f99ae7c8ecdd955249d166bad89edcad83879b85735c9a80f" => :sierra
+    sha256 "42acd100d3187950a56ec3fde87349feb78368d7c3552a9a1344f0c031511f72" => :el_capitan
+  end
 
   depends_on "cmake" => :build
 

--- a/ignition-rendering1.rb
+++ b/ignition-rendering1.rb
@@ -7,12 +7,12 @@ class IgnitionRendering1 < Formula
 
   head "https://bitbucket.org/ignitionrobotics/ign-rendering", :branch => "gz11", :using => :hg
 
-  bottle do
-    root_url "http://gazebosim.org/distributions/ign-rendering/releases"
-    sha256 "8b8c253114e3c6af1d6978e79b02c3c10895a5fe276a21570e370eaa4252491d" => :high_sierra
-    sha256 "520b171c51d0415f99ae7c8ecdd955249d166bad89edcad83879b85735c9a80f" => :sierra
-    sha256 "42acd100d3187950a56ec3fde87349feb78368d7c3552a9a1344f0c031511f72" => :el_capitan
-  end
+  # bottle do
+  #   root_url "http://gazebosim.org/distributions/ign-rendering/releases"
+  #   sha256 "8b8c253114e3c6af1d6978e79b02c3c10895a5fe276a21570e370eaa4252491d" => :high_sierra
+  #   sha256 "520b171c51d0415f99ae7c8ecdd955249d166bad89edcad83879b85735c9a80f" => :sierra
+  #   sha256 "42acd100d3187950a56ec3fde87349feb78368d7c3552a9a1344f0c031511f72" => :el_capitan
+  # end
 
   depends_on "cmake" => :build
 

--- a/ignition-sensors0.rb
+++ b/ignition-sensors0.rb
@@ -12,7 +12,7 @@ class IgnitionSensors0 < Formula
   depends_on "ignition-common3"
   depends_on "ignition-math6"
   depends_on "ignition-msgs3"
-  depends_on "ignition-rendering1"
+  depends_on "ignition-rendering0"
   depends_on "ignition-transport6"
   depends_on "pkg-config"
   depends_on "sdformat6"

--- a/ignition-sensors0.rb
+++ b/ignition-sensors0.rb
@@ -7,6 +7,13 @@ class IgnitionSensors0 < Formula
 
   head "https://bitbucket.org/ignitionrobotics/ign-sensors", :branch => "default", :using => :hg
 
+  bottle do
+    root_url "http://gazebosim.org/distributions/ign-sensors/releases"
+    sha256 "8b8c253114e3c6af1d6978e79b02c3c10895a5fe276a21570e370eaa4252491d" => :high_sierra
+    sha256 "520b171c51d0415f99ae7c8ecdd955249d166bad89edcad83879b85735c9a80f" => :sierra
+    sha256 "42acd100d3187950a56ec3fde87349feb78368d7c3552a9a1344f0c031511f72" => :el_capitan
+  end
+	
   depends_on "cmake" => :build
 
   depends_on "ignition-common3"

--- a/ignition-sensors0.rb
+++ b/ignition-sensors0.rb
@@ -7,12 +7,12 @@ class IgnitionSensors0 < Formula
 
   head "https://bitbucket.org/ignitionrobotics/ign-sensors", :branch => "default", :using => :hg
 
-  bottle do
-    root_url "http://gazebosim.org/distributions/ign-sensors/releases"
-    sha256 "8b8c253114e3c6af1d6978e79b02c3c10895a5fe276a21570e370eaa4252491d" => :high_sierra
-    sha256 "520b171c51d0415f99ae7c8ecdd955249d166bad89edcad83879b85735c9a80f" => :sierra
-    sha256 "42acd100d3187950a56ec3fde87349feb78368d7c3552a9a1344f0c031511f72" => :el_capitan
-  end
+  # bottle do
+  #   root_url "http://gazebosim.org/distributions/ign-sensors/releases"
+  #   sha256 "8b8c253114e3c6af1d6978e79b02c3c10895a5fe276a21570e370eaa4252491d" => :high_sierra
+  #   sha256 "520b171c51d0415f99ae7c8ecdd955249d166bad89edcad83879b85735c9a80f" => :sierra
+  #   sha256 "42acd100d3187950a56ec3fde87349feb78368d7c3552a9a1344f0c031511f72" => :el_capitan
+  # end
 	
   depends_on "cmake" => :build
 

--- a/ignition-sensors0.rb
+++ b/ignition-sensors0.rb
@@ -12,7 +12,7 @@ class IgnitionSensors0 < Formula
   depends_on "ignition-common3"
   depends_on "ignition-math6"
   depends_on "ignition-msgs3"
-  depends_on "ignition-rendering0"
+  depends_on "ignition-rendering1"
   depends_on "ignition-transport6"
   depends_on "pkg-config"
   depends_on "sdformat6"

--- a/ignition-sensors0.rb
+++ b/ignition-sensors0.rb
@@ -1,19 +1,19 @@
 class IgnitionSensors0 < Formula
   desc "Sensors library for robotics applications"
   homepage "https://bitbucket.org/ignitionrobotics/ign-sensors"
-  url "https://bitbucket.org/ignitionrobotics/ign-sensors/get/6773ea272585c96caa0a85b2102f5b2ae6481dfe.tar.gz"
-  version "0.0.0~20180529~6773ea2"
-  sha256 "365671b6de1d422c726f093bf2f6b88da983f537d88b08dcb8aca72931fbcf7a"
+  url "https://bitbucket.org/ignitionrobotics/ign-sensors/get/a44a773b2ce9.tar.gz"
+  version "0.0.0~20180718~a44a773"
+  sha256 "9406cc1577a7024e5b6fd1b3c5fe1fa6d4e8c20e10045c3fdb64eda6a884a688"
 
   head "https://bitbucket.org/ignitionrobotics/ign-sensors", :branch => "default", :using => :hg
 
   depends_on "cmake" => :build
 
-  depends_on "ignition-common2"
-  depends_on "ignition-math5"
-  depends_on "ignition-msgs2"
-  depends_on "ignition-rendering0"
-  depends_on "ignition-transport5"
+  depends_on "ignition-common3"
+  depends_on "ignition-math6"
+  depends_on "ignition-msgs3"
+  depends_on "ignition-rendering1"
+  depends_on "ignition-transport6"
   depends_on "pkg-config"
   depends_on "sdformat6"
 


### PR DESCRIPTION
Based on [this](https://github.com/osrf/homebrew-simulation/commit/d3bed28afee1887c21941586d1de3720662c4aa0#diff-a578e0ba26f6bce6e367db30255ca9fc) commit I updated the depencies for ign_sensors. This is broken because ignition sensors default branch uses gz11 branches for its dependencies since [this PR](https://bitbucket.org/ignitionrobotics/ign-sensors/pull-requests/14/bionic/diff).