### PR TITLE
ignition-msgs2: depend on math6

### DIFF
--- a/Formula/ignition-gui0.rb
+++ b/Formula/ignition-gui0.rb
@@ -24,7 +24,7 @@ class IgnitionGui0 < Formula
   depends_on "qwt"
   depends_on "tinyxml2"
 
-  conflicts_with "cartr/qt4/qt@4", :because => "Differing versions of qt"
+  # conflicts_with "cartr/qt4/qt@4", :because => "Differing versions of qt"
 
   def install
     ENV.m64

--- a/Formula/ignition-msgs2.rb
+++ b/Formula/ignition-msgs2.rb
@@ -20,6 +20,7 @@ class IgnitionMsgs2 < Formula
   depends_on "cmake"
   depends_on "ignition-cmake1"
   depends_on "ignition-math5"
+  depends_on "ignition-math6"
   depends_on "ignition-tools"
   depends_on "pkg-config"
   depends_on "protobuf"


### PR DESCRIPTION
as suggested by the following PR's:

* https://bitbucket.org/ignitionrobotics/ign-msgs/pull-requests/138/use-math6/
* https://bitbucket.org/ignitionrobotics/ign-gui/pull-requests/215/gui0-use-rendering2/