### PR TITLE
Create ignition-gui1 formula and remove previous alias

### DIFF
--- a/Aliases/ignition-gui
+++ b/Aliases/ignition-gui
@@ -1,1 +1,1 @@
-../Formula/ignition-gui0.rb
+../Formula/ignition-gui1.rb

--- a/Aliases/ignition-gui1
+++ b/Aliases/ignition-gui1
@@ -1,1 +1,0 @@
-../Formula/ignition-gui0.rb

--- a/Aliases/ignition-gui@1
+++ b/Aliases/ignition-gui@1
@@ -1,1 +1,1 @@
-../Formula/ignition-gui0.rb
+../Formula/ignition-gui1.rb

--- a/Formula/ignition-gui1.rb
+++ b/Formula/ignition-gui1.rb
@@ -11,6 +11,7 @@ class IgnitionGui1 < Formula
   depends_on "ignition-cmake2"
   depends_on "ignition-common3"
   depends_on "ignition-msgs3"
+  depends_on "ignition-plugin1"
   depends_on "ignition-rendering1"
   depends_on "ignition-transport6"
   depends_on :macos => :high_sierra # c++17

--- a/Formula/ignition-gui1.rb
+++ b/Formula/ignition-gui1.rb
@@ -1,0 +1,82 @@
+class IgnitionGui1 < Formula
+  desc "Common libraries for robotics applications. GUI Library"
+  homepage "https://bitbucket.org/ignitionrobotics/ign-gui"
+  url "https://bitbucket.org/ignitionrobotics/ign-gui/get/619b3b5944c8821e92cf625e012c819e95f6d2f0.tar.gz"
+  version "0.0.0~20181006~619b3b5"
+  sha256 "f45b3e2d559f2e07680241de8bce0d384600306e52deae5633690ee2edfab390"
+
+  head "https://bitbucket.org/ignitionrobotics/ign-gui", :branch => "gz11", :using => :hg
+
+  # bottle do
+  #   rebuild 1
+  #   root_url "http://gazebosim.org/distributions/ign-gui/releases"
+  #   sha256 "a435130d701ebdaa58bd29833a26d53c612ae2163a195b0124ad71f0e54675d8" => :high_sierra
+  #   sha256 "8660bbd506869aebc3c01114af9fa651d4ee67eaa9259748a7fc4204aeb01c08" => :sierra
+  #   sha256 "ab9346c2e57d496cc71275d44f6091c6e0792913ca5cc1c88af97e5f099bb37a" => :el_capitan
+  # end
+
+  depends_on "cmake" => :build
+  depends_on "ignition-cmake2"
+  depends_on "ignition-common3"
+  depends_on "ignition-msgs3"
+  depends_on "ignition-rendering1"
+  depends_on "ignition-transport6"
+  depends_on "pkg-config"
+  depends_on "qt"
+  depends_on "qwt"
+  depends_on "tinyxml2"
+
+  def install
+    ENV.m64
+
+    cmake_args = std_cmake_args
+    cmake_args << "-DQWT_WIN_INCLUDE_DIR=#{HOMEBREW_PREFIX}/lib/qwt.framework/Headers"
+    cmake_args << "-DQWT_WIN_LIBRARY_DIR=#{HOMEBREW_PREFIX}/lib/qwt.framework"
+
+    mkdir "build" do
+      system "cmake", "..", *cmake_args
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS
+    #include <iostream>
+    #include <ignition/gui/qt.h>
+    #include <ignition/gui/Iface.hh>
+
+    using namespace ignition;
+    using namespace gui;
+
+    //////////////////////////////////////////////////
+    int main(int _argc, char **_argv)
+    {
+      std::cout << "Hello, GUI!" << std::endl;
+      // Increase verboosity so we see all messages
+      setVerbosity(4);
+      // Initialize app
+      initApp();
+      // Create main window
+      createMainWindow();
+      // Customize main window
+      auto win = mainWindow();
+      win->setWindowTitle("Hello Window!");
+      // After window is closed
+      stop();
+      std::cout << "After run" << std::endl;
+
+      return 0;
+    }
+    EOS
+    ENV.append_path "PKG_CONFIG_PATH", "#{Formula["qt"].opt_lib}/pkgconfig"
+    system "pkg-config", "ignition-gui"
+    cflags   = `pkg-config --cflags ignition-gui`.split(" ")
+    ldflags  = `pkg-config --libs ignition-gui`.split(" ")
+    system ENV.cc, "test.cpp",
+                   *cflags,
+                   *ldflags,
+                   "-lc++",
+                   "-o", "test"
+    system "./test"
+  end
+end

--- a/Formula/ignition-gui1.rb
+++ b/Formula/ignition-gui1.rb
@@ -13,6 +13,7 @@ class IgnitionGui1 < Formula
   depends_on "ignition-msgs3"
   depends_on "ignition-rendering1"
   depends_on "ignition-transport6"
+  depends_on :macos => :high_sierra # c++17
   depends_on "pkg-config"
   depends_on "qt"
   depends_on "qwt"

--- a/Formula/ignition-gui1.rb
+++ b/Formula/ignition-gui1.rb
@@ -62,9 +62,9 @@ class IgnitionGui1 < Formula
     }
     EOS
     ENV.append_path "PKG_CONFIG_PATH", "#{Formula["qt"].opt_lib}/pkgconfig"
-    system "pkg-config", "ignition-gui"
-    cflags   = `pkg-config --cflags ignition-gui`.split(" ")
-    ldflags  = `pkg-config --libs ignition-gui`.split(" ")
+    system "pkg-config", "ignition-gui1"
+    cflags   = `pkg-config --cflags ignition-gui1`.split(" ")
+    ldflags  = `pkg-config --libs ignition-gui1`.split(" ")
     system ENV.cc, "test.cpp",
                    *cflags,
                    *ldflags,

--- a/Formula/ignition-gui1.rb
+++ b/Formula/ignition-gui1.rb
@@ -1,19 +1,11 @@
 class IgnitionGui1 < Formula
   desc "Common libraries for robotics applications. GUI Library"
   homepage "https://bitbucket.org/ignitionrobotics/ign-gui"
-  url "https://bitbucket.org/ignitionrobotics/ign-gui/get/619b3b5944c8821e92cf625e012c819e95f6d2f0.tar.gz"
-  version "0.0.0~20181006~619b3b5"
-  sha256 "f45b3e2d559f2e07680241de8bce0d384600306e52deae5633690ee2edfab390"
+  url "http://gazebosim.org/distributions/ign-gui/releases/ignition-gui-1.0.0~pre2.tar.bz2"
+  version "1.0.0~pre2"
+  sha256 "9e822c41f2e631922f31d997599193306f2aad53c94efe60cb8b863301425bb3"
 
   head "https://bitbucket.org/ignitionrobotics/ign-gui", :branch => "gz11", :using => :hg
-
-  # bottle do
-  #   rebuild 1
-  #   root_url "http://gazebosim.org/distributions/ign-gui/releases"
-  #   sha256 "a435130d701ebdaa58bd29833a26d53c612ae2163a195b0124ad71f0e54675d8" => :high_sierra
-  #   sha256 "8660bbd506869aebc3c01114af9fa651d4ee67eaa9259748a7fc4204aeb01c08" => :sierra
-  #   sha256 "ab9346c2e57d496cc71275d44f6091c6e0792913ca5cc1c88af97e5f099bb37a" => :el_capitan
-  # end
 
   depends_on "cmake" => :build
   depends_on "ignition-cmake2"


### PR DESCRIPTION
The number of different dependencies is too high to maintain the workaround of the alias.