### PR TITLE
sdformat8 blueprint bump

### DIFF
--- a/Formula/sdformat8.rb
+++ b/Formula/sdformat8.rb
@@ -7,7 +7,7 @@ class Sdformat8 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "3c6db89d3a0fe565d03bd8a7239348e118d86733121ca074825483d7395db87e" => :mojave
+    sha256 "84d9b514c1b3d6dbd636057831c1091aa6a21806417eb5e1aa72420f542f3b6a" => :mojave
   end
 
   depends_on "cmake" => :build

--- a/Formula/sdformat8.rb
+++ b/Formula/sdformat8.rb
@@ -1,9 +1,9 @@
 class Sdformat8 < Formula
   desc "Simulation Description Format"
   homepage "http://sdformat.org"
-  url "https://bitbucket.org/osrf/sdformat/get/a8e6bb7b2ed2d2bd09a30d66528d3cc8249750cd.tar.gz"
-  version "8.1.0~pre1~20190427~a8e6bb7"
-  sha256 "fafcf601ac162f7a7db855e4b4f720d3ca1118569bdbc2d3e1c9f58be4eb8939"
+  url "https://bitbucket.org/osrf/sdformat/get/a15694f2c14f81bc8ce308bff5dbaac253ac997c.tar.gz"
+  version "8.1.0~pre1~20190502~a15694f"
+  sha256 "aabc5fef6d0d4aaa1d01455c814fcf4a075ff8c8866881b5a7e8f6a0c4554f1d"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"


### PR DESCRIPTION
Bumping to latest commit on the `sdf8` branch: https://bitbucket.org/osrf/sdformat/commits/a15694f2c14f81bc8ce308bff5dbaac253ac997c

I'm not sure whether to, or how to, change the `bottle`

@nkoenig is triggering matching debian nightlies.