### PR TITLE
ignition-transport9: new formula

### DIFF
--- a/Aliases/ignition-transport9
+++ b/Aliases/ignition-transport9
@@ -1,1 +1,0 @@
-../Formula/ignition-transport8.rb

--- a/Formula/ignition-transport9.rb
+++ b/Formula/ignition-transport9.rb
@@ -1,0 +1,63 @@
+class IgnitionTransport9 < Formula
+  desc "Transport middleware for robotics"
+  homepage "https://ignitionrobotics.org"
+  url "https://github.com/ignitionrobotics/ign-transport/archive/876236053887dea5f0727a7e7e52d3580aac597d.tar.gz"
+  version "9.999.999~0~20200716~876236"
+  sha256 "a5ab1c8e23877f4485eeed21243ad3bef284846e4be2a4d550ecfdab648a6017"
+
+  head "https://github.com/ignitionrobotics/ign-transport", :branch => "master"
+
+  depends_on "doxygen" => [:build, :optional]
+  depends_on "protobuf-c" => :build
+
+  depends_on "cmake"
+  depends_on "cppzmq"
+  depends_on "ignition-cmake2"
+  depends_on "ignition-msgs6"
+  depends_on "ignition-tools"
+  depends_on :macos => :high_sierra # c++17
+  depends_on "ossp-uuid"
+  depends_on "pkg-config"
+  depends_on "protobuf"
+  depends_on "zeromq"
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS
+      #include <iostream>
+      #include <ignition/transport.hh>
+      int main() {
+        ignition::transport::NodeOptions options;
+        return 0;
+      }
+    EOS
+    (testpath/"CMakeLists.txt").write <<-EOS
+      cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+      find_package(ignition-transport9 QUIET REQUIRED)
+      add_executable(test_cmake test.cpp)
+      target_link_libraries(test_cmake ignition-transport9::ignition-transport9)
+    EOS
+    system "pkg-config", "ignition-transport9"
+    cflags = `pkg-config --cflags ignition-transport9`.split(" ")
+    system ENV.cc, "test.cpp",
+                   *cflags,
+                   "-L#{lib}",
+                   "-lignition-transport9",
+                   "-lc++",
+                   "-o", "test"
+    ENV["IGN_PARTITION"] = rand((1 << 32) - 1).to_s
+    system "./test"
+    mkdir "build" do
+      system "cmake", ".."
+      system "make"
+      system "./test_cmake"
+    end
+    # check for Xcode frameworks in bottle
+    cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
+    system cmd_not_grep_xcode
+  end
+end

--- a/Formula/ignition-transport9.rb
+++ b/Formula/ignition-transport9.rb
@@ -5,7 +5,7 @@ class IgnitionTransport9 < Formula
   version "9.999.999~0~20200716~876236"
   sha256 "a5ab1c8e23877f4485eeed21243ad3bef284846e4be2a4d550ecfdab648a6017"
   license "Apache-2.0"
-  
+
   head "https://github.com/ignitionrobotics/ign-transport", :branch => "master"
 
   depends_on "doxygen" => [:build, :optional]

--- a/Formula/ignition-transport9.rb
+++ b/Formula/ignition-transport9.rb
@@ -4,7 +4,8 @@ class IgnitionTransport9 < Formula
   url "https://github.com/ignitionrobotics/ign-transport/archive/876236053887dea5f0727a7e7e52d3580aac597d.tar.gz"
   version "9.999.999~0~20200716~876236"
   sha256 "a5ab1c8e23877f4485eeed21243ad3bef284846e4be2a4d550ecfdab648a6017"
-
+  license "Apache-2.0"
+  
   head "https://github.com/ignitionrobotics/ign-transport", :branch => "master"
 
   depends_on "doxygen" => [:build, :optional]


### PR DESCRIPTION
Remove alias and add new formula that depends on `ign-msgs6`. I took the last commit of https://github.com/ignitionrobotics/ign-transport/pull/149/

This is broken off https://github.com/osrf/homebrew-simulation/pull/1063 so we can make the changes incrementally.