### PR TITLE
Make ignition-tools to depend on ignition-cmake2

### DIFF
--- a/Formula/ignition-tools.rb
+++ b/Formula/ignition-tools.rb
@@ -14,6 +14,7 @@ class IgnitionTools < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "ignition-cmake2"
 
   def install
     mkdir "build" do


### PR DESCRIPTION
According to pull request https://bitbucket.org/ignitionrobotics/ign-tools/pull-requests/6/updating-to-use-ignition-cmake-2/