### PR TITLE
ignition-sensors2, ignition-rendering2 initial versions

### DIFF
--- a/Aliases/ignition-rendering2
+++ b/Aliases/ignition-rendering2
@@ -1,1 +1,0 @@
-../Formula/ignition-rendering1.rb

--- a/Aliases/ignition-sensors2
+++ b/Aliases/ignition-sensors2
@@ -1,1 +1,0 @@
-../Formula/ignition-sensors1.rb

--- a/Formula/ignition-rendering2.rb
+++ b/Formula/ignition-rendering2.rb
@@ -2,9 +2,11 @@ class IgnitionRendering2 < Formula
   desc "Rendering library for robotics applications"
   homepage "https://bitbucket.org/ignitionrobotics/ign-rendering"
   url "https://bitbucket.org/ignitionrobotics/ign-rendering/get/95a38eb155b92ebb4419d7a4377dcfe2d183e0a2.tar.bz2"
+  version "1.999.999~20190311~95a38eb1"
   sha256 "83571fff709752a66049bc1a16b90ecfbd3425a9bd82bf52cd598ae9f7310156"
 
   depends_on "cmake" => :build
+  depends_on "pkg-config" => [:build, :test]
 
   depends_on "freeimage"
   depends_on "ignition-cmake2"
@@ -13,7 +15,6 @@ class IgnitionRendering2 < Formula
   depends_on "ignition-plugin1"
   depends_on :macos => :high_sierra # c++17
   depends_on "ogre1.9"
-  depends_on "pkg-config"
 
   def install
     system "cmake", ".", *std_cmake_args

--- a/Formula/ignition-rendering2.rb
+++ b/Formula/ignition-rendering2.rb
@@ -1,0 +1,43 @@
+class IgnitionRendering2 < Formula
+  desc "Rendering library for robotics applications"
+  homepage "https://bitbucket.org/ignitionrobotics/ign-rendering"
+  url "https://bitbucket.org/ignitionrobotics/ign-rendering/get/95a38eb155b92ebb4419d7a4377dcfe2d183e0a2.tar.bz2"
+  sha256 "83571fff709752a66049bc1a16b90ecfbd3425a9bd82bf52cd598ae9f7310156"
+
+  depends_on "cmake" => :build
+
+  depends_on "freeimage"
+  depends_on "ignition-cmake2"
+  depends_on "ignition-common3"
+  depends_on "ignition-math6"
+  depends_on "ignition-plugin1"
+  depends_on :macos => :high_sierra # c++17
+  depends_on "ogre1.9"
+  depends_on "pkg-config"
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS
+      #include <ignition/rendering/PixelFormat.hh>
+      int main(int _argc, char** _argv)
+      {
+        ignition::rendering::PixelFormat pf = ignition::rendering::PF_UNKNOWN;
+        return ignition::rendering::PixelUtil::IsValid(pf);
+      }
+    EOS
+    ENV.append_path "PKG_CONFIG_PATH", "#{Formula["qt"].opt_lib}/pkgconfig"
+    system "pkg-config", "ignition-rendering2"
+    cflags   = `pkg-config --cflags ignition-rendering2`.split(" ")
+    ldflags  = `pkg-config --libs ignition-rendering2`.split(" ")
+    system ENV.cc, "test.cpp",
+                   *cflags,
+                   *ldflags,
+                   "-lc++",
+                   "-o", "test"
+    system "./test"
+  end
+end

--- a/Formula/ignition-sensors2.rb
+++ b/Formula/ignition-sensors2.rb
@@ -1,0 +1,62 @@
+class IgnitionSensors2 < Formula
+  desc "Sensors library for robotics applications"
+  homepage "https://bitbucket.org/ignitionrobotics/ign-sensors"
+  url "https://bitbucket.org/ignitionrobotics/ign-sensors/get/5258e71574442d4cea910297541ffc95972ef6af.tar.bz2"
+  sha256 "05e242350122a9b1e89163297c64237e710feb33a49d27bf8143e17d677d278b"
+
+  head "https://bitbucket.org/ignitionrobotics/ign-sensors", :branch => "default", :using => :hg
+
+  depends_on "cmake" => [:build, :test]
+  depends_on "pkg-config" => [:build, :test]
+
+  depends_on "ignition-cmake2"
+  depends_on "ignition-common3"
+  depends_on "ignition-math6"
+  depends_on "ignition-msgs3"
+  depends_on "ignition-rendering2"
+  depends_on "ignition-transport6"
+  depends_on "sdformat8"
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS
+      #include <ignition/sensors.hh>
+
+      int main()
+      {
+        ignition::sensors::Noise noise(ignition::sensors::NoiseType::NONE);
+
+        return 0;
+      }
+    EOS
+    (testpath/"CMakeLists.txt").write <<-EOS
+      cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+      find_package(ignition-sensors2 QUIET REQUIRED)
+      add_executable(test_cmake test.cpp)
+      target_link_libraries(test_cmake ignition-sensors2::ignition-sensors2)
+    EOS
+    # test building with pkg-config
+    ENV.append_path "PKG_CONFIG_PATH", "#{Formula["qt"].opt_lib}/pkgconfig"
+    system "pkg-config", "ignition-sensors2"
+    cflags   = `pkg-config --cflags ignition-sensors2`.split(" ")
+    ldflags  = `pkg-config --libs ignition-sensors2`.split(" ")
+    system ENV.cc, "test.cpp",
+                   *cflags,
+                   *ldflags,
+                   "-lc++",
+                   "-o", "test"
+    system "./test"
+    # test building with cmake
+    mkdir "build" do
+      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
+      ENV.delete("SDKROOT")
+      system "cmake", ".."
+      system "make"
+      system "./test_cmake"
+    end
+  end
+end

--- a/Formula/ignition-sensors2.rb
+++ b/Formula/ignition-sensors2.rb
@@ -2,6 +2,7 @@ class IgnitionSensors2 < Formula
   desc "Sensors library for robotics applications"
   homepage "https://bitbucket.org/ignitionrobotics/ign-sensors"
   url "https://bitbucket.org/ignitionrobotics/ign-sensors/get/5258e71574442d4cea910297541ffc95972ef6af.tar.bz2"
+  version "1.999.999~20190312~5258e715"
   sha256 "05e242350122a9b1e89163297c64237e710feb33a49d27bf8143e17d677d278b"
 
   head "https://bitbucket.org/ignitionrobotics/ign-sensors", :branch => "default", :using => :hg


### PR DESCRIPTION
New ignition-sensors2 formula based on a commit. 

I'm not very sure about the changes. Let me know if I need to change anything. 

I copied from `ignition-sensors1.rb` but removed the `bottle` section and the `version` field. The `url` now points to a specific commit and I also bumped ign-rendering dependency to ignition-rendering2