### PR TITLE
Add aliases for Acropolis versions +1

### DIFF
--- a/Aliases/ignition-cmake3
+++ b/Aliases/ignition-cmake3
@@ -1,0 +1,1 @@
+../Formula/ignition-cmake2.rb

--- a/Aliases/ignition-common4
+++ b/Aliases/ignition-common4
@@ -1,0 +1,1 @@
+../Formula/ignition-common3.rb

--- a/Aliases/ignition-fuel-tools4
+++ b/Aliases/ignition-fuel-tools4
@@ -1,0 +1,1 @@
+../Formula/ignition-fuel-tools3.rb

--- a/Aliases/ignition-fuel_tools3
+++ b/Aliases/ignition-fuel_tools3
@@ -1,0 +1,1 @@
+../Formula/ignition-fuel-tools3.rb

--- a/Aliases/ignition-gui2
+++ b/Aliases/ignition-gui2
@@ -1,0 +1,1 @@
+../Formula/ignition-gui1.rb

--- a/Aliases/ignition-math7
+++ b/Aliases/ignition-math7
@@ -1,0 +1,1 @@
+../Formula/ignition-math6.rb

--- a/Aliases/ignition-physics2
+++ b/Aliases/ignition-physics2
@@ -1,0 +1,1 @@
+../Formula/ignition-physics1.rb

--- a/Aliases/ignition-plugin2
+++ b/Aliases/ignition-plugin2
@@ -1,0 +1,1 @@
+../Formula/ignition-plugin1.rb


### PR DESCRIPTION
This allows the default branches to install correct dependencies during CI builds.

Thanks to @iche033 who already made some of these.