### PR TITLE
ignition-gui2 blueprint bump

### DIFF
--- a/Formula/ignition-gui2.rb
+++ b/Formula/ignition-gui2.rb
@@ -2,7 +2,7 @@ class IgnitionGui2 < Formula
   desc "Common libraries for robotics applications. GUI Library"
   homepage "https://bitbucket.org/ignitionrobotics/ign-gui"
   url "https://bitbucket.org/ignitionrobotics/ign-gui/get/85d9019f6c71f1c533468a0e9907f9a4d6115099.tar.bz2"
-  version "1.999.999~20190502~ 85d9019"
+  version "1.999.999~20190502~85d9019"
   sha256 "705c86b4bd7e38661760d79f2825d7f73bffb73509bfeb030363913c641577ed"
 
   head "https://bitbucket.org/ignitionrobotics/ign-gui", :branch => "default", :using => :hg

--- a/Formula/ignition-gui2.rb
+++ b/Formula/ignition-gui2.rb
@@ -1,9 +1,9 @@
 class IgnitionGui2 < Formula
   desc "Common libraries for robotics applications. GUI Library"
   homepage "https://bitbucket.org/ignitionrobotics/ign-gui"
-  url "https://bitbucket.org/ignitionrobotics/ign-gui/get/90726900c6d6e78cccfdc411a49c8fdb4125a2fc.tar.bz2"
-  version "1.999.999~20190412~907269"
-  sha256 "e46fd75246c041ffdd0a8549cfab8e14ebcc5e77ed6f35debc0fc43a800ef8ea"
+  url "https://bitbucket.org/ignitionrobotics/ign-gui/get/85d9019f6c71f1c533468a0e9907f9a4d6115099.tar.bz2"
+  version "1.999.999~20190502~ 85d9019"
+  sha256 "705c86b4bd7e38661760d79f2825d7f73bffb73509bfeb030363913c641577ed"
 
   head "https://bitbucket.org/ignitionrobotics/ign-gui", :branch => "default", :using => :hg
 

--- a/Formula/ignition-gui2.rb
+++ b/Formula/ignition-gui2.rb
@@ -9,8 +9,8 @@ class IgnitionGui2 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "a6b7f906bec21d3c353d590daa21a8500a2bbd6b2a7e5f83f5711c89725859a7" => :mojave
-    sha256 "b9259c1fdef7503f7aa6a19ae52a64eefe6ba5ffee63e3857d2e9c148593461c" => :high_sierra
+    sha256 "eaef20bff46739a23da48564c6fba399bb1f24639eee6bc282db8c3c37c994a8" => :mojave
+    sha256 "a7f90701701eed7722eec5d785cb699370750b1342411bda28e9a42653744067" => :high_sierra
   end
 
   depends_on "cmake" => [:build, :test]


### PR DESCRIPTION
Bumping to this commit: https://bitbucket.org/ignitionrobotics/ign-gui/commits/85d9019f6c71f1c533468a0e9907f9a4d6115099

It should already match the latest debian nightly.