### PR TITLE
ignition-launch: don't depend directly on SDF

### DIFF
--- a/Formula/ignition-launch1.rb
+++ b/Formula/ignition-launch1.rb
@@ -22,7 +22,6 @@ class IgnitionLaunch1 < Formula
   depends_on "ignition-tools"
   depends_on "ignition-transport7"
   depends_on "qt"
-  depends_on "sdformat8"
   depends_on "tinyxml2"
 
   def install

--- a/Formula/ignition-launch2.rb
+++ b/Formula/ignition-launch2.rb
@@ -20,7 +20,6 @@ class IgnitionLaunch2 < Formula
   depends_on "ignition-tools"
   depends_on "ignition-transport8"
   depends_on "qt"
-  depends_on "sdformat8"
   depends_on "tinyxml2"
 
   def install


### PR DESCRIPTION
SDFormat is an indirect dependency of launch, so I think it doesn't need to be declared.

Also see https://bitbucket.org/ignitionrobotics/ign-launch/pull-requests/53/