### PR TITLE
workflow: check GITHUB_* env variables are set (from fork)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,18 @@ jobs:
     steps:
       - name: Set up Git repository
         uses: actions/checkout@v2
+      - name: Check GITHUB_BASE_REF and GITHUB_SHA
+        run: |
+          if [[ -z "${GITHUB_BASE_REF}" ]]; then
+            echo GITHUB_BASE_REF not set. Please create pull requests from a fork.
+            exit 1
+          fi
+          echo GITHUB_BASE_REF ${GITHUB_BASE_REF}
+          if [[ -z "${GITHUB_SHA}" ]]; then
+            echo GITHUB_SHA not set. Something is wrong with github actions.
+            exit 1
+          fi
+          echo GITHUB_SHA ${GITHUB_SHA}
       - name: Run brew test-bot
         run: |
           set -e


### PR DESCRIPTION
This is identical to #1071 but it is made from a fork. I expect CI to pass for this PR and fail for #1017 

I noticed an issue with #1069 after it had been merged, but its CI didn't complain, which led me to discover that `homebrew-test-bot` can't tell which files have been changed when a pull is made from a non-forked repository (see [this code](https://github.com/Homebrew/homebrew-test-bot/blob/93c5d6540100b8c492edb503ea2efdb329926091/lib/tests/formulae.rb#L85-L97)). Normally it identifies which formulae have changed and then runs tests specifically for those formulae. In #1069, it didn't test any formulae:

~~~
==> Testing osrf/homebrew-simulation 082f366 (ignition-sensors4: bump for msgs6, transport9, sdf10 (#1069)):
    url             (undefined)
    origin/master   082f366 (ignition-sensors4: bump for msgs6, transport9, sdf10 (#1069))
    HEAD            082f366 (ignition-sensors4: bump for msgs6, transport9, sdf10 (#1069))
    diff_start_sha1 082f366be07ec443b324ac75a2e16cef8d8cb4c5
    diff_end_sha1   082f366be07ec443b324ac75a2e16cef8d8cb4c5
All steps passed!
~~~

I expect this PR to pass CI since I have created this branch on my fork.