### PR TITLE
ignition-sensors: depend on sdformat8

### DIFF
--- a/ignition-sensors0.rb
+++ b/ignition-sensors0.rb
@@ -23,7 +23,7 @@ class IgnitionSensors0 < Formula
   depends_on "ignition-rendering1"
   depends_on "ignition-transport6"
   depends_on "pkg-config"
-  depends_on "sdformat6"
+  depends_on "sdformat8"
 
   def install
     system "cmake", ".", *std_cmake_args


### PR DESCRIPTION
Failing here: https://build.osrfoundation.org/job/ignition_sensors-ci-default-homebrew-amd64/33/console