### PR TITLE
gazebo9/10, deps: bump revision for protobuf 3.7.0

### DIFF
--- a/Formula/gazebo10.rb
+++ b/Formula/gazebo10.rb
@@ -3,6 +3,7 @@ class Gazebo10 < Formula
   homepage "http://gazebosim.org"
   url "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/gazebo-10.0.0.tar.bz2"
   sha256 "df4760aa28845315ed221fa9dfb0b2a7c8adc99656f0dde91fe93e2ec30f79eb"
+  revision 1
 
   head "https://bitbucket.org/osrf/gazebo", :branch => "default", :using => :hg
 

--- a/Formula/gazebo10.rb
+++ b/Formula/gazebo10.rb
@@ -9,9 +9,9 @@ class Gazebo10 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "11940fe447a5a6ed33682ad48206053f9fd26b70446408f54d21829572a96dd0" => :mojave
-    sha256 "2c9799e960a0e72f06b721db02052be1ea32516c5e74e0b8d0067a9ef4588596" => :high_sierra
-    sha256 "065b27da5d0baeaf485fa6161fb6d07c6722c8872700af358f3eb74c21092c3b" => :sierra
+    sha256 "b32f41bb48a90eeaec5fcf4bafbbdd1571dd02eca006e097faa921297f90069e" => :mojave
+    sha256 "8a967ffe51558f527e7403948e05b30aefa2cc9d1eb44fd0e17862f9ac1e8ef1" => :high_sierra
+    sha256 "af54990ff644e1174e12296f3cd5803592ff7ae2f286e4eb0c7cd8f49df991b0" => :sierra
   end
 
   depends_on "cmake" => :build

--- a/Formula/gazebo9.rb
+++ b/Formula/gazebo9.rb
@@ -3,7 +3,7 @@ class Gazebo9 < Formula
   homepage "http://gazebosim.org"
   url "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/gazebo-9.6.0.tar.bz2"
   sha256 "289a78e09d1a49f55df2d3c72930f474f12b492c65d368af4f0e97e6dc4d1d19"
-  revision 2
+  revision 3
 
   head "https://bitbucket.org/osrf/gazebo", :branch => "default", :using => :hg
 

--- a/Formula/gazebo9.rb
+++ b/Formula/gazebo9.rb
@@ -9,9 +9,9 @@ class Gazebo9 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "9d59615f6199abae132adc25d428a1241bd19da34ec84cbd7cd4190fc4313f3d" => :mojave
-    sha256 "bd94619f20efc435d1f4aee7fb91db8edf40c2a30219916fe06f59b4b4838744" => :high_sierra
-    sha256 "ff393aa5f4911aa910884e1e361c5bbbf6c1918b73bd93e204e4d1f787c1ba89" => :sierra
+    sha256 "ab1f3fec140fdbfa17b73a41b0341712e2598256ed63ec17717aaac49b6b6377" => :mojave
+    sha256 "797dd45c09e148df28f23162b724cd1776bc033b015e9427ab344d73e2ee02c0" => :high_sierra
+    sha256 "21974b81dace190dc0193606b31d8211b69395738b546188d7e455948f80b20b" => :sierra
   end
 
   depends_on "cmake" => :build

--- a/Formula/ignition-msgs1.rb
+++ b/Formula/ignition-msgs1.rb
@@ -3,7 +3,7 @@ class IgnitionMsgs1 < Formula
   homepage "https://bitbucket.org/ignitionrobotics/ign-msgs"
   url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs-1.0.0.tar.bz2"
   sha256 "fed54d079a58087fa83cc871f01ba2919866292ba949b6b8f37a0cb3d7186b4b"
-  revision 2
+  revision 3
   version_scheme 1
 
   head "https://bitbucket.org/ignitionrobotics/ign-msgs", :branch => "default", :using => :hg

--- a/Formula/ignition-msgs1.rb
+++ b/Formula/ignition-msgs1.rb
@@ -9,12 +9,11 @@ class IgnitionMsgs1 < Formula
   head "https://bitbucket.org/ignitionrobotics/ign-msgs", :branch => "default", :using => :hg
 
   bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases"
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     cellar :any
-    sha256 "a1d2c5cf6b818781917ea40760b1ea2b3c18eb19e08f44906c8481d80e543496" => :mojave
-    sha256 "08ac01a6c9e57ffd603d91927b0abfeae240593f9a5703d7871878cf8a85ea2d" => :high_sierra
-    sha256 "23c76c6bac0f29e0b660bea0fe2e9e9e94f447ac98df4ff95cad2422d2c063a9" => :sierra
-    sha256 "ecd1acd2086d145059d831a094aedeb17a1a94cc8389c5bd321e2bd0fbaeed10" => :el_capitan
+    sha256 "39f51873a5c27cdb8106beae5be19bbca3db368b231ef38e4a659bca3f48f6ef" => :mojave
+    sha256 "6cb06bb820777fa68a2790e5dcb6bb842737cf1edc50e11252d320c4bf02b544" => :high_sierra
+    sha256 "89bf0324c66fd739ac9cc4ef2ed085cb86e4eb462da404beb22a957b8d824341" => :sierra
   end
 
   depends_on "protobuf-c" => :build

--- a/Formula/ignition-transport4.rb
+++ b/Formula/ignition-transport4.rb
@@ -3,7 +3,7 @@ class IgnitionTransport4 < Formula
   homepage "https://ignitionrobotics.org"
   url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases/ignition-transport4-4.0.0.tar.bz2"
   sha256 "b0d8d3d4b0d4fbb06ed293955f5dfe2f840fe510daec867422676b41fc3824b4"
-  revision 2
+  revision 3
 
   head "https://bitbucket.org/ignitionrobotics/ign-transport", :branch => "ign-transport4", :using => :hg
 

--- a/Formula/ignition-transport4.rb
+++ b/Formula/ignition-transport4.rb
@@ -8,12 +8,11 @@ class IgnitionTransport4 < Formula
   head "https://bitbucket.org/ignitionrobotics/ign-transport", :branch => "ign-transport4", :using => :hg
 
   bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases"
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     cellar :any
-    sha256 "cb0d3f9f60a888f822d6edd85d60dac72e6a6ee8cd37402679c031a104e477d3" => :mojave
-    sha256 "d6f198e35bfada6540a67de56fedaf953b9de058799b4263ee5b433953258c9a" => :high_sierra
-    sha256 "e46cdb2bc01143fb9364af56d715b627470669dacdeb12fa77afb54c6bd1b236" => :sierra
-    sha256 "323532012a4dc16edf06fc96a9620196cdc574e4f5534fe69d712eb325502195" => :el_capitan
+    sha256 "957604daa538a9b5d7f57e237797e36a2a0ed6a9c3f82e4867afcf2bfe8b50c2" => :mojave
+    sha256 "af521953de88d76f7c6aea53e0fcde716ea5e9d700c79257a18276c2e88cb839" => :high_sierra
+    sha256 "9ec498d203bc82ef86d913a2b50e9758bccc0bf3eddb838f73bbd3d74e38c684" => :sierra
   end
 
   depends_on "doxygen" => [:build, :optional]


### PR DESCRIPTION
[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo-install-one_liner-homebrew-amd64&build=1217)](https://build.osrfoundation.org/job/gazebo-install-one_liner-homebrew-amd64/1217/) https://build.osrfoundation.org/job/gazebo-install-one_liner-homebrew-amd64/1217/