### PR TITLE
gazebo9: switch back to tinyxml2

### DIFF
--- a/Formula/gazebo9.rb
+++ b/Formula/gazebo9.rb
@@ -3,7 +3,7 @@ class Gazebo9 < Formula
   homepage "http://gazebosim.org"
   url "http://gazebosim.org/distributions/gazebo/releases/gazebo-9.4.1.tar.bz2"
   sha256 "c787cd845ed454f6dd4179936c8326b45a61cec3cf18c30e5f63271a21e839c5"
-  revision 2
+  revision 3
 
   head "https://bitbucket.org/osrf/gazebo", :branch => "default", :using => :hg
 
@@ -35,7 +35,7 @@ class Gazebo9 < Formula
   depends_on "sdformat6"
   depends_on "tbb"
   depends_on "tinyxml"
-  depends_on "tinyxml2@6.2.0"
+  depends_on "tinyxml2"
   depends_on "zeromq" => :linked
 
   depends_on "bullet" => :recommended

--- a/Formula/ignition-common1.rb
+++ b/Formula/ignition-common1.rb
@@ -3,7 +3,7 @@ class IgnitionCommon1 < Formula
   homepage "https://bitbucket.org/ignitionrobotics/ign-common"
   url "http://gazebosim.org/distributions/ign-common/releases/ignition-common-1.1.1.tar.bz2"
   sha256 "2e8b65c9390bc78088865d95c0933c564b07b3b55b68c14e1c6d947ca8d9525a"
-  revision 1
+  revision 2
 
   head "https://bitbucket.org/ignitionrobotics/ign-common", :branch => "default", :using => :hg
 
@@ -22,7 +22,7 @@ class IgnitionCommon1 < Formula
   depends_on "ignition-math4"
   depends_on "ossp-uuid"
   depends_on "pkg-config"
-  depends_on "tinyxml2@6.2.0"
+  depends_on "tinyxml2"
 
   def install
     system "cmake", ".", *std_cmake_args
@@ -54,7 +54,6 @@ class IgnitionCommon1 < Formula
       add_executable(test_cmake test.cpp)
       target_link_libraries(test_cmake ${IGNITION-COMMON_LIBRARIES})
     EOS
-    ENV.append "PKG_CONFIG_PATH", Formula["tinyxml2@6.2.0"].opt_lib/"pkgconfig"
     system "pkg-config", "ignition-common1"
     cflags = `pkg-config --cflags ignition-common1`.split(" ")
     system ENV.cc, "test.cpp",

--- a/Formula/ignition-fuel-tools1.rb
+++ b/Formula/ignition-fuel-tools1.rb
@@ -3,7 +3,7 @@ class IgnitionFuelTools1 < Formula
   homepage "https://ignitionrobotics.org"
   url "http://gazebosim.org/distributions/ign-fuel-tools/releases/ignition-fuel-tools1-1.2.0.tar.bz2"
   sha256 "6b1d631a095e8273dc09be7456758aeaa7582b74bebe983cc14da49063994473"
-  revision 1
+  revision 2
   version_scheme 1
 
   bottle do
@@ -45,7 +45,6 @@ class IgnitionFuelTools1 < Formula
       target_link_libraries(test_cmake ignition-fuel_tools1::ignition-fuel_tools1)
     EOS
     # test building with pkg-config
-    ENV.append "PKG_CONFIG_PATH", Formula["tinyxml2@6.2.0"].opt_lib/"pkgconfig"
     system "pkg-config", "ignition-fuel_tools1"
     cflags = `pkg-config --cflags ignition-fuel_tools1`.split(" ")
     system ENV.cc, "test.cpp",


### PR DESCRIPTION
version 7.0.1 has been released, so we don't need to use our forked formula anymore