### PR TITLE
Bump ogre / sdformat revisions for boost 1.69

### DIFF
--- a/Formula/ogre1.9.rb
+++ b/Formula/ogre1.9.rb
@@ -4,7 +4,7 @@ class Ogre19 < Formula
   url "https://bitbucket.org/sinbad/ogre/get/108ab0bcc69603dba32c0ffd4bbbc39051f421c9.tar.bz2"
   version "1.9-20160714-108ab0bcc69603dba32c0ffd4bbbc39051f421c9"
   sha256 "3ca667b959905b290d782d7f0808e35d075c85db809d3239018e4e10e89b1721"
-  revision 7
+  revision 8
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ogre1.9.rb
+++ b/Formula/ogre1.9.rb
@@ -8,9 +8,9 @@ class Ogre19 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "160e7ee9686c2a87009c6ef6f774208841466da71aacd25dfb0ca896a5e5299e" => :mojave
-    sha256 "b530362abcf2db10ee8bc18b1f2f5bae9cd216a552a6e24c7bdfd7cfc51d56de" => :high_sierra
-    sha256 "584d3397f9ef3ff720ce6c3fbbcdbf2bb3f174cef85b0ffcbba1aa1f7bc10144" => :sierra
+    sha256 "a7113b6b6d88fe5755d0c9c809e592d59dcbe99ac7a24a8d76cd0bd69ebbd32f" => :mojave
+    sha256 "0aab13c0c1475912241bb0d26a4148d21e948c025b6b3199715e4e860cb97ef7" => :high_sierra
+    sha256 "ca9a63ea85a41014f49f46de0cb9ef120ae763738313b301e3e91ca09d170f5e" => :sierra
   end
 
   option "with-cg"

--- a/Formula/sdformat4.rb
+++ b/Formula/sdformat4.rb
@@ -9,9 +9,9 @@ class Sdformat4 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "3110ecc715f6ed7804065c7045adf775900427d35849825104e7d8fa2ba3410a" => :mojave
-    sha256 "6b81d8914cb9e4173cd0931e06a17f260dbcb15595a86dd6e54555e1668cc510" => :high_sierra
-    sha256 "ac922c99d9de95ffc74fc475104a0cda96c2b6ebf1b6b6f9631e52b538fa83af" => :sierra
+    sha256 "f0009e22737945b454aa126d10354e9a28e0722799437e0ef1c7363553169e24" => :mojave
+    sha256 "8ca2dca0a7f737943ad4ffa63ce538cabbba49098df9d5b6f76a92ef166801f4" => :high_sierra
+    sha256 "202ca00f9e7c5e4a0a4f916e3193466b45f13843bca0b85fca600ffa0cbb3f04" => :sierra
   end
 
   depends_on "cmake" => :build

--- a/Formula/sdformat4.rb
+++ b/Formula/sdformat4.rb
@@ -3,7 +3,7 @@ class Sdformat4 < Formula
   homepage "http://sdformat.org"
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-4.4.0.tar.bz2"
   sha256 "4424a984f69d3333f087e7aae1d8fa5aec61ad52e09be39e2f5e2cb69ade1527"
-  revision 3
+  revision 4
 
   head "https://bitbucket.org/osrf/sdformat", :branch => "sdf4", :using => :hg
 

--- a/Formula/sdformat4.rb
+++ b/Formula/sdformat4.rb
@@ -26,6 +26,9 @@ class Sdformat4 < Formula
   conflicts_with "sdformat", :because => "Differing version of the same formula"
   conflicts_with "sdformat3", :because => "Differing version of the same formula"
   conflicts_with "sdformat5", :because => "Differing version of the same formula"
+  conflicts_with "sdformat6", :because => "Differing version of the same formula"
+  conflicts_with "sdformat7", :because => "Differing version of the same formula"
+  conflicts_with "sdformat8", :because => "Differing version of the same formula"
 
   def install
     ENV.m64

--- a/Formula/sdformat5.rb
+++ b/Formula/sdformat5.rb
@@ -3,7 +3,7 @@ class Sdformat5 < Formula
   homepage "http://sdformat.org"
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-5.3.0.tar.bz2"
   sha256 "e5946e84431cf7874cf422d5b5a9f34f42b31d82b5baea532d1e466011bd89e0"
-  revision 4
+  revision 5
 
   head "https://bitbucket.org/osrf/sdformat", :branch => "default", :using => :hg
 

--- a/Formula/sdformat5.rb
+++ b/Formula/sdformat5.rb
@@ -26,6 +26,9 @@ class Sdformat5 < Formula
   conflicts_with "sdformat", :because => "Differing version of the same formula"
   conflicts_with "sdformat3", :because => "Differing version of the same formula"
   conflicts_with "sdformat4", :because => "Differing version of the same formula"
+  conflicts_with "sdformat6", :because => "Differing version of the same formula"
+  conflicts_with "sdformat7", :because => "Differing version of the same formula"
+  conflicts_with "sdformat8", :because => "Differing version of the same formula"
 
   def install
     ENV.m64

--- a/Formula/sdformat5.rb
+++ b/Formula/sdformat5.rb
@@ -9,9 +9,9 @@ class Sdformat5 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "4b8a84d2bc9cfcedcea70bea85324125bcfdef65681ea01c339e95fbad0012ff" => :mojave
-    sha256 "47d9edab2327d0fc594490070d73aa95b7b007b824a4b0989e299cc8a13ca3d7" => :high_sierra
-    sha256 "f84604dbfdbe4d6828ce5746fa8a614d1abeac27c07778bc788418a1ccf3a5e1" => :sierra
+    sha256 "2f8ad2df0a00ef492d8336f30c839139972e94ab5b4ddb72a14dc7d78bede658" => :mojave
+    sha256 "4873b0683399a7e7237642c4fd37fb2229d87c146f955f1c6e067571f391f63a" => :high_sierra
+    sha256 "491df711abe40a502245af24bc20a1d4c3e0a181fa6c45469b3e5534f4e4cd9b" => :sierra
   end
 
   depends_on "cmake" => :build

--- a/Formula/sdformat6.rb
+++ b/Formula/sdformat6.rb
@@ -9,9 +9,9 @@ class Sdformat6 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "b54f7bce9d7ef970d7968935f1784e212ac3ff37d64ad6c82b439b381bb0cb02" => :mojave
-    sha256 "3179c632c6664cbe0fdfad88e1c5c8acb1a4b4c9e5a3d8ee8856103b4cdd6db0" => :high_sierra
-    sha256 "dde590ba3a975bf1ddbaf4e2d92ad9c01178740f24e0b194872f2fbff27d1e26" => :sierra
+    sha256 "4225b11d56c632106f4fb90de0458ba6dad24b981b619b115f38e9cf58278d07" => :mojave
+    sha256 "ec07b9e4931703c0fbf9a7a915f8a7cdbb22c64537947d66a8b3da748a641228" => :high_sierra
+    sha256 "b198e8e1251fd267ab72886c480f288ef00a25e8d3c3ef79fa24c654807a02ff" => :sierra
   end
 
   depends_on "cmake" => :build

--- a/Formula/sdformat6.rb
+++ b/Formula/sdformat6.rb
@@ -3,6 +3,7 @@ class Sdformat6 < Formula
   homepage "http://sdformat.org"
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-6.2.0.tar.bz2"
   sha256 "be818648f0a639a0c410231673e8c7ba043c2589586e43ef8c757070855898fa"
+  revision 1
 
   head "https://bitbucket.org/osrf/sdformat", :branch => "default", :using => :hg
 

--- a/Formula/sdformat6.rb
+++ b/Formula/sdformat6.rb
@@ -27,6 +27,8 @@ class Sdformat6 < Formula
   conflicts_with "sdformat3", :because => "Differing version of the same formula"
   conflicts_with "sdformat4", :because => "Differing version of the same formula"
   conflicts_with "sdformat5", :because => "Differing version of the same formula"
+  conflicts_with "sdformat7", :because => "Differing version of the same formula"
+  conflicts_with "sdformat8", :because => "Differing version of the same formula"
 
   def install
     ENV.m64

--- a/Formula/sdformat7.rb
+++ b/Formula/sdformat7.rb
@@ -10,9 +10,9 @@ class Sdformat7 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "bf3d324d52935d7f243a80ab85453b0d9c5e72fc9f6d7c50fa9d1aae94096c08" => :mojave
-    sha256 "5a9c88cbbe90b664c16e1052ada5de714c8dbc48a992b0b1187c325a976e744c" => :high_sierra
-    sha256 "9e06b3d56433ece25f0054a51f64c682c791abadb425b15fa742e8694dac0cdc" => :sierra
+    sha256 "ba0798dc96e5c7044c4a9c1e3de7558fa141c3442d185307fb58292ca374b908" => :mojave
+    sha256 "4b2b10f850c00393d2772964fd895856ad7f8edcbd57747f69c95927be31fb78" => :high_sierra
+    sha256 "c6bc10aeeda21616645773d176188157f408561033e46f6ad4d20cd23c80da92" => :sierra
   end
 
   depends_on "cmake" => :build

--- a/Formula/sdformat7.rb
+++ b/Formula/sdformat7.rb
@@ -4,7 +4,7 @@ class Sdformat7 < Formula
   url "https://bitbucket.org/osrf/sdformat/get/2fed80e6bc44.tar.gz"
   version "6.999.999~20180905~2fed80e"
   sha256 "b9792f701be807a9f522b9b9b09c521340744ba1bd593d533765b1dc7bb40bb5"
-  revision 1
+  revision 2
 
   head "https://bitbucket.org/osrf/sdformat", :branch => "default", :using => :hg
 

--- a/Formula/sdformat7.rb
+++ b/Formula/sdformat7.rb
@@ -29,6 +29,7 @@ class Sdformat7 < Formula
   conflicts_with "sdformat4", :because => "Differing version of the same formula"
   conflicts_with "sdformat5", :because => "Differing version of the same formula"
   conflicts_with "sdformat6", :because => "Differing version of the same formula"
+  conflicts_with "sdformat8", :because => "Differing version of the same formula"
 
   def install
     ENV.m64


### PR DESCRIPTION
Gazebo bottles are disabled to shorten the build time for gazebo deps. Gazebo bottles will be rebuilt after this is merged.