### PR TITLE
Bump revisions for console_bridge 0.5

### DIFF
--- a/Formula/dartsim@6.10.0.rb
+++ b/Formula/dartsim@6.10.0.rb
@@ -9,8 +9,8 @@ class DartsimAT6100 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "6f4ee5684f2e09078656f04e3d30b5b20fd8d9903971c73c3f59c960b13f8eb7" => :mojave
-    sha256 "5b7e5a40851c7871a4a831792550c05807fce1872969d6ef93347521aba73a66" => :high_sierra
+    sha256 "faff0536a9ae9c2b2723102ad27b67d1fc5025bdea8291ab2eacd8176d49d3b6" => :mojave
+    sha256 "1bc5095431e18111046d93a522ff35f36b87c3c23dbe108fb1132ec6d6c56847" => :high_sierra
   end
 
   keg_only "open robotics fork of dart HEAD + custom changes"

--- a/Formula/dartsim@6.10.0.rb
+++ b/Formula/dartsim@6.10.0.rb
@@ -45,6 +45,9 @@ class DartsimAT6100 < Formula
       macho.add_rpath(opt_lib.to_s)
       macho.write!
     end
+
+    # Clean up the build file garbage that has been installed.
+    rm_r Dir["#{share}/doc/dart/**/CMakeFiles/"]
   end
 
   test do

--- a/Formula/dartsim@6.10.0.rb
+++ b/Formula/dartsim@6.10.0.rb
@@ -5,7 +5,7 @@ class DartsimAT6100 < Formula
   url "https://github.com/azeey/dart/archive/fdde7e7894ebc36bae8811f7a63e5b1c899bb4af.tar.gz"
   version "6.10.0~20190718~fdde7e7894ebc36bae8811f7a63e5b1c899bb4af"
   sha256 "2083a5a52a8376d1c99c33423a64c35c80fec97825cb1ed65f1d09e74a3940c7"
-  revision 4
+  revision 5
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ignition-physics1.rb
+++ b/Formula/ignition-physics1.rb
@@ -8,7 +8,7 @@ class IgnitionPhysics1 < Formula
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     cellar :any
-    sha256 "563437424c25fea6ec7a4fe08c723b2712b5a3d2f107a61a6078f55eff1b8291" => :mojave
+    sha256 "cd569afef8934abd980ccce150e7c72d89fc448904989cf9dcbb1e1b0bcc4e67" => :mojave
   end
 
   depends_on "cmake" => :build

--- a/Formula/ignition-physics1.rb
+++ b/Formula/ignition-physics1.rb
@@ -3,6 +3,7 @@ class IgnitionPhysics1 < Formula
   homepage "https://bitbucket.org/ignitionrobotics/ign-physics"
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics-1.7.0.tar.bz2"
   sha256 "d7218b0cac62ddc0055313291cc15f69744fc903026bdecffe1e185142b58cb2"
+  revision 1
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ignition-physics2.rb
+++ b/Formula/ignition-physics2.rb
@@ -3,7 +3,7 @@ class IgnitionPhysics2 < Formula
   homepage "https://bitbucket.org/ignitionrobotics/ign-physics"
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics2-2.0.0.tar.bz2"
   sha256 "37dceb6137a36bdc7ae260e77169d563a4f9cdfa9afa62db3f66041b197d2e27"
-  revision 3
+  revision 4
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ignition-physics2.rb
+++ b/Formula/ignition-physics2.rb
@@ -8,7 +8,7 @@ class IgnitionPhysics2 < Formula
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     cellar :any
-    sha256 "f0f84bf6e81cf85fd397cd25808e547bd354b444531224884f378e0bbe388fc6" => :mojave
+    sha256 "70d562d47fb5c5bb13bbc3520a6416a73d7e08a32af64daf51184cba23c5e8a0" => :mojave
   end
 
   depends_on "cmake" => :build

--- a/Formula/sdformat8.rb
+++ b/Formula/sdformat8.rb
@@ -7,7 +7,7 @@ class Sdformat8 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "a00f3d4efb3486c41b4f23db415a71c412ffd2fea6196d387e56bb14af063d08" => :mojave
+    sha256 "06fa90faf755e50dace5b3683190a04b0d37c4abfcb6ddff50ce9a8fd0f55870" => :mojave
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/sdformat8.rb
+++ b/Formula/sdformat8.rb
@@ -3,7 +3,7 @@ class Sdformat8 < Formula
   homepage "http://sdformat.org"
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-8.8.0.tar.bz2"
   sha256 "73167c9f4edc75540b8b5239db9a61c5eaa7c39c845b37c25784ac4e96a35170"
-  revision 1
+  revision 2
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/sdformat9.rb
+++ b/Formula/sdformat9.rb
@@ -3,7 +3,7 @@ class Sdformat9 < Formula
   homepage "http://sdformat.org"
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-9.2.0.tar.bz2"
   sha256 "18193e571877d06b679a476f52329f326d02b5f70bc90c7cdc92f7dae2f5d784"
-  revision 1
+  revision 2
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/sdformat9.rb
+++ b/Formula/sdformat9.rb
@@ -7,7 +7,7 @@ class Sdformat9 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "34d5bd0a03cefa817bb995a3cc5c6e9d82e48658b6aed770384598b976977f37" => :mojave
+    sha256 "9c3084344959cd1b3de0ef21cf70ecbea19f779aa58269ff20053466eadf7d24" => :mojave
   end
 
   depends_on "cmake" => [:build, :test]


### PR DESCRIPTION
Many things were broken when console_bridge 0.5.0 was released since it bumped a minor version. This bumps revisions on the broken bottles, and I will start a bottle build job.