### PR TITLE
ogre2.1: new commit, fix build for xcode 10+

### DIFF
--- a/Formula/ogre2.1.rb
+++ b/Formula/ogre2.1.rb
@@ -1,9 +1,11 @@
 class Ogre21 < Formula
   desc "Scene-oriented 3D engine written in c++"
   homepage "https://www.ogre3d.org/"
-  url "https://bitbucket.org/sinbad/ogre/get/06a386fa64e79a7204a90faf53da1735743f6c2e.tar.bz2"
-  version "2.0.9999~20180616~06a386f"
-  sha256 "d2e28bfcfbb1277355047c1d8bcd141b05b83af52d277725168e4281eac92a6d"
+  url "https://bitbucket.org/sinbad/ogre/get/bf5de3029fd5a88d103ff99d7b2f94a5f8396ac9.tar.bz2"
+  version "2.0.9999~20190325~bf5de30"
+  sha256 "3949377daf5485847eeb78e420c3de4d8ed522bab8ac4c053c3deb4daa4bf4bd"
+
+  head "https://bitbucket.org/sinbad/ogre", :branch => "v2-1", :using => :hg
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/ogre/releases"
@@ -17,6 +19,7 @@ class Ogre21 < Formula
   depends_on "freeimage"
   depends_on "freetype"
   depends_on "libzzip"
+  depends_on "rapidjson"
   depends_on "tbb"
   depends_on :x11
 
@@ -27,6 +30,11 @@ class Ogre21 < Formula
     # fix for cmake3 and c++11
     url "https://gist.github.com/scpeters/4a7516b52c6e918ac02cbacabfeda4b3/raw/c515f8f313c444b306dfff9d437ec7cf3622ab12/cmake3.diff"
     sha256 "99d76e023cd5740da66c76ced40ce85e7da7b811ea99d9015d1293fc454badc0"
+  end
+
+  patch do
+    url "https://bitbucket.org/scpeters/ogre-1/commits/14b5dc7fc2d8e1281140d027e1effb4d8a317895/raw"
+    sha256 "41c678d3021feab844c5731c0cc2aa7007b731cfde5e084bc87d3a1eba9fa581"
   end
 
   # workaround for test since OgreMeshTool can't find plugins_tools.cfg otherwise
@@ -41,8 +49,11 @@ class Ogre21 < Formula
       "-DOGRE_BUILD_DOCS:BOOL=FALSE",
       "-DOGRE_INSTALL_DOCS:BOOL=FALSE",
       "-DOGRE_BUILD_SAMPLES:BOOL=FALSE",
+      "-DOGRE_BUILD_SAMPLES2:BOOL=FALSE",
       "-DOGRE_INSTALL_SAMPLES_SOURCE:BOOL=FALSE",
     ]
+    # use the following to disable GL3Plus render engine which won't work when OpenGL is removed
+    # cmake_args << "-DOGRE_BUILD_RENDERSYSTEM_GL3PLUS:BOOL=OFF" if MacOS::Xcode.version >= "10"
     cmake_args.concat std_cmake_args
 
     mkdir "build" do

--- a/Formula/ogre2.1.rb
+++ b/Formula/ogre2.1.rb
@@ -8,10 +8,11 @@ class Ogre21 < Formula
   head "https://bitbucket.org/sinbad/ogre", :branch => "v2-1", :using => :hg
 
   bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/ogre/releases"
-    sha256 "088deeb420ba6d058962eca59a58967f54280b197669c5dc59fa3cb06071417a" => :high_sierra
-    sha256 "ade07317c6ca515204be1ef64b4d8c87e60732e6d426d100447587a611235c4c" => :sierra
-    sha256 "115c6af607d0844bc3d51f65933a0394dc23c40a5c3453a1c37abdb7e74b81cb" => :el_capitan
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    cellar :any
+    sha256 "8a2e7dfba343138df66831a7e81d61431da6e42c7eccbbc392535106ca77eb3c" => :mojave
+    sha256 "9f01ccd917196f78ad06198fa69fea2698ae4161bb7b61b4fa21b3b56d50e6ce" => :high_sierra
+    sha256 "ffde1dc5510e2c624f808cdf6f06e4d41f808a3db9234a9c8e2bfff3614e6597" => :sierra
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
Officially Apple says that OpenGL is only deprecated on mojave, but I'm seeing compilation errors like https://github.com/OGRECave/ogre/issues/817 when I try to build ogre 2.1. A workaround suggested in that issue is to disable the GL3Plus rendersystem, which I have added here when xcode 10+ is detected. So I think GL3Plus will be built for Sierra, but it will only have Metal for 10.13+.

There is a possibility that we could fix GL3Plus for Xcode10, but I'm not sure how easy that will be, and 10.15 will only support Metal anyway.

I also added a dependency on rapidjson, which is needed by the Hlms material system.