### PR TITLE
ignition-gui4: bump for msgs6 and transport9

### DIFF
--- a/Formula/ignition-gui4.rb
+++ b/Formula/ignition-gui4.rb
@@ -1,9 +1,9 @@
 class IgnitionGui4 < Formula
   desc "Common libraries for robotics applications. GUI Library"
   homepage "https://github.com/ignitionrobotics/ign-gui"
-  url "https://github.com/ignitionrobotics/ign-gui/archive/a60cb7d61339b407ff3285ddbf16f618c4c4b3b9.tar.gz"
-  version "3.999.999~0~20200520~a60cb7"
-  sha256 "3984a5a00010b1da7a95908149345cabb1cbbc3428d03eeaa27c3a4354c3d53d"
+  url "https://github.com/ignitionrobotics/ign-gui/archive/5d1428a3c90302daa73d5b94c14618fb4c25f7d4.tar.gz"
+  version "3.999.999~0~20200721~5d1428"
+  sha256 "12a6e69a90f546721fac3ff7e4a0e41705373e3f63508a82599052241573666a"
   license "Apache-2.0"
 
   head "https://github.com/ignitionrobotics/ign-gui", :branch => "master"
@@ -17,10 +17,10 @@ class IgnitionGui4 < Formula
   depends_on "pkg-config" => [:build, :test]
   depends_on "ignition-cmake2"
   depends_on "ignition-common3"
-  depends_on "ignition-msgs5"
+  depends_on "ignition-msgs6"
   depends_on "ignition-plugin1"
   depends_on "ignition-rendering4"
-  depends_on "ignition-transport8"
+  depends_on "ignition-transport9"
   depends_on :macos => :mojave # c++17
   depends_on "qt"
   depends_on "qwt"

--- a/Formula/ignition-transport9.rb
+++ b/Formula/ignition-transport9.rb
@@ -2,7 +2,7 @@ class IgnitionTransport9 < Formula
   desc "Transport middleware for robotics"
   homepage "https://ignitionrobotics.org"
   url "https://github.com/ignitionrobotics/ign-transport/archive/876236053887dea5f0727a7e7e52d3580aac597d.tar.gz"
-  version "9.999.999~0~20200716~876236"
+  version "8.999.999~0~20200716~876236"
   sha256 "a5ab1c8e23877f4485eeed21243ad3bef284846e4be2a4d550ecfdab648a6017"
   license "Apache-2.0"
 

--- a/Formula/ignition-transport9.rb
+++ b/Formula/ignition-transport9.rb
@@ -2,7 +2,7 @@ class IgnitionTransport9 < Formula
   desc "Transport middleware for robotics"
   homepage "https://ignitionrobotics.org"
   url "https://github.com/ignitionrobotics/ign-transport/archive/876236053887dea5f0727a7e7e52d3580aac597d.tar.gz"
-  version "8.999.999~0~20200716~876236"
+  version "9.999.999~0~20200716~876236"
   sha256 "a5ab1c8e23877f4485eeed21243ad3bef284846e4be2a4d550ecfdab648a6017"
   license "Apache-2.0"
 


### PR DESCRIPTION
Breaking off just the `ign-gui` part of https://github.com/osrf/homebrew-simulation/pull/1063/files.

Using the latest commit from https://github.com/ignitionrobotics/ign-gui/pull/92/

~~Also fixed major version of `ign-transport9` that was wrong on #1065~~ will do it in a separate PR