### PR TITLE
Back to enable ign-launch test

### DIFF
--- a/Formula/ignition-launch0.rb
+++ b/Formula/ignition-launch0.rb
@@ -29,8 +29,7 @@ class IgnitionLaunch0 < Formula
     system "make", "install"
   end
 
-  # TODO: fix test. Failing: https://build.osrfoundation.org/job/generic-release-homebrew_bottle_builder/209/label=osx_mojave/
-  # test do
-  #  system "ignition", "-run", "config/gazebo.ign"
-  # end
+  test do
+    system "ignition", "-run", "config/gazebo.ign"
+  end
 end


### PR DESCRIPTION
Some tests were disabled during the last release due to problems with Mojave. Back to enable the ign-launch one here.