### PR TITLE
Bitbucket -> GitHub urls: some old, some new

### DIFF
--- a/Formula/ignition-fuel-tools5.rb
+++ b/Formula/ignition-fuel-tools5.rb
@@ -1,9 +1,9 @@
 class IgnitionFuelTools5 < Formula
   desc "Tools for using Fuel API to download robot models"
   homepage "https://ignitionrobotics.org"
-  url "https://bitbucket.org/ignitionrobotics/ign-fuel-tools/get/5b7d9e7be787619a3b125b0675912e1a21403fc6.tar.bz2"
+  url "https://github.com/ignitionrobotics/ign-fuel-tools/archive/e0ecb6f22b2ed0fb2e547eb419b61bebf1cd3afa.tar.gz"
   version "4.999.999~0~20200407~5b7d9e"
-  sha256 "8f8a25b56265dd3853383100f9b73b9af22fdb06980c8d917dfb0316afb16229"
+  sha256 "a6eaa557c45938cef64520ab9f434f32701a1a2849260641c1c67d2eab38b096"
 
   head "https://github.com/ignitionrobotics/ign-fuel-tools", :branch => "master"
 

--- a/Formula/ignition-gazebo4.rb
+++ b/Formula/ignition-gazebo4.rb
@@ -1,9 +1,9 @@
 class IgnitionGazebo4 < Formula
   desc "Ignition Gazebo robot simulator"
   homepage "https://github.com/ignitionrobotics/ign-gazebo"
-  url "https://bitbucket.org/ignitionrobotics/ign-gazebo/get/78c43e71a5a079588fd18c84efab54578267e7ec.tar.bz2"
+  url "https://github.com/ignitionrobotics/ign-gazebo/archive/b1dd4006ea612f675484f6052a5c84157df2f8ab.tar.gz"
   version "3.999.999~0~20200224~78c43e7"
-  sha256 "ce663e5bbc06a13653088d3c0f8a21a47642be6aa3d59804b7d05669cf7f02d8"
+  sha256 "948ddeb9197c4fb8c2ff4cf59f0a86c81c45ae35fc187233ba167d37945af4d4"
   revision 1
 
   head "https://github.com/ignitionrobotics/ign-gazebo", :branch => "master"

--- a/Formula/ignition-launch3.rb
+++ b/Formula/ignition-launch3.rb
@@ -1,9 +1,9 @@
 class IgnitionLaunch3 < Formula
   desc "Launch libraries for robotics applications"
   homepage "https://github.com/ignitionrobotics/ign-launch"
-  url "https://bitbucket.org/ignitionrobotics/ign-launch/get/8995670392f01a43424ff3bc934da174329aebb5.tar.bz2"
+  url "https://github.com/ignitionrobotics/ign-launch/archive/f9a11aeefdfe2a22ef6b4b253f2e68548436725b.tar.gz"
   version "2.999.999~0~20200316~899567"
-  sha256 "c427112fed59fcb783ccbdaf58586546b1e561046c695ca16843db7e1e308d7c"
+  sha256 "2d25ab18e6593a777e77a1e64d398486b712e1ab78cbfca9ec7320af5daac319"
 
   head "https://github.com/ignitionrobotics/ign-launch", :branch => "master"
 

--- a/Formula/ignition-msgs6.rb
+++ b/Formula/ignition-msgs6.rb
@@ -1,9 +1,9 @@
 class IgnitionMsgs6 < Formula
   desc "Middleware protobuf messages for robotics"
   homepage "https://github.com/ignitionrobotics/ign-msgs"
-  url "https://bitbucket.org/ignitionrobotics/ign-msgs/get/47d93769c80c7da72f03c3dd8ba5a36fcd6ab076.tar.bz2"
+  url "https://github.com/ignitionrobotics/ign-msgs/archive/5bbf3bd4bd5b33df42c0803fec3864a52b66cff4.tar.gz"
   version "5.999.999~0~20200407~47d937"
-  sha256 "8b9422786573a4f40e2aa63741fa964336a3e1138c8dee6e8c98847ff4ea1fb1"
+  sha256 "e9e7bceae471eed7fd6fe9dee9c003deb86d05fdf2d92acbe2e8703ac3947093"
 
   head "https://github.com/ignitionrobotics/ign-msgs", :branch => "master"
 

--- a/Formula/ignition-rendering0.rb
+++ b/Formula/ignition-rendering0.rb
@@ -25,8 +25,8 @@ class IgnitionRendering0 < Formula
 
   patch do
     # Don't conflict with ignition-rendering1
-    url "https://bitbucket.org/ignitionrobotics/ign-rendering/commits/8aaa4b8188cae5cd5082e46a05abde6bfcc7fbde/raw/"
-    sha256 "87ca51e370faab94d2ff92bc3fde3d236fe5f264a582a5740e047d85818280a8"
+    url "https://github.com/ignitionrobotics/ign-rendering/commit/ba788c7261d367e3f1d72d62ee57ad8a32602bc1.diff?full_index=1"
+    sha256 "41710795b494e86b983dae5c97e604f38a605d29f638f1386474bd3f348879fb"
   end
 
   def install

--- a/Formula/ignition-rendering4.rb
+++ b/Formula/ignition-rendering4.rb
@@ -1,9 +1,9 @@
 class IgnitionRendering4 < Formula
   desc "Rendering library for robotics applications"
   homepage "https://github.com/ignitionrobotics/ign-rendering"
-  url "https://bitbucket.org/ignitionrobotics/ign-rendering/get/f0dc5f4ce27697dbc02e2fe74a1a0fb3b5c091d8.tar.gz"
+  url "https://github.com/ignitionrobotics/ign-rendering/archive/5d01146555fbfdb51a2a0d14158676f8ec4dc8d6.tar.gz"
   version "3.999.999~0~20200310~f0dc5f4"
-  sha256 "4f5eae2d1de279ae16c20607c8dcc0ef1dab057e4b29cda68dccfbe07161a71f"
+  sha256 "61e1e151954f9bf73087789672a765ad46aad9d46f83730440902cf79f60109c"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ignition-rndf0.rb
+++ b/Formula/ignition-rndf0.rb
@@ -1,8 +1,8 @@
 class IgnitionRndf0 < Formula
   desc "Ignition RNDF is a library for parsing RNDF road network files"
   homepage "https://ignitionrobotics.org"
-  url "https://bitbucket.org/ignitionrobotics/ign-rndf/get/7b8b1d2afa680424e4f53dbc7beafcdb88db50e0.tar.gz"
-  sha256 "12f78a8534d812bc6248021d78961b1458715ec6f84edc2cce2a1c5fe01fc416"
+  url "https://github.com/ignitionrobotics/ign-rndf/archive/45652bceabce1ea1630b41623f56560f10674343.tar.gz"
+  sha256 "ae108308d8a7b4dddfd3a5d23eb3d8a844e1760bf01cb3066cdd45570cf6c26f"
 
   head "https://github.com/ignitionrobotics/ign-rndf", :branch => "master"
 

--- a/Formula/ignition-sensors4.rb
+++ b/Formula/ignition-sensors4.rb
@@ -1,9 +1,9 @@
 class IgnitionSensors4 < Formula
   desc "Sensors library for robotics applications"
   homepage "https://github.com/ignitionrobotics/ign-sensors"
-  url "https://bitbucket.org/ignitionrobotics/ign-sensors/get/84f8018bc3185ada6f4e85a8d0728f2cdd3b3699.tar.gz"
+  url "https://github.com/ignitionrobotics/ign-sensors/archive/766301b738d9a92a7b17fbdefdbc0f0487fb1bea.tar.gz"
   version "3.999.999~0~20200408~84f8018"
-  sha256 "73522f74aa29fbb423c6908dd1670a5298ce2609a54cd95cb5901b47198af914"
+  sha256 "1d5334a25c9cb34c36744d1d2ebdc7dd0c92c8bf214df4eabc26f487493058b6"
 
   head "https://github.com/ignitionrobotics/ign-sensors", :branch => "master"
 

--- a/Formula/ogre1.9.rb
+++ b/Formula/ogre1.9.rb
@@ -69,14 +69,14 @@ class Ogre19 < Formula
 
   patch do
     # fix for boost 1.65
-    url "https://bitbucket.org/sinbad/ogre/commits/0cd739f7551d0aad3329abb42d981e970e074fa7/raw"
-    sha256 "cb22b8703f36596efa13618085b2d1a59522d04386cf7eb6eca42a99d0abe83d"
+    url "https://github.com/OGRECave/ogre/commit/cade48b4c2215dd77ea74b7aa219a22c2a5d6654.diff?full_index=1"
+    sha256 "4b000a58663713dbfdf3e06ce99a641b636dcb8ae76c84d53a960a419fe452b8"
   end
 
   patch do
     # fix for boost 1.67
-    url "https://bitbucket.org/sinbad/ogre/commits/16a75ea693e65fed3af943b4b2bfaa7e6c8219b1/raw"
-    sha256 "ffad5129caf3344fb408d6af3c8076bb4e97becdcd6d08302db469694a596616"
+    url "https://github.com/OGRECave/ogre/commit/2371c8d001725190a9cda62dc5df282cde78f951.diff?full_index=1"
+    sha256 "9c6b600d528f6329d9728faa4eacf4363dd71d8c0e4dae238e480361796d58c8"
   end
 
   def install


### PR DESCRIPTION
This updates bitbucket URL's to point to the same commit on GitHub. It includes some old formulae (ignition-rndf0, ignition-rendering0, ogre1.9) and new formulae (ignition dome dependencies).