### PR TITLE
Enable the use of ogre2.1 in ignition-rendering

### DIFF
--- a/Formula/ignition-rendering2.rb
+++ b/Formula/ignition-rendering2.rb
@@ -21,6 +21,7 @@ class IgnitionRendering2 < Formula
   depends_on "ignition-plugin1"
   depends_on :macos => :high_sierra # c++17
   depends_on "ogre1.9"
+  depends_on "ogre2.1"
 
   def install
     system "cmake", ".", *std_cmake_args


### PR DESCRIPTION
Add support for ogre2.1 in ignition rendering by adding it as a dependency. Not sure if we want the same for previous majors of ign-rendering, @iche033 ?