### PR TITLE
gazebo7: revision bump for protobuf 3.11

### DIFF
--- a/Formula/gazebo7.rb
+++ b/Formula/gazebo7.rb
@@ -3,7 +3,7 @@ class Gazebo7 < Formula
   homepage "http://gazebosim.org"
   url "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/gazebo-7.16.0.tar.bz2"
   sha256 "c6e5f27b9bfa2494a02dd34d567869c5431659895dea3aca22dc15df6716cf4f"
-  revision 2
+  revision 3
 
   head "https://bitbucket.org/osrf/gazebo", :branch => "gazebo7", :using => :hg
 

--- a/Formula/gazebo7.rb
+++ b/Formula/gazebo7.rb
@@ -55,6 +55,12 @@ class Gazebo7 < Formula
     sha256 "c4774f64c490fa03236564312bd24a8630963762e25d98d072e747f0412df18e"
   end
 
+  patch do
+    # Fix gts linking
+    url "https://bitbucket.org/osrf/gazebo/commits/d9682e139668d9798bbea938c47aeed62a0b060f/raw"
+    sha256 "6e716cadf7e4d70c73e376f5ee5db2d2df49a321ef70be83d6979dfd1e07d4e2"
+  end
+
   def install
     ENV.m64
 

--- a/Formula/gazebo7.rb
+++ b/Formula/gazebo7.rb
@@ -7,12 +7,6 @@ class Gazebo7 < Formula
 
   head "https://bitbucket.org/osrf/gazebo", :branch => "gazebo7", :using => :hg
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "c86db7f9b29dff2bef4e8366483e9ea39dc454829902669a1611560bde76729f" => :mojave
-    sha256 "45ad0f4b074cd0925d2428fcb1ca221cbdbec13faa776f7dd9ce76c588ce5878" => :high_sierra
-  end
-
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
 


### PR DESCRIPTION
Also add a patch to fix linking with gts, since this has been causing builds to fail:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo-ci-gazebo7-homebrew-amd64&build=269)](https://build.osrfoundation.org/view/main/view/BuildCopFail/job/gazebo-ci-gazebo7-homebrew-amd64/269/) https://build.osrfoundation.org/view/main/view/BuildCopFail/job/gazebo-ci-gazebo7-homebrew-amd64/269/