### PR TITLE
protobuf 3.10: bump ignition-msgs4 and dependents

### DIFF
--- a/Formula/ignition-gazebo2.rb
+++ b/Formula/ignition-gazebo2.rb
@@ -9,7 +9,7 @@ class IgnitionGazebo2 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "1ae7105997892ebb7c6b7c2371df52f4db368063edca63098fae9373e21368df" => :mojave
+    sha256 "9222791c47f3d7da0fcb0718e2f515a10810a9772cf0d665fa1e6b3b6853ff90" => :mojave
   end
 
   depends_on "cmake" => :build

--- a/Formula/ignition-gazebo2.rb
+++ b/Formula/ignition-gazebo2.rb
@@ -3,6 +3,7 @@ class IgnitionGazebo2 < Formula
   homepage "https://bitbucket.org/ignitionrobotics/ign-gazebo"
   url "https://osrf-distributions.s3.amazonaws.com/ign-gazebo/releases/ignition-gazebo2-2.10.0.tar.bz2"
   sha256 "b096a472563bbda9940797b52bd6dc9fd20adf458f503999c748d864e2061238"
+  revision 1
 
   head "https://bitbucket.org/ignitionrobotics/ign-gazebo", :branch => "default", :using => :hg
 

--- a/Formula/ignition-gazebo3.rb
+++ b/Formula/ignition-gazebo3.rb
@@ -10,7 +10,7 @@ class IgnitionGazebo3 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "390a9eaf68b3846235ce9f6c9ce6025ec9f5565c5ec140a1de9ea8cae7bd35ae" => :mojave
+    sha256 "a6090bcf3b9a4b29b94f7df4f758c2d3887e25b439d3c1ff58033e3ef6aac0ab" => :mojave
   end
 
   depends_on "cmake" => :build

--- a/Formula/ignition-gazebo3.rb
+++ b/Formula/ignition-gazebo3.rb
@@ -4,7 +4,7 @@ class IgnitionGazebo3 < Formula
   url "https://bitbucket.org/ignitionrobotics/ign-gazebo/get/cc18930145e52014e7ea18352dcbc13c55dd2b12.tar.bz2"
   version "2.999.999~20190802~cc18930"
   sha256 "45dd25a9634ff6fe2cd267f7f60746f5b4deebbf98d67c4b447eed324424c0b4"
-  revision 1
+  revision 2
 
   head "https://bitbucket.org/ignitionrobotics/ign-gazebo", :branch => "default", :using => :hg
 

--- a/Formula/ignition-gui2.rb
+++ b/Formula/ignition-gui2.rb
@@ -9,8 +9,8 @@ class IgnitionGui2 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "78d4958349aa8ef501c026685fa7da559759cd7f79f1a7fba4114a2b29945e20" => :mojave
-    sha256 "56e845ebccfb7974845c7a3f9e32c6d1fb9d9e2f9b0be699ee2d4432bf6475fc" => :high_sierra
+    sha256 "bc284e35cc700794bb2a9286c1e1b91f82ac9809dee78e462c7a3f0725c55da0" => :mojave
+    sha256 "438eff5224fc176f381d67efeffcf4a9ae63bb419ff5d3e79f791c6d0c484657" => :high_sierra
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/ignition-gui2.rb
+++ b/Formula/ignition-gui2.rb
@@ -3,7 +3,7 @@ class IgnitionGui2 < Formula
   homepage "https://bitbucket.org/ignitionrobotics/ign-gui"
   url "https://osrf-distributions.s3.amazonaws.com/ign-gui/releases/ignition-gui2-2.0.1.tar.bz2"
   sha256 "7902822e66d2865a1f7d988bb61c6b2b6d37f2a3b378a8bf9d25ebc5c292b43d"
-  revision 1
+  revision 2
 
   head "https://bitbucket.org/ignitionrobotics/ign-gui", :branch => "default", :using => :hg
 

--- a/Formula/ignition-gui3.rb
+++ b/Formula/ignition-gui3.rb
@@ -4,7 +4,7 @@ class IgnitionGui3 < Formula
   url "https://bitbucket.org/ignitionrobotics/ign-gui/get/4fc18bf44e8cf6575c33f0627f8b7496264df598.tar.bz2"
   version "2.999.999~20190802~4fc18b"
   sha256 "12876b21ac96c5627015c16397384e908a2d612d3b67de86feb122e2f23c7ee2"
-  revision 1
+  revision 2
 
   head "https://bitbucket.org/ignitionrobotics/ign-gui", :branch => "default", :using => :hg
 

--- a/Formula/ignition-gui3.rb
+++ b/Formula/ignition-gui3.rb
@@ -10,8 +10,8 @@ class IgnitionGui3 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "fb5b4a12a4421bffdf3f7a29a4c48030b9b9dcb2d57d2f82004bae6edae2cf9c" => :mojave
-    sha256 "52a37f3bd7914a1e1fe1d4590d03b2c0a0121e7a8caee9ebed5a2b66ba4b9d9d" => :high_sierra
+    sha256 "4eedeb68a198354d13a3b029fc68c03de31adfa135a7174e737a348f5906d2c4" => :mojave
+    sha256 "e5dbdb1d26f2a0332a91950bb4c7c5812c9934a3988153a3d3c50b5fd7c44aae" => :high_sierra
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/ignition-launch1.rb
+++ b/Formula/ignition-launch1.rb
@@ -7,7 +7,7 @@ class IgnitionLaunch1 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "68e3814a82cc8e19c286ceef9df533128f3fe16ffe279233f7fd4d2f467c95d3" => :mojave
+    sha256 "5404eef495cc29930be9555e116288f0444d86184c62596f6a27afa6e6040eb4" => :mojave
   end
 
   depends_on "cmake" => :build

--- a/Formula/ignition-launch1.rb
+++ b/Formula/ignition-launch1.rb
@@ -3,6 +3,7 @@ class IgnitionLaunch1 < Formula
   homepage "https://bitbucket.org/ignitionrobotics/ign-launch"
   url "https://osrf-distributions.s3.amazonaws.com/ign-launch/releases/ignition-launch-1.2.3.tar.bz2"
   sha256 "e18ac000709b0908ff71efb2085ec4fd73a20bbf5d4c037236851e92c3828503"
+  revision 1
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ignition-msgs4.rb
+++ b/Formula/ignition-msgs4.rb
@@ -3,7 +3,7 @@ class IgnitionMsgs4 < Formula
   homepage "https://bitbucket.org/ignitionrobotics/ign-msgs"
   url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs4-4.7.0.tar.bz2"
   sha256 "3bbf7b30425a811191f8c0a7549942a81ded05af80521801937bf2eeb9c222b1"
-  revision 1
+  revision 2
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ignition-msgs4.rb
+++ b/Formula/ignition-msgs4.rb
@@ -8,8 +8,8 @@ class IgnitionMsgs4 < Formula
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     cellar :any
-    sha256 "cdb6c4cdbf321f009e72710040e274ed4d99d2ca070fc8f4c617714dde0e8dde" => :mojave
-    sha256 "bc67d991bef09cfd0c0d7fd94a08ee77492e7a2a15174a2a8831b45583e9ae50" => :high_sierra
+    sha256 "66b6a9326448eb642608adade041e81923b77a54c3994bf4c73515af9214f84d" => :mojave
+    sha256 "fb5fe05b438693f22aa249f39b3b604dc0dc93863b33cbcf3744d141fae82101" => :high_sierra
   end
 
   depends_on "protobuf-c" => :build

--- a/Formula/ignition-sensors2.rb
+++ b/Formula/ignition-sensors2.rb
@@ -3,6 +3,7 @@ class IgnitionSensors2 < Formula
   homepage "https://bitbucket.org/ignitionrobotics/ign-sensors"
   url "https://osrf-distributions.s3.amazonaws.com/ign-sensors/releases/ignition-sensors2-2.6.1.tar.bz2"
   sha256 "67f437201ebcd8f1a363857cfacce0db213a4873f2cb4de82fa90ba47bf404fc"
+  revision 1
 
   head "https://bitbucket.org/ignitionrobotics/ign-sensors", :branch => "default", :using => :hg
 

--- a/Formula/ignition-sensors2.rb
+++ b/Formula/ignition-sensors2.rb
@@ -9,7 +9,7 @@ class IgnitionSensors2 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "3520e97ccfe824bc39f4ac2cdbb8cb5b9f069caece8865cbe086f883158d34db" => :mojave
+    sha256 "03ff04bc9ae763e27083c5b739b9215fcb25b4c16ce2f8ab29f630365519fd73" => :mojave
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/ignition-sensors3.rb
+++ b/Formula/ignition-sensors3.rb
@@ -10,7 +10,7 @@ class IgnitionSensors3 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "1c12fce303b083b69d9cde312bbb47f7cbbee6d1465161bd142d411ee14d749c" => :mojave
+    sha256 "6816deed53ddf35fdedadef0e5736af7b15f34c25ddfe127195b3c3c8d8d01d3" => :mojave
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/ignition-sensors3.rb
+++ b/Formula/ignition-sensors3.rb
@@ -4,7 +4,7 @@ class IgnitionSensors3 < Formula
   url "https://bitbucket.org/ignitionrobotics/ign-sensors/get/cd22b21d6130f6e9e236fb6bb3a641105cf1c236.tar.bz2"
   version "2.999.999~20190802~cd22b21"
   sha256 "6ed3398be82082a374bdc6d702b2e025530c65267a888f49d0da110d3c8380ae"
-  revision 1
+  revision 2
 
   head "https://bitbucket.org/ignitionrobotics/ign-sensors", :branch => "default", :using => :hg
 

--- a/Formula/ignition-transport7.rb
+++ b/Formula/ignition-transport7.rb
@@ -7,8 +7,8 @@ class IgnitionTransport7 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "a2ae5a3909479dd2bb3126bca979fa405a9155de7600003792db9eb0d1b1f882" => :mojave
-    sha256 "1bba3a6ffbd04cb375ead550f9bc298f07da1790941d0f7d9948315d157c4312" => :high_sierra
+    sha256 "d3b9bfccece5dd53793edbe9ac040fe64e916c08fecee3c60f2d2a688895ecde" => :mojave
+    sha256 "bd64ec56f4fd4a5621170806d18e4272347481f57ac2b3553db2c382957107ed" => :high_sierra
   end
 
   depends_on "doxygen" => [:build, :optional]

--- a/Formula/ignition-transport7.rb
+++ b/Formula/ignition-transport7.rb
@@ -3,7 +3,7 @@ class IgnitionTransport7 < Formula
   homepage "https://ignitionrobotics.org"
   url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases/ignition-transport7-7.1.0.tar.bz2"
   sha256 "b49b0c50946044327241472b9c6d68b9c06f621866bf4f5548a5f587c4290ab5"
-  revision 1
+  revision 2
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/pull/44841

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo-install-one_liner-homebrew-amd64&build=1453)](https://build.osrfoundation.org/view/os_homebrew/job/gazebo-install-one_liner-homebrew-amd64/1453/) https://build.osrfoundation.org/view/os_homebrew/job/gazebo-install-one_liner-homebrew-amd64/1453/