### PR TITLE
ogre2.1: revert to commit used by deb

### DIFF
--- a/Formula/ogre2.1.rb
+++ b/Formula/ogre2.1.rb
@@ -10,9 +10,9 @@ class Ogre21 < Formula
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     cellar :any
-    sha256 "8a2e7dfba343138df66831a7e81d61431da6e42c7eccbbc392535106ca77eb3c" => :mojave
-    sha256 "9f01ccd917196f78ad06198fa69fea2698ae4161bb7b61b4fa21b3b56d50e6ce" => :high_sierra
-    sha256 "ffde1dc5510e2c624f808cdf6f06e4d41f808a3db9234a9c8e2bfff3614e6597" => :sierra
+    sha256 "e1f3e42863ce7cd5f8da8b70ce62b3fc01eb9ad4b7b4fcd6840eda4940f3e215" => :mojave
+    sha256 "fddac650048e82dfa25ace0cbc5602e65c8e58e99120f59be10e8101d18261af" => :high_sierra
+    sha256 "9e9cbae5a7f64ad6f6b20458403e61352a9a80cc8df3198551801c6521690503" => :sierra
   end
 
   depends_on "cmake" => :build

--- a/Formula/ogre2.1.rb
+++ b/Formula/ogre2.1.rb
@@ -2,7 +2,7 @@ class Ogre21 < Formula
   desc "Scene-oriented 3D engine written in c++"
   homepage "https://www.ogre3d.org/"
   url "https://bitbucket.org/sinbad/ogre/get/06a386fa64e79a7204a90faf53da1735743f6c2e.tar.bz2"
-  version "2.0.9999~pre0~0~20180616~06a386f"
+  version "2.0.99999~pre0~0~20180616~06a386f"
   sha256 "d2e28bfcfbb1277355047c1d8bcd141b05b83af52d277725168e4281eac92a6d"
 
   head "https://bitbucket.org/sinbad/ogre", :branch => "v2-1", :using => :hg

--- a/Formula/ogre2.1.rb
+++ b/Formula/ogre2.1.rb
@@ -1,9 +1,9 @@
 class Ogre21 < Formula
   desc "Scene-oriented 3D engine written in c++"
   homepage "https://www.ogre3d.org/"
-  url "https://bitbucket.org/sinbad/ogre/get/bf5de3029fd5a88d103ff99d7b2f94a5f8396ac9.tar.bz2"
-  version "2.0.9999~20190325~bf5de30"
-  sha256 "3949377daf5485847eeb78e420c3de4d8ed522bab8ac4c053c3deb4daa4bf4bd"
+  url "https://bitbucket.org/sinbad/ogre/get/06a386fa64e79a7204a90faf53da1735743f6c2e.tar.bz2"
+  version "2.0.9999~pre0~0~20180616~06a386f"
+  sha256 "d2e28bfcfbb1277355047c1d8bcd141b05b83af52d277725168e4281eac92a6d"
 
   head "https://bitbucket.org/sinbad/ogre", :branch => "v2-1", :using => :hg
 


### PR DESCRIPTION
@j-rivero @iche033 I rebased #655 on top of this commit that reverts to the ogre2.1 commit used by our deb and tested ign-rendering1 successfully:

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_rendering-ci-pr_any-homebrew-amd64&build=231)](https://build.osrfoundation.org/job/ignition_rendering-ci-pr_any-homebrew-amd64/231/) https://build.osrfoundation.org/job/ignition_rendering-ci-pr_any-homebrew-amd64/231/

I'll build a new bottle for this, but we also need to modify the formula to allow for side-by-side installation.