### PR TITLE
sdformat8: depend on urdfdom

### DIFF
--- a/Formula/sdformat8.rb
+++ b/Formula/sdformat8.rb
@@ -3,30 +3,27 @@ class Sdformat8 < Formula
   homepage "http://sdformat.org"
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-8.8.0.tar.bz2"
   sha256 "73167c9f4edc75540b8b5239db9a61c5eaa7c39c845b37c25784ac4e96a35170"
+  revision 1
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 "2f6ccb33deb27c3e01c5bbfdd8a1d314f4dcd2292d37e3c1dcb8ec306433ff54" => :mojave
   end
 
-  depends_on "cmake" => :build
+  depends_on "cmake" => [:build, :test]
+  depends_on "pkg-config" => [:build, :test]
 
   depends_on "doxygen"
   depends_on "ignition-math6"
   depends_on :macos => :mojave # c++17
-  depends_on "pkg-config"
   depends_on "tinyxml"
-  depends_on "urdfdom" => :optional
+  depends_on "urdfdom"
 
   def install
     ENV.m64
 
-    cmake_args = std_cmake_args
-    cmake_args << "-DUSE_EXTERNAL_URDF:BOOL=True" if build.with? "urdfdom"
-    cmake_args << ".."
-
     mkdir "build" do
-      system "cmake", *cmake_args
+      system "cmake", "..", *std_cmake_args
       system "make", "install"
     end
   end

--- a/Formula/sdformat8.rb
+++ b/Formula/sdformat8.rb
@@ -7,7 +7,7 @@ class Sdformat8 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "2f6ccb33deb27c3e01c5bbfdd8a1d314f4dcd2292d37e3c1dcb8ec306433ff54" => :mojave
+    sha256 "a00f3d4efb3486c41b4f23db415a71c412ffd2fea6196d387e56bb14af063d08" => :mojave
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/sdformat8.rb
+++ b/Formula/sdformat8.rb
@@ -19,6 +19,12 @@ class Sdformat8 < Formula
   depends_on "tinyxml"
   depends_on "urdfdom"
 
+  patch do
+    # Fix for building against external urdfdom
+    url "https://bitbucket.org/osrf/sdformat/commits/9569df114fc1b5c5cd3add59918dbed2ab41618e/raw"
+    sha256 "e2f32c2bbdfb53bec4c36262c65f7839a0fe34646557a5bce23dc2e927cc13bc"
+  end
+
   def install
     ENV.m64
 


### PR DESCRIPTION
don't merge this until the following bitbucket PR has been merged:

* https://bitbucket.org/osrf/sdformat/pull-requests/677/fix-homebrew-build-with-external-urdfdom/diff