### PR TITLE
ignition-rendering1: better test for ogre plugin, bump revision

### DIFF
--- a/Formula/ignition-rendering1.rb
+++ b/Formula/ignition-rendering1.rb
@@ -7,8 +7,8 @@ class IgnitionRendering1 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "cafade1cb99232ab1e187b986b0489f17121a6879aff7fde762a7417207d4689" => :mojave
-    sha256 "3f065edd6db6be46c5225377f5a393e00e0877a8f1be6261aa218734aee92c05" => :high_sierra
+    sha256 "2cd474e3ff77d19e393f1f6c73a004e0ef0eb46c911de8b1bc576c7174d999d2" => :mojave
+    sha256 "6fa7646f34ba9b813d768f969f22cdec58d3d5a3a0a0a864e086bb41d20a8104" => :high_sierra
   end
 
   depends_on "cmake" => :build

--- a/Formula/ignition-rendering1.rb
+++ b/Formula/ignition-rendering1.rb
@@ -3,6 +3,7 @@ class IgnitionRendering1 < Formula
   homepage "https://bitbucket.org/ignitionrobotics/ign-rendering"
   url "https://osrf-distributions.s3.amazonaws.com/ign-rendering/releases/ignition-rendering-1.0.0.tar.bz2"
   sha256 "73dc1ce94c281ddd21796ebf363e1cd03acf15709cda959926d3187462221bfe"
+  revision 1
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"


### PR DESCRIPTION
The test wasn't sufficient to indicate that a revision bump was needed when we rebuilt bottles for ogre 1.69, but the test in aa457dc fails with the current bottle in a way that matches the test failures we've seen in ign-gazebo.