### PR TITLE
gazebo7: don't depend on ignition-transport

### DIFF
--- a/Formula/gazebo7.rb
+++ b/Formula/gazebo7.rb
@@ -7,6 +7,12 @@ class Gazebo7 < Formula
 
   head "https://bitbucket.org/osrf/gazebo", :branch => "gazebo7", :using => :hg
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 "c86db7f9b29dff2bef4e8366483e9ea39dc454829902669a1611560bde76729f" => :mojave
+    sha256 "45ad0f4b074cd0925d2428fcb1ca221cbdbec13faa776f7dd9ce76c588ce5878" => :high_sierra
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
 

--- a/Formula/gazebo7.rb
+++ b/Formula/gazebo7.rb
@@ -3,7 +3,7 @@ class Gazebo7 < Formula
   homepage "http://gazebosim.org"
   url "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/gazebo-7.16.0.tar.bz2"
   sha256 "c6e5f27b9bfa2494a02dd34d567869c5431659895dea3aca22dc15df6716cf4f"
-  revision 1
+  revision 2
 
   head "https://bitbucket.org/osrf/gazebo", :branch => "gazebo7", :using => :hg
 
@@ -16,7 +16,6 @@ class Gazebo7 < Formula
   depends_on "freeimage"
   depends_on "graphviz"
   depends_on "ignition-math2"
-  depends_on "ignition-transport"
   depends_on "libtar"
   depends_on "ogre1.9"
   depends_on "protobuf"


### PR DESCRIPTION
There's a weird bug that causes the `ignition-tools` bottle builds to fail due to gazebo7 installing `qt@4` and a workaround for this specific case is to remove the `ignition-transport` dependency since it is optional to gazebo7.