### PR TITLE
bump ignition-msgs4 revision to get new bottles built

### DIFF
--- a/Formula/ignition-msgs4.rb
+++ b/Formula/ignition-msgs4.rb
@@ -4,6 +4,8 @@ class IgnitionMsgs4 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs4-4.9.0.tar.bz2"
   sha256 "3a75aabd1f39bf0e48f0c99070e210154d62c35b3571f20d47348e08ac3015f6"
 
+  revision 1
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     cellar :any


### PR DESCRIPTION
The msgs4 for Formula was merged in https://github.com/osrf/homebrew-simulation/pull/1015 but the bottles failed to be generated so there is a problem with brew installation

I'm bumping the revision here with the intention to run new bottles.