### PR TITLE
use travis for high sierra, not azure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ matrix:
     - env: OSX=10.14
       os: osx
       osx_image: xcode10.3
+    - env: OSX=10.13
+      os: osx
+      osx_image: xcode10.1
 
 before_install:
   - export TRAVIS_COMMIT="$(git rev-parse --verify -q HEAD)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,9 +3,6 @@ strategy:
     mojave:
       imageName: 'macOS-10.14'
       xcodeVersion: '11.3'
-    high_sierra:
-      imageName: 'macOS-10.13'
-      xcodeVersion: '10.1'
 
 pool:
   vmImage: $(imageName)


### PR DESCRIPTION
The high sierra hosted images will be removed from azure in March, so switch back to travis for these.

https://devblogs.microsoft.com/devops/azure-pipelines-hosted-pools-updates/