### PR TITLE
ignition-sensors4: bump for msgs6, transport9, sdf10

### DIFF
--- a/Formula/ignition-sensors4.rb
+++ b/Formula/ignition-sensors4.rb
@@ -1,9 +1,9 @@
 class IgnitionSensors4 < Formula
   desc "Sensors library for robotics applications"
   homepage "https://github.com/ignitionrobotics/ign-sensors"
-  url "https://github.com/ignitionrobotics/ign-sensors/archive/766301b738d9a92a7b17fbdefdbc0f0487fb1bea.tar.gz"
-  version "3.999.999~0~20200408~84f8018"
-  sha256 "1d5334a25c9cb34c36744d1d2ebdc7dd0c92c8bf214df4eabc26f487493058b6"
+  url "https://github.com/ignitionrobotics/ign-sensors/archive/cf9a8bcf66477a6b30f7415cfb5591699bc2fedc.tar.gz"
+  version "3.999.999~0~20200721~cf9a8bc"
+  sha256 "a9fa1db1c340169e701d2ecb59b91e865bdb4856b72466da409a0b2302b5bca0"
   license "Apache-2.0"
   revision 1
 
@@ -20,10 +20,10 @@ class IgnitionSensors4 < Formula
   depends_on "ignition-cmake2"
   depends_on "ignition-common3"
   depends_on "ignition-math6"
-  depends_on "ignition-msgs5"
+  depends_on "ignition-msgs6"
   depends_on "ignition-rendering4"
-  depends_on "ignition-transport8"
-  depends_on "sdformat9"
+  depends_on "ignition-transport9"
+  depends_on "sdformat10"
 
   def install
     system "cmake", ".", *std_cmake_args


### PR DESCRIPTION
Breaking off just the `ign-sensors` part of https://github.com/osrf/homebrew-simulation/pull/1063/.

Using the latest commit from https://github.com/ignitionrobotics/ign-sensors/pull/31
