### PR TITLE
ignition-transport9: fix version

### DIFF
--- a/Formula/ignition-transport9.rb
+++ b/Formula/ignition-transport9.rb
@@ -5,6 +5,7 @@ class IgnitionTransport9 < Formula
   version "8.999.999~0~20200716~876236"
   sha256 "a5ab1c8e23877f4485eeed21243ad3bef284846e4be2a4d550ecfdab648a6017"
   license "Apache-2.0"
+  version_scheme 1
 
   head "https://github.com/ignitionrobotics/ign-transport", :branch => "master"
 

--- a/Formula/ignition-transport9.rb
+++ b/Formula/ignition-transport9.rb
@@ -2,7 +2,7 @@ class IgnitionTransport9 < Formula
   desc "Transport middleware for robotics"
   homepage "https://ignitionrobotics.org"
   url "https://github.com/ignitionrobotics/ign-transport/archive/876236053887dea5f0727a7e7e52d3580aac597d.tar.gz"
-  version "9.999.999~0~20200716~876236"
+  version "8.999.999~0~20200716~876236"
   sha256 "a5ab1c8e23877f4485eeed21243ad3bef284846e4be2a4d550ecfdab648a6017"
   license "Apache-2.0"
 


### PR DESCRIPTION
So, I messed up on #1065 and `ignition-transport9` was released with a major too high. Now brew won't allow a version decrease.

Is this fixable? 😟