### PR TITLE
Stop modifying ENV variables in tests

### DIFF
--- a/Formula/ignition-common0.rb
+++ b/Formula/ignition-common0.rb
@@ -57,8 +57,6 @@ class IgnitionCommon0 < Formula
     system "./test"
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       ENV.append "LIBRARY_PATH", Formula["gettext"].opt_lib
       system "cmake", ".."
       system "make"

--- a/Formula/ignition-common1.rb
+++ b/Formula/ignition-common1.rb
@@ -65,8 +65,6 @@ class IgnitionCommon1 < Formula
     system "./test"
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       ENV.append "LIBRARY_PATH", Formula["gettext"].opt_lib
       system "cmake", ".."
       system "make"

--- a/Formula/ignition-common2.rb
+++ b/Formula/ignition-common2.rb
@@ -65,8 +65,6 @@ class IgnitionCommon2 < Formula
     system "./test"
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       ENV.append "LIBRARY_PATH", Formula["gettext"].opt_lib
       system "cmake", ".."
       system "make"

--- a/Formula/ignition-common3.rb
+++ b/Formula/ignition-common3.rb
@@ -64,8 +64,6 @@ class IgnitionCommon3 < Formula
     system "./test"
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       ENV.append "LIBRARY_PATH", Formula["gettext"].opt_lib
       system "cmake", ".."
       system "make"

--- a/Formula/ignition-fuel-tools0.rb
+++ b/Formula/ignition-fuel-tools0.rb
@@ -48,8 +48,6 @@ class IgnitionFuelTools0 < Formula
     system "./test"
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"

--- a/Formula/ignition-fuel-tools1.rb
+++ b/Formula/ignition-fuel-tools1.rb
@@ -56,8 +56,6 @@ class IgnitionFuelTools1 < Formula
     system "./test"
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"

--- a/Formula/ignition-fuel-tools2.rb
+++ b/Formula/ignition-fuel-tools2.rb
@@ -55,8 +55,6 @@ class IgnitionFuelTools2 < Formula
     system "./test"
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"

--- a/Formula/ignition-fuel-tools3.rb
+++ b/Formula/ignition-fuel-tools3.rb
@@ -55,8 +55,6 @@ class IgnitionFuelTools3 < Formula
     system "./test"
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"

--- a/Formula/ignition-fuel-tools4.rb
+++ b/Formula/ignition-fuel-tools4.rb
@@ -56,8 +56,6 @@ class IgnitionFuelTools4 < Formula
     system "./test"
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"

--- a/Formula/ignition-gazebo1.rb
+++ b/Formula/ignition-gazebo1.rb
@@ -89,8 +89,6 @@ class IgnitionGazebo1 < Formula
     # test building with cmake
     ENV.append_path "CMAKE_PREFIX_PATH", Formula["qt"].opt_prefix
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"

--- a/Formula/ignition-gazebo2.rb
+++ b/Formula/ignition-gazebo2.rb
@@ -94,8 +94,6 @@ class IgnitionGazebo2 < Formula
     # test building with cmake
     ENV.append_path "CMAKE_PREFIX_PATH", Formula["qt"].opt_prefix
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"

--- a/Formula/ignition-gazebo3.rb
+++ b/Formula/ignition-gazebo3.rb
@@ -92,8 +92,6 @@ class IgnitionGazebo3 < Formula
     # test building with cmake
     ENV.append_path "CMAKE_PREFIX_PATH", Formula["qt"].opt_prefix
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"

--- a/Formula/ignition-gazebo4.rb
+++ b/Formula/ignition-gazebo4.rb
@@ -93,8 +93,6 @@ class IgnitionGazebo4 < Formula
     # test building with cmake
     ENV.append_path "CMAKE_PREFIX_PATH", Formula["qt"].opt_prefix
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"

--- a/Formula/ignition-gui0.rb
+++ b/Formula/ignition-gui0.rb
@@ -86,8 +86,6 @@ class IgnitionGui0 < Formula
     # test building with cmake
     ENV.append_path "CMAKE_PREFIX_PATH", Formula["qt"].opt_prefix
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"

--- a/Formula/ignition-gui1.rb
+++ b/Formula/ignition-gui1.rb
@@ -92,8 +92,6 @@ class IgnitionGui1 < Formula
     # test building with cmake
     ENV.append_path "CMAKE_PREFIX_PATH", Formula["qt"].opt_prefix
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"

--- a/Formula/ignition-gui2.rb
+++ b/Formula/ignition-gui2.rb
@@ -96,8 +96,6 @@ class IgnitionGui2 < Formula
     # test building with cmake
     ENV.append_path "CMAKE_PREFIX_PATH", Formula["qt"].opt_prefix
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"

--- a/Formula/ignition-gui3.rb
+++ b/Formula/ignition-gui3.rb
@@ -96,8 +96,6 @@ class IgnitionGui3 < Formula
     # test building with cmake
     ENV.append_path "CMAKE_PREFIX_PATH", Formula["qt"].opt_prefix
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"

--- a/Formula/ignition-gui4.rb
+++ b/Formula/ignition-gui4.rb
@@ -97,8 +97,6 @@ class IgnitionGui4 < Formula
     # test building with cmake
     ENV.append_path "CMAKE_PREFIX_PATH", Formula["qt"].opt_prefix
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"

--- a/Formula/ignition-math4.rb
+++ b/Formula/ignition-math4.rb
@@ -53,8 +53,6 @@ class IgnitionMath4 < Formula
     system "./test"
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"

--- a/Formula/ignition-math5.rb
+++ b/Formula/ignition-math5.rb
@@ -54,8 +54,6 @@ class IgnitionMath5 < Formula
     system "./test"
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"

--- a/Formula/ignition-math6.rb
+++ b/Formula/ignition-math6.rb
@@ -51,8 +51,6 @@ class IgnitionMath6 < Formula
     system "./test"
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"

--- a/Formula/ignition-msgs0.rb
+++ b/Formula/ignition-msgs0.rb
@@ -48,8 +48,6 @@ class IgnitionMsgs0 < Formula
     system "./test"
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"

--- a/Formula/ignition-msgs1.rb
+++ b/Formula/ignition-msgs1.rb
@@ -57,8 +57,6 @@ class IgnitionMsgs1 < Formula
     system "./test"
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"

--- a/Formula/ignition-msgs2.rb
+++ b/Formula/ignition-msgs2.rb
@@ -52,8 +52,6 @@ class IgnitionMsgs2 < Formula
     system "./test"
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"

--- a/Formula/ignition-msgs3.rb
+++ b/Formula/ignition-msgs3.rb
@@ -49,8 +49,6 @@ class IgnitionMsgs3 < Formula
     system "./test"
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"

--- a/Formula/ignition-msgs4.rb
+++ b/Formula/ignition-msgs4.rb
@@ -56,8 +56,6 @@ class IgnitionMsgs4 < Formula
     system "./test"
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"

--- a/Formula/ignition-msgs5.rb
+++ b/Formula/ignition-msgs5.rb
@@ -56,8 +56,6 @@ class IgnitionMsgs5 < Formula
     system "./test"
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"

--- a/Formula/ignition-plugin0.rb
+++ b/Formula/ignition-plugin0.rb
@@ -48,8 +48,6 @@ class IgnitionPlugin0 < Formula
     system "./test"
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       ENV.append "LIBRARY_PATH", Formula["gettext"].opt_lib
       system "cmake", ".."
       system "make"

--- a/Formula/ignition-plugin1.rb
+++ b/Formula/ignition-plugin1.rb
@@ -46,8 +46,6 @@ class IgnitionPlugin1 < Formula
     system "./test"
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       ENV.append "LIBRARY_PATH", Formula["gettext"].opt_lib
       system "cmake", ".."
       system "make"

--- a/Formula/ignition-rendering1.rb
+++ b/Formula/ignition-rendering1.rb
@@ -59,8 +59,6 @@ class IgnitionRendering1 < Formula
     system "./test" unless azure || travis
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake" unless azure || travis

--- a/Formula/ignition-rendering2.rb
+++ b/Formula/ignition-rendering2.rb
@@ -58,8 +58,6 @@ class IgnitionRendering2 < Formula
     system "./test" unless azure || travis
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake" unless azure || travis

--- a/Formula/ignition-rendering3.rb
+++ b/Formula/ignition-rendering3.rb
@@ -57,8 +57,6 @@ class IgnitionRendering3 < Formula
     system "./test" unless azure || travis
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake" unless azure || travis

--- a/Formula/ignition-rendering4.rb
+++ b/Formula/ignition-rendering4.rb
@@ -58,8 +58,6 @@ class IgnitionRendering4 < Formula
     system "./test" unless azure || travis
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake" unless azure || travis

--- a/Formula/ignition-sensors1.rb
+++ b/Formula/ignition-sensors1.rb
@@ -52,8 +52,6 @@ class IgnitionSensors1 < Formula
     system "./test"
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"

--- a/Formula/ignition-sensors2.rb
+++ b/Formula/ignition-sensors2.rb
@@ -58,8 +58,6 @@ class IgnitionSensors2 < Formula
     system "./test"
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"

--- a/Formula/ignition-sensors3.rb
+++ b/Formula/ignition-sensors3.rb
@@ -56,8 +56,6 @@ class IgnitionSensors3 < Formula
     system "./test"
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"

--- a/Formula/ignition-sensors4.rb
+++ b/Formula/ignition-sensors4.rb
@@ -57,8 +57,6 @@ class IgnitionSensors4 < Formula
     system "./test"
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"

--- a/Formula/sdformat8.rb
+++ b/Formula/sdformat8.rb
@@ -66,8 +66,6 @@ class Sdformat8 < Formula
     system "./test"
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"

--- a/Formula/sdformat9.rb
+++ b/Formula/sdformat9.rb
@@ -66,8 +66,6 @@ class Sdformat9 < Formula
     system "./test"
     # test building with cmake
     mkdir "build" do
-      ENV.delete("MACOSX_DEPLOYMENT_TARGET")
-      ENV.delete("SDKROOT")
       system "cmake", ".."
       system "make"
       system "./test_cmake"


### PR DESCRIPTION
There have been weird bugs related to which macOS SDK was chosen for compilation, such as #147. At one point I applied the fix from #147 to all the `test` blocks for new ignition formulae, but it seems to be causing problems in #982; so I'm going to try removing them all here. No bottles should be built from this PR; this should be squashed and merged, but after we've re-targeted #982 to this branch and confirmed that it fixes the issues.

cc @chapulina 