### PR TITLE
Add ignition-launch alias to ignition-launch0

### DIFF
--- a/Aliases/ignition-launch
+++ b/Aliases/ignition-launch
@@ -1,0 +1,1 @@
+../Formula/ignition-launch0.rb


### PR DESCRIPTION
The generic build was failing due to the lack of a formula named `ignition-launch`