### PR TITLE
Rebuild gui2, msgs1, sensors2 and transport7. Rebuild gazebo9 gazebo10 and ignition-transport4.

### DIFF
--- a/Formula/gazebo10.rb
+++ b/Formula/gazebo10.rb
@@ -3,7 +3,7 @@ class Gazebo10 < Formula
   homepage "http://gazebosim.org"
   url "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/gazebo-10.2.0.tar.bz2"
   sha256 "47d8bfe70ffcde21cbc6dec142f3aecefaac66c63562aab6114f442f7ab27392"
-  revision 2
+  revision 3
 
   head "https://bitbucket.org/osrf/gazebo", :branch => "default", :using => :hg
 

--- a/Formula/gazebo9.rb
+++ b/Formula/gazebo9.rb
@@ -3,6 +3,7 @@ class Gazebo9 < Formula
   homepage "http://gazebosim.org"
   url "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/gazebo-9.13.0.tar.bz2"
   sha256 "2ff87d23c56dd843b3b38e1b1eafc93bd453710e8a4a31229b3244343ec1741a"
+  revision 1
 
   head "https://bitbucket.org/osrf/gazebo", :branch => "default", :using => :hg
 

--- a/Formula/ignition-gui2.rb
+++ b/Formula/ignition-gui2.rb
@@ -3,7 +3,7 @@ class IgnitionGui2 < Formula
   homepage "https://bitbucket.org/ignitionrobotics/ign-gui"
   url "https://osrf-distributions.s3.amazonaws.com/ign-gui/releases/ignition-gui2-2.1.0.tar.bz2"
   sha256 "1a8da1079148b19ded56987aa924025895243add194bfc46fda6964939e9ace1"
-  revision 1
+  revision 2
 
   head "https://bitbucket.org/ignitionrobotics/ign-gui", :branch => "default", :using => :hg
 

--- a/Formula/ignition-msgs1.rb
+++ b/Formula/ignition-msgs1.rb
@@ -3,7 +3,7 @@ class IgnitionMsgs1 < Formula
   homepage "https://bitbucket.org/ignitionrobotics/ign-msgs"
   url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs-1.0.0.tar.bz2"
   sha256 "fed54d079a58087fa83cc871f01ba2919866292ba949b6b8f37a0cb3d7186b4b"
-  revision 6
+  revision 7
   version_scheme 1
 
   head "https://bitbucket.org/ignitionrobotics/ign-msgs", :branch => "default", :using => :hg

--- a/Formula/ignition-sensors2.rb
+++ b/Formula/ignition-sensors2.rb
@@ -3,6 +3,7 @@ class IgnitionSensors2 < Formula
   homepage "https://bitbucket.org/ignitionrobotics/ign-sensors"
   url "https://osrf-distributions.s3.amazonaws.com/ign-sensors/releases/ignition-sensors2-2.8.0.tar.bz2"
   sha256 "f957e9948af37671d0f0b77fd24acde2401cc0f79e21d6658d781cb838fb1a87"
+  revision 1
 
   head "https://bitbucket.org/ignitionrobotics/ign-sensors", :branch => "default", :using => :hg
 

--- a/Formula/ignition-transport4.rb
+++ b/Formula/ignition-transport4.rb
@@ -3,7 +3,7 @@ class IgnitionTransport4 < Formula
   homepage "https://ignitionrobotics.org"
   url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases/ignition-transport4-4.0.0.tar.bz2"
   sha256 "b0d8d3d4b0d4fbb06ed293955f5dfe2f840fe510daec867422676b41fc3824b4"
-  revision 6
+  revision 7
 
   head "https://bitbucket.org/ignitionrobotics/ign-transport", :branch => "ign-transport4", :using => :hg
 

--- a/Formula/ignition-transport7.rb
+++ b/Formula/ignition-transport7.rb
@@ -3,6 +3,7 @@ class IgnitionTransport7 < Formula
   homepage "https://ignitionrobotics.org"
   url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases/ignition-transport7-7.4.0.tar.bz2"
   sha256 "09f038244e27a2514ebc736499e40e42aa0824bbb5c02df913042ae10c886d41"
+  revision 1
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"


### PR DESCRIPTION
fixes #1022 . I've added what I've detected [here](https://build.osrfoundation.org/job/generic-release-homebrew_bottle_builder/label=osx_mojave/795/console) +  @traversaro suggestion in the issue  

Rebuild gui2, msgs1, sensors2 and transport4 transport7 to get protobuf new linkage
Rebuild gazebo9 gazebo10 to get new bullet linkage (needed for testing in the generation job)