### PR TITLE
ignition-msgs4 blueprint bump

### DIFF
--- a/Formula/ignition-msgs4.rb
+++ b/Formula/ignition-msgs4.rb
@@ -1,9 +1,9 @@
 class IgnitionMsgs4 < Formula
   desc "Middleware protobuf messages for robotics"
   homepage "https://bitbucket.org/ignitionrobotics/ign-msgs"
-  url "https://bitbucket.org/ignitionrobotics/ign-msgs/get/7429b60ffdbc77bdbfd8dd3dfaed2343351da447.tar.gz"
-  version "3.999.999~2~20190415~7429b60"
-  sha256 "365a444948833c46da6e47a9c086d6f8c85e44864cb9f0b2d54f935d2894d759"
+  url "https://bitbucket.org/ignitionrobotics/ign-msgs/get/b82726d01252e141847335da3e8144d4e4cba54b.tar.gz"
+  version "3.999.999~2~20190502~b82726d"
+  sha256 "fe6db6f5687f879fc695fc81992ef0835529fb7fc5310bac6f6858bad93de9e9"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ignition-msgs4.rb
+++ b/Formula/ignition-msgs4.rb
@@ -8,8 +8,8 @@ class IgnitionMsgs4 < Formula
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     cellar :any
-    sha256 "71cc6b411c3262230910416103507bc19532c5d9ee473dd2a5bf07f6a8530e00" => :mojave
-    sha256 "508f7f29cf7674dfcfedee2f060c96e048ea9c95b817a94e9d4f47809be07255" => :high_sierra
+    sha256 "8caec149ac10d46899f3782e75f6a26826c224d7b92af20997b00b80c983569c" => :mojave
+    sha256 "45f095d210904d50a868c67ab23db55d071ecee0d3709713256772c021914cbc" => :high_sierra
   end
 
   depends_on "protobuf-c" => :build


### PR DESCRIPTION
This commit: https://bitbucket.org/ignitionrobotics/ign-msgs/commits/b82726d01252e141847335da3e8144d4e4cba54b

Matching debian nightlies are being triggered.