### PR TITLE
sdformat4, gazebo7: rebuild for boost 1.70

### DIFF
--- a/Formula/gazebo7.rb
+++ b/Formula/gazebo7.rb
@@ -9,9 +9,9 @@ class Gazebo7 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "18ae1b239ae65073510d71a070f3a914b5c5311f1c03bbca6ff1c22d7341a7db" => :mojave
-    sha256 "5b55937d8ba81504fac1f979cca733e4ff42fab2a1e4c0121167561d0a496b00" => :high_sierra
-    sha256 "2a9744fbeccc6e2f2ffaf508d6306c93452b7e5d54d6ad668dd9fde6e8211009" => :sierra
+    sha256 "62d835704d3f6a46395566d71d85874ab1b02bb3aeb52be0438cc840ba50f024" => :mojave
+    sha256 "470d0d0fbf06300154a048ae12f0d084fbf194a20fc38d0f5b5996e5a6dcc7e4" => :high_sierra
+    sha256 "bdc93961b781fd4a800488e37494d0a35cecceba533bf5ac9218fe8ee79a3cbd" => :sierra
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/sdformat4.rb
+++ b/Formula/sdformat4.rb
@@ -9,9 +9,9 @@ class Sdformat4 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "f0009e22737945b454aa126d10354e9a28e0722799437e0ef1c7363553169e24" => :mojave
-    sha256 "8ca2dca0a7f737943ad4ffa63ce538cabbba49098df9d5b6f76a92ef166801f4" => :high_sierra
-    sha256 "202ca00f9e7c5e4a0a4f916e3193466b45f13843bca0b85fca600ffa0cbb3f04" => :sierra
+    sha256 "f4926ac28179ed217c034f7b69a42176b7a8290be7dd91bb87fcd5fe96f64daf" => :mojave
+    sha256 "b727234177c477d3de90413ac7880ecca91e0c73acf69fcf6c2a2d3b099806b1" => :high_sierra
+    sha256 "d0b28be274c293fd1c5395fcae0be37f43f6c16ef129a171d39a020564e6b7f9" => :sierra
   end
 
   depends_on "cmake" => :build

--- a/Formula/sdformat4.rb
+++ b/Formula/sdformat4.rb
@@ -3,7 +3,7 @@ class Sdformat4 < Formula
   homepage "http://sdformat.org"
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-4.4.0.tar.bz2"
   sha256 "4424a984f69d3333f087e7aae1d8fa5aec61ad52e09be39e2f5e2cb69ade1527"
-  revision 4
+  revision 5
 
   head "https://bitbucket.org/osrf/sdformat", :branch => "sdf4", :using => :hg
 
@@ -52,6 +52,11 @@ class Sdformat4 < Formula
         "  <model name='example'>"
         "    <link name='link'>"
         "      <sensor type='gps' name='mysensor' />"
+        "      <sensor type='imu' name='imu'>"
+        "        <imu>"
+        "          <noise/>"
+        "        </imu>"
+        "      </sensor>"
         "    </link>"
         "  </model>"
         "</sdf>");
@@ -63,10 +68,11 @@ class Sdformat4 < Formula
     EOS
     system "pkg-config", "sdformat"
     cflags = `pkg-config --cflags sdformat`.split(" ")
+    libs = `pkg-config --libs sdformat`.split(" ")
     system ENV.cc, "test.cpp",
                    *cflags,
                    "-L#{lib}",
-                   "-lsdformat",
+                   *libs,
                    "-lc++",
                    "-o", "test"
     system "./test"


### PR DESCRIPTION
Similar to #757 and #758, but sdformat4 also needs to be rebuilt, as reported in #756.