### PR TITLE
gazebo9: patch for boost 1.68

### DIFF
--- a/Formula/gazebo9.rb
+++ b/Formula/gazebo9.rb
@@ -28,7 +28,7 @@ class Gazebo9 < Formula
   depends_on "sdformat6"
   depends_on "tbb"
   depends_on "tinyxml"
-  depends_on "tinyxml2"
+  depends_on "tinyxml2@6.2.0"
   depends_on "zeromq" => :linked
 
   depends_on "bullet" => :recommended

--- a/Formula/gazebo9.rb
+++ b/Formula/gazebo9.rb
@@ -48,6 +48,12 @@ class Gazebo9 < Formula
   conflicts_with "gazebo8", :because => "Differing version of the same formula"
 
   patch do
+    # Fix for compatibility with boost 1.68
+    url "https://bitbucket.org/osrf/gazebo/commits/cc53e4cdd34875dbb99048137f1d27541d12b3d0/raw/"
+    sha256 "f382a668ba2c6a318f3d4b5f616a11ad098973d941cd73a5493f0b1788ae8a42"
+  end
+
+  patch do
     # Fix build when homebrew python is installed
     # keep this patch
     url "https://gist.githubusercontent.com/scpeters/9199370/raw/afe595587e38737c537124a3652db99de026c272/brew_python_fix.patch"

--- a/Formula/gazebo9.rb
+++ b/Formula/gazebo9.rb
@@ -3,7 +3,7 @@ class Gazebo9 < Formula
   homepage "http://gazebosim.org"
   url "http://gazebosim.org/distributions/gazebo/releases/gazebo-9.4.1.tar.bz2"
   sha256 "c787cd845ed454f6dd4179936c8326b45a61cec3cf18c30e5f63271a21e839c5"
-  revision 1
+  revision 2
 
   head "https://bitbucket.org/osrf/gazebo", :branch => "default", :using => :hg
 

--- a/Formula/gazebo9.rb
+++ b/Formula/gazebo9.rb
@@ -7,6 +7,13 @@ class Gazebo9 < Formula
 
   head "https://bitbucket.org/osrf/gazebo", :branch => "default", :using => :hg
 
+  bottle do
+    root_url "http://gazebosim.org/distributions/bottles-simulation"
+    sha256 "e9ee21d3db0e95a8ffa482efde3648eda1a41886df856981de531718c7073340" => :mojave
+    sha256 "99d649564929396ced7d3d4313fece64156ab989f80d29e2f6e9ab10d6fdc1fe" => :high_sierra
+    sha256 "c4da8b3ba7380eef88f0f3a1fb1e665dfb0eb50550f025036d61ba46cb588e7f" => :sierra
+  end
+
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
 

--- a/Formula/gazebo9.rb
+++ b/Formula/gazebo9.rb
@@ -13,6 +13,7 @@ class Gazebo9 < Formula
   depends_on "boost"
   depends_on "doxygen"
   depends_on "freeimage"
+  depends_on "graphviz"
   depends_on "ignition-fuel-tools1"
   depends_on "ignition-math4"
   depends_on "ignition-msgs1"

--- a/Formula/gazebo9.rb
+++ b/Formula/gazebo9.rb
@@ -32,10 +32,10 @@ class Gazebo9 < Formula
   depends_on "zeromq" => :linked
 
   depends_on "bullet" => :recommended
-  depends_on "dartsim" => :recommended
   depends_on "ffmpeg" => :recommended
   depends_on "gts" => :recommended
   depends_on "simbody" => :recommended
+  depends_on "dartsim" => :optional
   depends_on "gdal" => :optional
   depends_on "player" => :optional
 

--- a/Formula/ignition-common1.rb
+++ b/Formula/ignition-common1.rb
@@ -23,7 +23,7 @@ class IgnitionCommon1 < Formula
   depends_on "ignition-math4"
   depends_on "ossp-uuid"
   depends_on "pkg-config"
-  depends_on "tinyxml2"
+  depends_on "tinyxml2@6.2.0"
 
   def install
     system "cmake", ".", *std_cmake_args

--- a/Formula/ignition-common1.rb
+++ b/Formula/ignition-common1.rb
@@ -55,6 +55,7 @@ class IgnitionCommon1 < Formula
       add_executable(test_cmake test.cpp)
       target_link_libraries(test_cmake ${IGNITION-COMMON_LIBRARIES})
     EOS
+    ENV.append "PKG_CONFIG_PATH", Formula["tinyxml2@6.2.0"].opt_lib/"pkgconfig"
     system "pkg-config", "ignition-common1"
     cflags = `pkg-config --cflags ignition-common1`.split(" ")
     system ENV.cc, "test.cpp",

--- a/Formula/ignition-common1.rb
+++ b/Formula/ignition-common1.rb
@@ -3,6 +3,7 @@ class IgnitionCommon1 < Formula
   homepage "https://bitbucket.org/ignitionrobotics/ign-common"
   url "http://gazebosim.org/distributions/ign-common/releases/ignition-common-1.1.1.tar.bz2"
   sha256 "2e8b65c9390bc78088865d95c0933c564b07b3b55b68c14e1c6d947ca8d9525a"
+  revision 1
 
   head "https://bitbucket.org/ignitionrobotics/ign-common", :branch => "default", :using => :hg
 

--- a/Formula/ignition-common1.rb
+++ b/Formula/ignition-common1.rb
@@ -8,12 +8,11 @@ class IgnitionCommon1 < Formula
   head "https://bitbucket.org/ignitionrobotics/ign-common", :branch => "default", :using => :hg
 
   bottle do
-    root_url "http://gazebosim.org/distributions/ign-common/releases"
+    root_url "http://gazebosim.org/distributions/bottles-simulation"
     cellar :any
-    sha256 "8b29ed353a8bf74eb674b5ddd5bf3fb2018fd71b021367d562a0ad520e056579" => :mojave
-    sha256 "c2f06b275a5e82784417e72d9fe40be02731d285a6bd4a4beff29287282335b1" => :high_sierra
-    sha256 "95637ed2153b1a0dde52453bb2686197583d79cba68deccc37089052f9d02fd7" => :sierra
-    sha256 "68058186521d1882c55eaf2ce52b9de8f02287f49b68b2442e09c5a23775aa44" => :el_capitan
+    sha256 "7fac4d4859c6224b86a96742ea13da1ba4a2ac312df98fbcf60f8a62b1f22c6a" => :mojave
+    sha256 "9dc34e66f32fd63b5792c5c4385ffe5ec81895133da5a26e600e88381b665646" => :high_sierra
+    sha256 "c64df45c5240d326046cc79300e0ca435bc94734ced04fe93cf06b79b8c9fb1f" => :sierra
   end
 
   depends_on "cmake"

--- a/Formula/ignition-fuel-tools1.rb
+++ b/Formula/ignition-fuel-tools1.rb
@@ -46,6 +46,7 @@ class IgnitionFuelTools1 < Formula
       target_link_libraries(test_cmake ignition-fuel_tools1::ignition-fuel_tools1)
     EOS
     # test building with pkg-config
+    ENV.append "PKG_CONFIG_PATH", Formula["tinyxml2@6.2.0"].opt_lib/"pkgconfig"
     system "pkg-config", "ignition-fuel_tools1"
     cflags = `pkg-config --cflags ignition-fuel_tools1`.split(" ")
     system ENV.cc, "test.cpp",

--- a/Formula/ignition-fuel-tools1.rb
+++ b/Formula/ignition-fuel-tools1.rb
@@ -3,6 +3,7 @@ class IgnitionFuelTools1 < Formula
   homepage "https://ignitionrobotics.org"
   url "http://gazebosim.org/distributions/ign-fuel-tools/releases/ignition-fuel-tools1-1.2.0.tar.bz2"
   sha256 "6b1d631a095e8273dc09be7456758aeaa7582b74bebe983cc14da49063994473"
+  revision 1
   version_scheme 1
 
   bottle do

--- a/Formula/ignition-fuel-tools1.rb
+++ b/Formula/ignition-fuel-tools1.rb
@@ -7,11 +7,10 @@ class IgnitionFuelTools1 < Formula
   version_scheme 1
 
   bottle do
-    root_url "http://gazebosim.org/distributions/ign-fuel-tools/releases"
-    sha256 "48feaa87e39fe2e20640eec0ebc692845f07e95b420b1e758c0d6026490a9c99" => :mojave
-    sha256 "87450e361248be0e072cc30ae100da6e86b439335b3129b39daeb39e600bdef0" => :high_sierra
-    sha256 "65194a031cad888a5e30c7f52b56cbb1c9b3c82fcf7a1ccaa7166bbabbe62f7c" => :sierra
-    sha256 "e34be34fde7f61f9ecbe2092e0cb649faefbf4b6122ad67278d7e2ebca859870" => :el_capitan
+    root_url "http://gazebosim.org/distributions/bottles-simulation"
+    sha256 "bb751f0bdd3ac1e9a93995bd62777f1b06032eb05701973e691d9f8b5c3c02ab" => :mojave
+    sha256 "efc37f0b7d1ff129e9081eb78c76a0bf88d279dc508f8e25c485f26de77b7862" => :high_sierra
+    sha256 "4a9afcd5dce53a6b982dd54c750da990b1ca440f6a2a3e3b3511d943ff889405" => :sierra
   end
 
   depends_on "cmake"


### PR DESCRIPTION
needed due to recent tinyxml2 update: https://github.com/Homebrew/homebrew-core/pull/33884

Also, depend on graphviz to help fix build problems reported in #517 