### PR TITLE
Remove broken bottles for: gui2, msgs1, sensors2, transport4, transport7. gazebo9 and gazebo10

### DIFF
--- a/Formula/gazebo10.rb
+++ b/Formula/gazebo10.rb
@@ -7,12 +7,6 @@ class Gazebo10 < Formula
 
   head "https://bitbucket.org/osrf/gazebo", :branch => "default", :using => :hg
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "ab8994784261cef9dc1b3742fd69e31c9e6fd6d21eb437389ca2930fbae14b0a" => :mojave
-    sha256 "5484a1a8d031151da3403682e632490c5df4fb3162c8c5f420c4c182f7abe6dd" => :high_sierra
-  end
-
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
 

--- a/Formula/gazebo9.rb
+++ b/Formula/gazebo9.rb
@@ -6,12 +6,6 @@ class Gazebo9 < Formula
 
   head "https://bitbucket.org/osrf/gazebo", :branch => "default", :using => :hg
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "52f47c2c07e654a021590eace26ca0d65a6fbadf6f33a37e8c46bceb5c183ed4" => :mojave
-    sha256 "d2bf6bb71f10a250ba88514237a899ec2f48f055bbd498b824a131d7ebee312a" => :high_sierra
-  end
-
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
 

--- a/Formula/ignition-blueprint.rb
+++ b/Formula/ignition-blueprint.rb
@@ -7,12 +7,6 @@ class IgnitionBlueprint < Formula
 
   head "https://bitbucket.org/ignitionrobotics/ign-blueprint", :branch => "default", :using => :hg
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    cellar :any_skip_relocation
-    sha256 "7068744b5a742aa3c3127efd207c6fa5011c41053e9ef0db1358ecc1e241521d" => :mojave
-  end
-
   depends_on "cmake" => :build
   depends_on "ignition-cmake2"
   depends_on "ignition-common3"

--- a/Formula/ignition-gazebo2.rb
+++ b/Formula/ignition-gazebo2.rb
@@ -6,11 +6,6 @@ class IgnitionGazebo2 < Formula
 
   head "https://bitbucket.org/ignitionrobotics/ign-gazebo", :branch => "default", :using => :hg
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "37b86818d50a08a92a77c8a1b1140e98acd97526115e9c1cb61233f0426c11b6" => :mojave
-  end
-
   depends_on "cmake" => :build
   depends_on "gflags"
   depends_on "google-benchmark"

--- a/Formula/ignition-gui2.rb
+++ b/Formula/ignition-gui2.rb
@@ -7,11 +7,6 @@ class IgnitionGui2 < Formula
 
   head "https://bitbucket.org/ignitionrobotics/ign-gui", :branch => "default", :using => :hg
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "73e4beb6a21de1782f479c5b21d1e586b6bf4dd323d5dcf91f3ac82d46363908" => :mojave
-  end
-
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
   depends_on "ignition-cmake2"

--- a/Formula/ignition-launch1.rb
+++ b/Formula/ignition-launch1.rb
@@ -4,11 +4,6 @@ class IgnitionLaunch1 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-launch/releases/ignition-launch-1.5.0.tar.bz2"
   sha256 "714ea555a3792748d63e81ff3f259e4479f37d05c5960edc0f10062d7de65dc4"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "e7d11dbcda05fe75c373cb0637c053b58f2346d17fb6e85ec560bc452375a0e2" => :mojave
-  end
-
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
 

--- a/Formula/ignition-msgs1.rb
+++ b/Formula/ignition-msgs1.rb
@@ -8,13 +8,6 @@ class IgnitionMsgs1 < Formula
 
   head "https://bitbucket.org/ignitionrobotics/ign-msgs", :branch => "default", :using => :hg
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    cellar :any
-    sha256 "6fe5b8add04797f785c2845a04237f34698731436aa39f8c855d67e10e958e0e" => :mojave
-    sha256 "8641d3f547dd2533cc63d566cfa7d9150d75a6a43615e22b3c600b2600d75a0a" => :high_sierra
-  end
-
   depends_on "protobuf-c" => :build
   depends_on "cmake"
   depends_on "ignition-cmake0"

--- a/Formula/ignition-sensors2.rb
+++ b/Formula/ignition-sensors2.rb
@@ -6,11 +6,6 @@ class IgnitionSensors2 < Formula
 
   head "https://bitbucket.org/ignitionrobotics/ign-sensors", :branch => "default", :using => :hg
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "bdd51d69e14e3d1357c47682f06677933b4e3a8816e25d2c0766c9aa54a14eb1" => :mojave
-  end
-
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
 

--- a/Formula/ignition-transport4.rb
+++ b/Formula/ignition-transport4.rb
@@ -7,13 +7,6 @@ class IgnitionTransport4 < Formula
 
   head "https://bitbucket.org/ignitionrobotics/ign-transport", :branch => "ign-transport4", :using => :hg
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    cellar :any
-    sha256 "7368c24a392cf54a87c3fdf7ae6d13ab0dfe1a3e35a4061e7359a25c14254f97" => :mojave
-    sha256 "2abbd2957493775a0bc209083183917bb1748e3c5d1416d42679329aa81a52d5" => :high_sierra
-  end
-
   depends_on "doxygen" => [:build, :optional]
 
   depends_on "protobuf-c" => :build

--- a/Formula/ignition-transport7.rb
+++ b/Formula/ignition-transport7.rb
@@ -4,11 +4,6 @@ class IgnitionTransport7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases/ignition-transport7-7.4.0.tar.bz2"
   sha256 "09f038244e27a2514ebc736499e40e42aa0824bbb5c02df913042ae10c886d41"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "731e507a0e9582af5fda2cc894d272ac6e0ed9ad97f341fd35570fc66fe0e219" => :mojave
-  end
-
   depends_on "doxygen" => [:build, :optional]
   depends_on "protobuf-c" => :build
 


### PR DESCRIPTION
Protobuf bump killed the ABI in some cases, Bullet bump in some others. They should be regenerated, removing them to use brew test-bot without failures while testing code.