### PR TITLE
Use brew style --fix on all formulae

### DIFF
--- a/Formula/chrono-engine.rb
+++ b/Formula/chrono-engine.rb
@@ -4,7 +4,7 @@ class ChronoEngine < Formula
   url "https://github.com/projectchrono/chrono/archive/2.0.0.tar.gz"
   sha256 "ef5d5831881bc2fc6f3f80106e6e763c904f57dc39b6db880968f00451ac936b"
   license "BSD-3-Clause"
-  head "https://github.com/projectchrono/chrono.git", :branch => "develop"
+  head "https://github.com/projectchrono/chrono.git", branch: "develop"
 
   depends_on "cmake" => :build
   depends_on "irrlicht" => :optional

--- a/Formula/gazebo10.rb
+++ b/Formula/gazebo10.rb
@@ -6,7 +6,7 @@ class Gazebo10 < Formula
   license "Apache-2.0"
   revision 3
 
-  head "https://github.com/osrf/gazebo", :branch => "gazebo10"
+  head "https://github.com/osrf/gazebo", branch: "gazebo10"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
@@ -25,7 +25,7 @@ class Gazebo10 < Formula
   depends_on "ignition-msgs1"
   depends_on "ignition-transport4"
   depends_on "libtar"
-  depends_on :macos => :mojave # ogre1.9 missing in highsierra
+  depends_on macos: :mojave # ogre1.9 missing in highsierra
   depends_on "ogre1.9"
   depends_on "ossp-uuid" => :linked
   depends_on "protobuf"
@@ -46,15 +46,15 @@ class Gazebo10 < Formula
   depends_on "gdal" => :optional
   depends_on "player" => :optional
 
-  conflicts_with "gazebo2", :because => "differing version of the same formula"
-  conflicts_with "gazebo3", :because => "differing version of the same formula"
-  conflicts_with "gazebo4", :because => "differing version of the same formula"
-  conflicts_with "gazebo5", :because => "differing version of the same formula"
-  conflicts_with "gazebo6", :because => "differing version of the same formula"
-  conflicts_with "gazebo7", :because => "differing version of the same formula"
-  conflicts_with "gazebo8", :because => "differing version of the same formula"
-  conflicts_with "gazebo9", :because => "differing version of the same formula"
-  conflicts_with "gazebo11", :because => "differing version of the same formula"
+  conflicts_with "gazebo2", because: "differing version of the same formula"
+  conflicts_with "gazebo3", because: "differing version of the same formula"
+  conflicts_with "gazebo4", because: "differing version of the same formula"
+  conflicts_with "gazebo5", because: "differing version of the same formula"
+  conflicts_with "gazebo6", because: "differing version of the same formula"
+  conflicts_with "gazebo7", because: "differing version of the same formula"
+  conflicts_with "gazebo8", because: "differing version of the same formula"
+  conflicts_with "gazebo9", because: "differing version of the same formula"
+  conflicts_with "gazebo11", because: "differing version of the same formula"
 
   patch do
     # Fix build when homebrew python is installed

--- a/Formula/gazebo11.rb
+++ b/Formula/gazebo11.rb
@@ -6,7 +6,7 @@ class Gazebo11 < Formula
   license "Apache-2.0"
   revision 2
 
-  head "https://github.com/osrf/gazebo", :branch => "gazebo11"
+  head "https://github.com/osrf/gazebo", branch: "gazebo11"
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
@@ -41,15 +41,15 @@ class Gazebo11 < Formula
   depends_on "gdal" => :optional
   depends_on "player" => :optional
 
-  conflicts_with "gazebo2", :because => "differing version of the same formula"
-  conflicts_with "gazebo3", :because => "differing version of the same formula"
-  conflicts_with "gazebo4", :because => "differing version of the same formula"
-  conflicts_with "gazebo5", :because => "differing version of the same formula"
-  conflicts_with "gazebo6", :because => "differing version of the same formula"
-  conflicts_with "gazebo7", :because => "differing version of the same formula"
-  conflicts_with "gazebo8", :because => "differing version of the same formula"
-  conflicts_with "gazebo9", :because => "differing version of the same formula"
-  conflicts_with "gazebo10", :because => "differing version of the same formula"
+  conflicts_with "gazebo2", because: "differing version of the same formula"
+  conflicts_with "gazebo3", because: "differing version of the same formula"
+  conflicts_with "gazebo4", because: "differing version of the same formula"
+  conflicts_with "gazebo5", because: "differing version of the same formula"
+  conflicts_with "gazebo6", because: "differing version of the same formula"
+  conflicts_with "gazebo7", because: "differing version of the same formula"
+  conflicts_with "gazebo8", because: "differing version of the same formula"
+  conflicts_with "gazebo9", because: "differing version of the same formula"
+  conflicts_with "gazebo10", because: "differing version of the same formula"
 
   patch do
     # Fix build when homebrew python is installed

--- a/Formula/gazebo2.rb
+++ b/Formula/gazebo2.rb
@@ -4,9 +4,9 @@ class Gazebo2 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/gazebo-2.2.6.tar.bz2"
   sha256 "c5e886a9d43a99865d3393dab643493c906c106781ea2ee50555bb8dcf03bd81"
   license "Apache-2.0"
-  head "https://github.com/osrf/gazebo", :branch => "gazebo_2.2"
+  head "https://github.com/osrf/gazebo", branch: "gazebo_2.2"
 
-  deprecate! :date => "2016-01-25"
+  deprecate! date: "2016-01-25"
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
@@ -25,12 +25,12 @@ class Gazebo2 < Formula
   depends_on "tbb"
   depends_on "tinyxml"
 
-  conflicts_with "gazebo3", :because => "differing version of the same formula"
-  conflicts_with "gazebo4", :because => "differing version of the same formula"
-  conflicts_with "gazebo5", :because => "differing version of the same formula"
-  conflicts_with "gazebo6", :because => "differing version of the same formula"
-  conflicts_with "gazebo7", :because => "differing version of the same formula"
-  conflicts_with "gazebo8", :because => "differing version of the same formula"
+  conflicts_with "gazebo3", because: "differing version of the same formula"
+  conflicts_with "gazebo4", because: "differing version of the same formula"
+  conflicts_with "gazebo5", because: "differing version of the same formula"
+  conflicts_with "gazebo6", because: "differing version of the same formula"
+  conflicts_with "gazebo7", because: "differing version of the same formula"
+  conflicts_with "gazebo8", because: "differing version of the same formula"
 
   patch do
     # Fix build when homebrew python is installed

--- a/Formula/gazebo3.rb
+++ b/Formula/gazebo3.rb
@@ -4,9 +4,9 @@ class Gazebo3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/gazebo-3.2.0.tar.bz2"
   sha256 "6b77382a491833d5292b3e1fca34a04c968025a09746d87cdcf77cff040acea5"
   license "Apache-2.0"
-  head "https://github.com/osrf/gazebo", :branch => "gazebo_3.1"
+  head "https://github.com/osrf/gazebo", branch: "gazebo_3.1"
 
-  deprecate! :date => "2015-07-27"
+  deprecate! date: "2015-07-27"
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
@@ -25,12 +25,12 @@ class Gazebo3 < Formula
   depends_on "tbb"
   depends_on "tinyxml"
 
-  conflicts_with "gazebo2", :because => "differing version of the same formula"
-  conflicts_with "gazebo4", :because => "differing version of the same formula"
-  conflicts_with "gazebo5", :because => "differing version of the same formula"
-  conflicts_with "gazebo6", :because => "differing version of the same formula"
-  conflicts_with "gazebo7", :because => "differing version of the same formula"
-  conflicts_with "gazebo8", :because => "differing version of the same formula"
+  conflicts_with "gazebo2", because: "differing version of the same formula"
+  conflicts_with "gazebo4", because: "differing version of the same formula"
+  conflicts_with "gazebo5", because: "differing version of the same formula"
+  conflicts_with "gazebo6", because: "differing version of the same formula"
+  conflicts_with "gazebo7", because: "differing version of the same formula"
+  conflicts_with "gazebo8", because: "differing version of the same formula"
 
   patch do
     # Fix build when homebrew python is installed

--- a/Formula/gazebo4.rb
+++ b/Formula/gazebo4.rb
@@ -4,9 +4,9 @@ class Gazebo4 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/gazebo-4.1.3.tar.bz2"
   sha256 "5041b3f931f90c90b6163485b7074681f1a7a06dca9e3f271021a1d3b6777a53"
   license "Apache-2.0"
-  head "https://github.com/osrf/gazebo", :branch => "gazebo_4.1"
+  head "https://github.com/osrf/gazebo", branch: "gazebo_4.1"
 
-  deprecate! :date => "2016-01-25"
+  deprecate! date: "2016-01-25"
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
@@ -25,12 +25,12 @@ class Gazebo4 < Formula
   depends_on "tbb"
   depends_on "tinyxml"
 
-  conflicts_with "gazebo2", :because => "differing version of the same formula"
-  conflicts_with "gazebo3", :because => "differing version of the same formula"
-  conflicts_with "gazebo5", :because => "differing version of the same formula"
-  conflicts_with "gazebo6", :because => "differing version of the same formula"
-  conflicts_with "gazebo7", :because => "differing version of the same formula"
-  conflicts_with "gazebo8", :because => "differing version of the same formula"
+  conflicts_with "gazebo2", because: "differing version of the same formula"
+  conflicts_with "gazebo3", because: "differing version of the same formula"
+  conflicts_with "gazebo5", because: "differing version of the same formula"
+  conflicts_with "gazebo6", because: "differing version of the same formula"
+  conflicts_with "gazebo7", because: "differing version of the same formula"
+  conflicts_with "gazebo8", because: "differing version of the same formula"
 
   patch do
     # Fix build when homebrew python is installed

--- a/Formula/gazebo5.rb
+++ b/Formula/gazebo5.rb
@@ -6,9 +6,9 @@ class Gazebo5 < Formula
   license "Apache-2.0"
   revision 2
 
-  head "https://github.com/osrf/gazebo", :branch => "gazebo5"
+  head "https://github.com/osrf/gazebo", branch: "gazebo5"
 
-  deprecate! :date => "2017-01-25"
+  deprecate! date: "2017-01-25"
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
@@ -27,12 +27,12 @@ class Gazebo5 < Formula
   depends_on "tbb"
   depends_on "tinyxml"
 
-  conflicts_with "gazebo2", :because => "differing version of the same formula"
-  conflicts_with "gazebo3", :because => "differing version of the same formula"
-  conflicts_with "gazebo4", :because => "differing version of the same formula"
-  conflicts_with "gazebo6", :because => "differing version of the same formula"
-  conflicts_with "gazebo7", :because => "differing version of the same formula"
-  conflicts_with "gazebo8", :because => "differing version of the same formula"
+  conflicts_with "gazebo2", because: "differing version of the same formula"
+  conflicts_with "gazebo3", because: "differing version of the same formula"
+  conflicts_with "gazebo4", because: "differing version of the same formula"
+  conflicts_with "gazebo6", because: "differing version of the same formula"
+  conflicts_with "gazebo7", because: "differing version of the same formula"
+  conflicts_with "gazebo8", because: "differing version of the same formula"
 
   patch do
     # Fix build when homebrew python is installed

--- a/Formula/gazebo6.rb
+++ b/Formula/gazebo6.rb
@@ -6,9 +6,9 @@ class Gazebo6 < Formula
   license "Apache-2.0"
   revision 2
 
-  head "https://github.com/osrf/gazebo", :branch => "gazebo6"
+  head "https://github.com/osrf/gazebo", branch: "gazebo6"
 
-  deprecate! :date => "2017-01-25"
+  deprecate! date: "2017-01-25"
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
@@ -28,12 +28,12 @@ class Gazebo6 < Formula
   depends_on "tbb"
   depends_on "tinyxml"
 
-  conflicts_with "gazebo2", :because => "differing version of the same formula"
-  conflicts_with "gazebo3", :because => "differing version of the same formula"
-  conflicts_with "gazebo4", :because => "differing version of the same formula"
-  conflicts_with "gazebo5", :because => "differing version of the same formula"
-  conflicts_with "gazebo7", :because => "differing version of the same formula"
-  conflicts_with "gazebo8", :because => "differing version of the same formula"
+  conflicts_with "gazebo2", because: "differing version of the same formula"
+  conflicts_with "gazebo3", because: "differing version of the same formula"
+  conflicts_with "gazebo4", because: "differing version of the same formula"
+  conflicts_with "gazebo5", because: "differing version of the same formula"
+  conflicts_with "gazebo7", because: "differing version of the same formula"
+  conflicts_with "gazebo8", because: "differing version of the same formula"
 
   patch do
     # Fix build when homebrew python is installed

--- a/Formula/gazebo7.rb
+++ b/Formula/gazebo7.rb
@@ -6,7 +6,7 @@ class Gazebo7 < Formula
   license "Apache-2.0"
   revision 3
 
-  head "https://github.com/osrf/gazebo", :branch => "gazebo7"
+  head "https://github.com/osrf/gazebo", branch: "gazebo7"
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
@@ -34,15 +34,15 @@ class Gazebo7 < Formula
   depends_on "gdal" => :optional
   depends_on "player" => :optional
 
-  conflicts_with "gazebo2", :because => "differing version of the same formula"
-  conflicts_with "gazebo3", :because => "differing version of the same formula"
-  conflicts_with "gazebo4", :because => "differing version of the same formula"
-  conflicts_with "gazebo5", :because => "differing version of the same formula"
-  conflicts_with "gazebo6", :because => "differing version of the same formula"
-  conflicts_with "gazebo8", :because => "differing version of the same formula"
-  conflicts_with "gazebo9", :because => "differing version of the same formula"
-  conflicts_with "gazebo10", :because => "differing version of the same formula"
-  conflicts_with "gazebo11", :because => "differing version of the same formula"
+  conflicts_with "gazebo2", because: "differing version of the same formula"
+  conflicts_with "gazebo3", because: "differing version of the same formula"
+  conflicts_with "gazebo4", because: "differing version of the same formula"
+  conflicts_with "gazebo5", because: "differing version of the same formula"
+  conflicts_with "gazebo6", because: "differing version of the same formula"
+  conflicts_with "gazebo8", because: "differing version of the same formula"
+  conflicts_with "gazebo9", because: "differing version of the same formula"
+  conflicts_with "gazebo10", because: "differing version of the same formula"
+  conflicts_with "gazebo11", because: "differing version of the same formula"
 
   patch do
     # Fix build when homebrew python is installed

--- a/Formula/gazebo8.rb
+++ b/Formula/gazebo8.rb
@@ -7,9 +7,9 @@ class Gazebo8 < Formula
   revision 5
   version_scheme 1
 
-  head "https://github.com/osrf/gazebo", :branch => "gazebo8"
+  head "https://github.com/osrf/gazebo", branch: "gazebo8"
 
-  deprecate! :date => "2019-01-25"
+  deprecate! date: "2019-01-25"
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
@@ -42,12 +42,12 @@ class Gazebo8 < Formula
   depends_on "gdal" => :optional
   depends_on "player" => :optional
 
-  conflicts_with "gazebo2", :because => "differing version of the same formula"
-  conflicts_with "gazebo3", :because => "differing version of the same formula"
-  conflicts_with "gazebo4", :because => "differing version of the same formula"
-  conflicts_with "gazebo5", :because => "differing version of the same formula"
-  conflicts_with "gazebo6", :because => "differing version of the same formula"
-  conflicts_with "gazebo7", :because => "differing version of the same formula"
+  conflicts_with "gazebo2", because: "differing version of the same formula"
+  conflicts_with "gazebo3", because: "differing version of the same formula"
+  conflicts_with "gazebo4", because: "differing version of the same formula"
+  conflicts_with "gazebo5", because: "differing version of the same formula"
+  conflicts_with "gazebo6", because: "differing version of the same formula"
+  conflicts_with "gazebo7", because: "differing version of the same formula"
 
   patch do
     # Fix for compatibility with boost 1.69

--- a/Formula/gazebo9.rb
+++ b/Formula/gazebo9.rb
@@ -6,7 +6,7 @@ class Gazebo9 < Formula
   license "Apache-2.0"
   revision 1
 
-  head "https://github.com/osrf/gazebo", :branch => "gazebo9"
+  head "https://github.com/osrf/gazebo", branch: "gazebo9"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
@@ -25,7 +25,7 @@ class Gazebo9 < Formula
   depends_on "ignition-msgs1"
   depends_on "ignition-transport4"
   depends_on "libtar"
-  depends_on :macos => :mojave # ogre1.9 missing in highsierra
+  depends_on macos: :mojave # ogre1.9 missing in highsierra
   depends_on "ogre1.9"
   depends_on "ossp-uuid" => :linked
   depends_on "protobuf"
@@ -46,15 +46,15 @@ class Gazebo9 < Formula
   depends_on "gdal" => :optional
   depends_on "player" => :optional
 
-  conflicts_with "gazebo2", :because => "differing version of the same formula"
-  conflicts_with "gazebo3", :because => "differing version of the same formula"
-  conflicts_with "gazebo4", :because => "differing version of the same formula"
-  conflicts_with "gazebo5", :because => "differing version of the same formula"
-  conflicts_with "gazebo6", :because => "differing version of the same formula"
-  conflicts_with "gazebo7", :because => "differing version of the same formula"
-  conflicts_with "gazebo8", :because => "differing version of the same formula"
-  conflicts_with "gazebo10", :because => "differing version of the same formula"
-  conflicts_with "gazebo11", :because => "differing version of the same formula"
+  conflicts_with "gazebo2", because: "differing version of the same formula"
+  conflicts_with "gazebo3", because: "differing version of the same formula"
+  conflicts_with "gazebo4", because: "differing version of the same formula"
+  conflicts_with "gazebo5", because: "differing version of the same formula"
+  conflicts_with "gazebo6", because: "differing version of the same formula"
+  conflicts_with "gazebo7", because: "differing version of the same formula"
+  conflicts_with "gazebo8", because: "differing version of the same formula"
+  conflicts_with "gazebo10", because: "differing version of the same formula"
+  conflicts_with "gazebo11", because: "differing version of the same formula"
 
   patch do
     # Fix build when homebrew python is installed

--- a/Formula/gazebo@1.rb
+++ b/Formula/gazebo@1.rb
@@ -4,11 +4,11 @@ class GazeboAT1 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/gazebo-1.9.7.tar.bz2"
   sha256 "27f3f81d3b11f997e8879e660445e49e81f8d15909ef7352b166c5050c61573a"
   license "Apache-2.0"
-  head "https://github.com/osrf/gazebo", :branch => "gazebo_1.9"
+  head "https://github.com/osrf/gazebo", branch: "gazebo_1.9"
 
   keg_only "old version of gazebo"
 
-  deprecate! :date => "2015-07-27"
+  deprecate! date: "2015-07-27"
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/haptix-comm.rb
+++ b/Formula/haptix-comm.rb
@@ -4,7 +4,7 @@ class HaptixComm < Formula
   url "https://osrf-distributions.s3.amazonaws.com/haptix-comm/releases/haptix-comm-0.9.0.tar.bz2"
   sha256 "d495f65e401fc9e3c8fcbdded347313287c2de55f1605f6b76d02a26b893c08d"
   license "Apache-2.0"
-  head "https://github.com/osrf/haptix-comm", :branch => "master"
+  head "https://github.com/osrf/haptix-comm", branch: "master"
 
   depends_on "cmake" => :build
   depends_on "doxygen" => [:build, :optional]

--- a/Formula/ignition-acropolis.rb
+++ b/Formula/ignition-acropolis.rb
@@ -4,7 +4,7 @@ class IgnitionAcropolis < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-acropolis/releases/ignition-acropolis-1.0.1.tar.bz2"
   sha256 "1d4c81e08bea92f508cd71b7a2af22f0111f205799f888eac6aa8c665e0260fe"
 
-  head "https://github.com/ignitionrobotics/ign-acropolis", :branch => "master"
+  head "https://github.com/ignitionrobotics/ign-acropolis", branch: "master"
 
   depends_on "cmake" => :build
   depends_on "ignition-cmake2"
@@ -21,7 +21,7 @@ class IgnitionAcropolis < Formula
   depends_on "ignition-sensors1"
   depends_on "ignition-tools"
   depends_on "ignition-transport6"
-  depends_on :macos => :mojave # c++17
+  depends_on macos: :mojave # c++17
   depends_on "pkg-config"
   depends_on "sdformat8"
 

--- a/Formula/ignition-blueprint.rb
+++ b/Formula/ignition-blueprint.rb
@@ -5,7 +5,7 @@ class IgnitionBlueprint < Formula
   sha256 "a55860fa37bfb0c357ca86aaa31cd5de42e5f8f9022bced3e827808785e83041"
   revision 2
 
-  head "https://github.com/ignitionrobotics/ign-blueprint", :branch => "master"
+  head "https://github.com/ignitionrobotics/ign-blueprint", branch: "master"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
@@ -28,7 +28,7 @@ class IgnitionBlueprint < Formula
   depends_on "ignition-sensors2"
   depends_on "ignition-tools"
   depends_on "ignition-transport7"
-  depends_on :macos => :mojave # c++17
+  depends_on macos: :mojave # c++17
   depends_on "pkg-config"
   depends_on "sdformat8"
 

--- a/Formula/ignition-citadel.rb
+++ b/Formula/ignition-citadel.rb
@@ -6,7 +6,7 @@ class IgnitionCitadel < Formula
   license "Apache-2.0"
   version_scheme 1
 
-  head "https://github.com/ignitionrobotics/ign-citadel", :branch => "master"
+  head "https://github.com/ignitionrobotics/ign-citadel", branch: "master"
 
   depends_on "cmake" => :build
   depends_on "ignition-cmake2"
@@ -23,7 +23,7 @@ class IgnitionCitadel < Formula
   depends_on "ignition-sensors3"
   depends_on "ignition-tools"
   depends_on "ignition-transport8"
-  depends_on :macos => :mojave # c++17
+  depends_on macos: :mojave # c++17
   depends_on "pkg-config"
   depends_on "sdformat9"
 

--- a/Formula/ignition-cmake0.rb
+++ b/Formula/ignition-cmake0.rb
@@ -5,7 +5,7 @@ class IgnitionCmake0 < Formula
   sha256 "60745d5637a790a244b68c848ded6dd78acb11b542ae302d7ac9b7b629634064"
   license "Apache-2.0"
 
-  head "https://github.com/ignitionrobotics/ign-cmake", :branch => "ign-cmake0"
+  head "https://github.com/ignitionrobotics/ign-cmake", branch: "ign-cmake0"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ignition-cmake1.rb
+++ b/Formula/ignition-cmake1.rb
@@ -5,7 +5,7 @@ class IgnitionCmake1 < Formula
   sha256 "1d9cad25b61774e0cb131fa244cc09b082166c2644b6aeaaa1f20d0d060cc30c"
   license "Apache-2.0"
 
-  head "https://github.com/ignitionrobotics/ign-cmake", :branch => "ign-cmake1"
+  head "https://github.com/ignitionrobotics/ign-cmake", branch: "ign-cmake1"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ignition-common0.rb
+++ b/Formula/ignition-common0.rb
@@ -6,7 +6,7 @@ class IgnitionCommon0 < Formula
   sha256 "4e9c5507a2f480a2e2dc8dd2aaa22e91905791f87745e69f918ab67304ef39a7"
   license "Apache-2.0"
 
-  head "https://github.com/ignitionrobotics/ign-common", :branch => "ign-common0"
+  head "https://github.com/ignitionrobotics/ign-common", branch: "ign-common0"
 
   depends_on "cmake"
   depends_on "ffmpeg"

--- a/Formula/ignition-common1.rb
+++ b/Formula/ignition-common1.rb
@@ -6,7 +6,7 @@ class IgnitionCommon1 < Formula
   license "Apache-2.0"
   revision 3
 
-  head "https://github.com/ignitionrobotics/ign-common", :branch => "ign-common1"
+  head "https://github.com/ignitionrobotics/ign-common", branch: "ign-common1"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ignition-common2.rb
+++ b/Formula/ignition-common2.rb
@@ -5,7 +5,7 @@ class IgnitionCommon2 < Formula
   sha256 "f76ed5a7a86728391bc6d7fb13fb07b61a1106e39d8cb87f3053154432d4b0f6"
   license "Apache-2.0"
 
-  head "https://github.com/ignitionrobotics/ign-common", :branch => "ign-common2"
+  head "https://github.com/ignitionrobotics/ign-common", branch: "ign-common2"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ignition-common3.rb
+++ b/Formula/ignition-common3.rb
@@ -18,7 +18,7 @@ class IgnitionCommon3 < Formula
   depends_on "gts"
   depends_on "ignition-cmake2"
   depends_on "ignition-math6"
-  depends_on :macos => :high_sierra # c++17
+  depends_on macos: :high_sierra # c++17
   depends_on "ossp-uuid"
   depends_on "pkg-config"
   depends_on "tinyxml2"

--- a/Formula/ignition-fuel-tools3.rb
+++ b/Formula/ignition-fuel-tools3.rb
@@ -19,7 +19,7 @@ class IgnitionFuelTools3 < Formula
   depends_on "jsoncpp"
   depends_on "libyaml"
   depends_on "libzip"
-  depends_on :macos => :high_sierra # c++17
+  depends_on macos: :high_sierra # c++17
   depends_on "pkg-config"
 
   def install

--- a/Formula/ignition-fuel-tools4.rb
+++ b/Formula/ignition-fuel-tools4.rb
@@ -20,7 +20,7 @@ class IgnitionFuelTools4 < Formula
   depends_on "jsoncpp"
   depends_on "libyaml"
   depends_on "libzip"
-  depends_on :macos => :high_sierra # c++17
+  depends_on macos: :high_sierra # c++17
   depends_on "pkg-config"
 
   def install

--- a/Formula/ignition-fuel-tools5.rb
+++ b/Formula/ignition-fuel-tools5.rb
@@ -6,7 +6,7 @@ class IgnitionFuelTools5 < Formula
   sha256 "a6eaa557c45938cef64520ab9f434f32701a1a2849260641c1c67d2eab38b096"
   license "Apache-2.0"
 
-  head "https://github.com/ignitionrobotics/ign-fuel-tools", :branch => "master"
+  head "https://github.com/ignitionrobotics/ign-fuel-tools", branch: "master"
 
   depends_on "cmake"
   depends_on "ignition-cmake2"
@@ -15,7 +15,7 @@ class IgnitionFuelTools5 < Formula
   depends_on "jsoncpp"
   depends_on "libyaml"
   depends_on "libzip"
-  depends_on :macos => :high_sierra # c++17
+  depends_on macos: :high_sierra # c++17
   depends_on "pkg-config"
 
   def install

--- a/Formula/ignition-gazebo1.rb
+++ b/Formula/ignition-gazebo1.rb
@@ -6,7 +6,7 @@ class IgnitionGazebo1 < Formula
   license "Apache-2.0"
   revision 1
 
-  head "https://github.com/ignitionrobotics/ign-gazebo", :branch => "ign-gazebo1"
+  head "https://github.com/ignitionrobotics/ign-gazebo", branch: "ign-gazebo1"
 
   depends_on "cmake" => :build
   depends_on "gflags"
@@ -21,11 +21,11 @@ class IgnitionGazebo1 < Formula
   depends_on "ignition-rendering1"
   depends_on "ignition-sensors1"
   depends_on "ignition-transport6"
-  depends_on :macos => :mojave # c++17
+  depends_on macos: :mojave # c++17
   depends_on "pkg-config"
   depends_on "sdformat8"
 
-  conflicts_with "ignition-gazebo2", :because => "both install bin/ign-gazebo symlinks"
+  conflicts_with "ignition-gazebo2", because: "both install bin/ign-gazebo symlinks"
 
   def install
     ENV.m64

--- a/Formula/ignition-gazebo2.rb
+++ b/Formula/ignition-gazebo2.rb
@@ -5,7 +5,7 @@ class IgnitionGazebo2 < Formula
   sha256 "696ab334fa33d7591c01cd11d8fcc45e77de9864d6a33e7f0428b829bd3cfcdb"
   license "Apache-2.0"
 
-  head "https://github.com/ignitionrobotics/ign-gazebo", :branch => "ign-gazebo2"
+  head "https://github.com/ignitionrobotics/ign-gazebo", branch: "ign-gazebo2"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
@@ -26,11 +26,11 @@ class IgnitionGazebo2 < Formula
   depends_on "ignition-rendering2"
   depends_on "ignition-sensors2"
   depends_on "ignition-transport7"
-  depends_on :macos => :mojave # c++17
+  depends_on macos: :mojave # c++17
   depends_on "pkg-config"
   depends_on "sdformat8"
 
-  conflicts_with "ignition-gazebo1", :because => "both install bin/ign-gazebo symlinks"
+  conflicts_with "ignition-gazebo1", because: "both install bin/ign-gazebo symlinks"
 
   def install
     ENV.m64

--- a/Formula/ignition-gazebo3.rb
+++ b/Formula/ignition-gazebo3.rb
@@ -6,7 +6,7 @@ class IgnitionGazebo3 < Formula
   license "Apache-2.0"
   revision 1
 
-  head "https://github.com/ignitionrobotics/ign-gazebo", :branch => "ign-gazebo3"
+  head "https://github.com/ignitionrobotics/ign-gazebo", branch: "ign-gazebo3"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
@@ -27,7 +27,7 @@ class IgnitionGazebo3 < Formula
   depends_on "ignition-rendering3"
   depends_on "ignition-sensors3"
   depends_on "ignition-transport8"
-  depends_on :macos => :mojave # c++17
+  depends_on macos: :mojave # c++17
   depends_on "pkg-config"
   depends_on "sdformat9"
 

--- a/Formula/ignition-gazebo4.rb
+++ b/Formula/ignition-gazebo4.rb
@@ -7,7 +7,7 @@ class IgnitionGazebo4 < Formula
   license "Apache-2.0"
   revision 1
 
-  head "https://github.com/ignitionrobotics/ign-gazebo", :branch => "master"
+  head "https://github.com/ignitionrobotics/ign-gazebo", branch: "master"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
@@ -28,7 +28,7 @@ class IgnitionGazebo4 < Formula
   depends_on "ignition-rendering4"
   depends_on "ignition-sensors4"
   depends_on "ignition-transport9"
-  depends_on :macos => :mojave # c++17
+  depends_on macos: :mojave # c++17
   depends_on "pkg-config"
   depends_on "sdformat10"
 

--- a/Formula/ignition-gui0.rb
+++ b/Formula/ignition-gui0.rb
@@ -6,7 +6,7 @@ class IgnitionGui0 < Formula
   license "Apache-2.0"
   revision 2
 
-  head "https://github.com/ignitionrobotics/ign-gui", :branch => "ign-gui0"
+  head "https://github.com/ignitionrobotics/ign-gui", branch: "ign-gui0"
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
@@ -17,7 +17,7 @@ class IgnitionGui0 < Formula
   depends_on "ignition-msgs2"
   depends_on "ignition-rendering2"
   depends_on "ignition-transport5"
-  depends_on :macos => :high_sierra # c++17
+  depends_on macos: :high_sierra # c++17
   depends_on "qt"
   depends_on "qwt"
   depends_on "tinyxml2"

--- a/Formula/ignition-gui1.rb
+++ b/Formula/ignition-gui1.rb
@@ -6,7 +6,7 @@ class IgnitionGui1 < Formula
   license "Apache-2.0"
   revision 2
 
-  head "https://github.com/ignitionrobotics/ign-gui", :branch => "ign-gui1"
+  head "https://github.com/ignitionrobotics/ign-gui", branch: "ign-gui1"
 
   depends_on "cmake" => :build
   depends_on "ignition-cmake2"
@@ -15,7 +15,7 @@ class IgnitionGui1 < Formula
   depends_on "ignition-plugin1"
   depends_on "ignition-rendering1"
   depends_on "ignition-transport6"
-  depends_on :macos => :high_sierra # c++17
+  depends_on macos: :high_sierra # c++17
   depends_on "pkg-config"
   depends_on "qt"
   depends_on "qwt"

--- a/Formula/ignition-gui2.rb
+++ b/Formula/ignition-gui2.rb
@@ -5,7 +5,7 @@ class IgnitionGui2 < Formula
   sha256 "3e7b5f50e823f29fd3e6f1be030b308497b0100296e08c4e5240a06a58a2ee8c"
   license "Apache-2.0"
 
-  head "https://github.com/ignitionrobotics/ign-gui", :branch => "ign-gui2"
+  head "https://github.com/ignitionrobotics/ign-gui", branch: "ign-gui2"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
@@ -20,7 +20,7 @@ class IgnitionGui2 < Formula
   depends_on "ignition-plugin1"
   depends_on "ignition-rendering2"
   depends_on "ignition-transport7"
-  depends_on :macos => :mojave # c++17
+  depends_on macos: :mojave # c++17
   depends_on "qt"
   depends_on "qwt"
   depends_on "tinyxml2"

--- a/Formula/ignition-gui3.rb
+++ b/Formula/ignition-gui3.rb
@@ -5,7 +5,7 @@ class IgnitionGui3 < Formula
   sha256 "969e3515e055a9f1b743b0366c91fb1e30434efc892cd0195f04689fb33dabe7"
   license "Apache-2.0"
 
-  head "https://github.com/ignitionrobotics/ign-gui", :branch => "ign-gui3"
+  head "https://github.com/ignitionrobotics/ign-gui", branch: "ign-gui3"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
@@ -20,7 +20,7 @@ class IgnitionGui3 < Formula
   depends_on "ignition-plugin1"
   depends_on "ignition-rendering3"
   depends_on "ignition-transport8"
-  depends_on :macos => :mojave # c++17
+  depends_on macos: :mojave # c++17
   depends_on "qt"
   depends_on "qwt"
   depends_on "tinyxml2"

--- a/Formula/ignition-gui4.rb
+++ b/Formula/ignition-gui4.rb
@@ -6,7 +6,7 @@ class IgnitionGui4 < Formula
   sha256 "12a6e69a90f546721fac3ff7e4a0e41705373e3f63508a82599052241573666a"
   license "Apache-2.0"
 
-  head "https://github.com/ignitionrobotics/ign-gui", :branch => "master"
+  head "https://github.com/ignitionrobotics/ign-gui", branch: "master"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
@@ -21,7 +21,7 @@ class IgnitionGui4 < Formula
   depends_on "ignition-plugin1"
   depends_on "ignition-rendering4"
   depends_on "ignition-transport9"
-  depends_on :macos => :mojave # c++17
+  depends_on macos: :mojave # c++17
   depends_on "qt"
   depends_on "qwt"
   depends_on "tinyxml2"

--- a/Formula/ignition-launch2.rb
+++ b/Formula/ignition-launch2.rb
@@ -5,7 +5,7 @@ class IgnitionLaunch2 < Formula
   sha256 "1ff5ed5e5f3216f40eacfcb01f206f989b279393f4ee65a36885c603d01bff29"
   license "Apache-2.0"
 
-  head "https://github.com/ignitionrobotics/ign-launch", :branch => "ign-launch2"
+  head "https://github.com/ignitionrobotics/ign-launch", branch: "ign-launch2"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ignition-launch3.rb
+++ b/Formula/ignition-launch3.rb
@@ -6,7 +6,7 @@ class IgnitionLaunch3 < Formula
   sha256 "2d25ab18e6593a777e77a1e64d398486b712e1ab78cbfca9ec7320af5daac319"
   license "Apache-2.0"
 
-  head "https://github.com/ignitionrobotics/ign-launch", :branch => "master"
+  head "https://github.com/ignitionrobotics/ign-launch", branch: "master"
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/ignition-math2.rb
+++ b/Formula/ignition-math2.rb
@@ -5,7 +5,7 @@ class IgnitionMath2 < Formula
   sha256 "4c007af9efe42908a240895b2a9bcb5c4e570ac0e4ed152c4edd724f86171931"
   license "Apache-2.0"
 
-  head "https://github.com/ignitionrobotics/ign-math", :branch => "ign-math2"
+  head "https://github.com/ignitionrobotics/ign-math", branch: "ign-math2"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/ign-math/releases"
@@ -20,7 +20,7 @@ class IgnitionMath2 < Formula
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
 
-  conflicts_with "ignition-math3", :because => "symbols collision between the two libraries"
+  conflicts_with "ignition-math3", because: "symbols collision between the two libraries"
 
   def install
     system "cmake", ".", *std_cmake_args

--- a/Formula/ignition-math3.rb
+++ b/Formula/ignition-math3.rb
@@ -5,7 +5,7 @@ class IgnitionMath3 < Formula
   sha256 "97bb7f20b64c9a281873ac6fd02932390ca9a0d5709256e671c4db4221a8e051"
   license "Apache-2.0"
 
-  head "https://github.com/ignitionrobotics/ign-math", :branch => "ign-math3"
+  head "https://github.com/ignitionrobotics/ign-math", branch: "ign-math3"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/ign-math/releases"
@@ -20,7 +20,7 @@ class IgnitionMath3 < Formula
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
 
-  conflicts_with "ignition-math2", :because => "symbols collision between the two libraries"
+  conflicts_with "ignition-math2", because: "symbols collision between the two libraries"
 
   def install
     system "cmake", ".", *std_cmake_args

--- a/Formula/ignition-math4.rb
+++ b/Formula/ignition-math4.rb
@@ -5,7 +5,7 @@ class IgnitionMath4 < Formula
   sha256 "5533d1aca0a87450a6ec4770e489bfe24860e6da843b005e594be264c2d6faa0"
   license "Apache-2.0"
 
-  head "https://github.com/ignitionrobotics/ign-math", :branch => "ign-math4"
+  head "https://github.com/ignitionrobotics/ign-math", branch: "ign-math4"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/ign-math/releases"
@@ -20,7 +20,7 @@ class IgnitionMath4 < Formula
   depends_on "doxygen" => :build
   depends_on "ignition-cmake0"
 
-  conflicts_with "ignition-math2", :because => "symbols collision between the two libraries"
+  conflicts_with "ignition-math2", because: "symbols collision between the two libraries"
 
   def install
     system "cmake", ".", *std_cmake_args

--- a/Formula/ignition-math5.rb
+++ b/Formula/ignition-math5.rb
@@ -6,7 +6,7 @@ class IgnitionMath5 < Formula
   license "Apache-2.0"
   version_scheme 1
 
-  head "https://github.com/ignitionrobotics/ign-math", :branch => "ign-math5"
+  head "https://github.com/ignitionrobotics/ign-math", branch: "ign-math5"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
@@ -21,7 +21,7 @@ class IgnitionMath5 < Formula
   depends_on "eigen"
   depends_on "ignition-cmake1"
 
-  conflicts_with "ignition-math2", :because => "symbols collision between the two libraries"
+  conflicts_with "ignition-math2", because: "symbols collision between the two libraries"
 
   def install
     system "cmake", ".", *std_cmake_args

--- a/Formula/ignition-math6.rb
+++ b/Formula/ignition-math6.rb
@@ -18,7 +18,7 @@ class IgnitionMath6 < Formula
   depends_on "eigen"
   depends_on "ignition-cmake2"
 
-  conflicts_with "ignition-math2", :because => "symbols collision between the two libraries"
+  conflicts_with "ignition-math2", because: "symbols collision between the two libraries"
 
   def install
     system "cmake", ".", *std_cmake_args

--- a/Formula/ignition-math@1.rb
+++ b/Formula/ignition-math@1.rb
@@ -4,7 +4,7 @@ class IgnitionMathAT1 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-math/releases/ignition-math-1.0.0.tar.bz2"
   sha256 "5c15bbafdab35d1e0b2f9e43ea13fc665e29c19530c94c89b92a86491128b30a"
   license "Apache-2.0"
-  head "https://github.com/ignitionrobotics/ign-math", :branch => "master"
+  head "https://github.com/ignitionrobotics/ign-math", branch: "master"
 
   depends_on "cmake" => :build
   depends_on "doxygen" => [:build, :optional]

--- a/Formula/ignition-msgs0.rb
+++ b/Formula/ignition-msgs0.rb
@@ -6,7 +6,7 @@ class IgnitionMsgs0 < Formula
   license "Apache-2.0"
   revision 7
 
-  head "https://github.com/ignitionrobotics/ign-msgs", :branch => "ign-msgs0"
+  head "https://github.com/ignitionrobotics/ign-msgs", branch: "ign-msgs0"
 
   depends_on "protobuf-c" => :build
   depends_on "cmake"

--- a/Formula/ignition-msgs1.rb
+++ b/Formula/ignition-msgs1.rb
@@ -7,7 +7,7 @@ class IgnitionMsgs1 < Formula
   revision 8
   version_scheme 1
 
-  head "https://github.com/ignitionrobotics/ign-msgs", :branch => "ign-msgs1"
+  head "https://github.com/ignitionrobotics/ign-msgs", branch: "ign-msgs1"
 
   depends_on "protobuf-c" => :build
   depends_on "cmake"

--- a/Formula/ignition-msgs2.rb
+++ b/Formula/ignition-msgs2.rb
@@ -6,7 +6,7 @@ class IgnitionMsgs2 < Formula
   license "Apache-2.0"
   revision 2
 
-  head "https://github.com/ignitionrobotics/ign-msgs", :branch => "ign-msgs2"
+  head "https://github.com/ignitionrobotics/ign-msgs", branch: "ign-msgs2"
 
   depends_on "protobuf-c" => :build
 
@@ -15,7 +15,7 @@ class IgnitionMsgs2 < Formula
   depends_on "ignition-math5"
   depends_on "ignition-math6"
   depends_on "ignition-tools"
-  depends_on :macos => :high_sierra # c++17
+  depends_on macos: :high_sierra # c++17
   depends_on "pkg-config"
   depends_on "protobuf"
 

--- a/Formula/ignition-msgs3.rb
+++ b/Formula/ignition-msgs3.rb
@@ -12,7 +12,7 @@ class IgnitionMsgs3 < Formula
   depends_on "ignition-cmake2"
   depends_on "ignition-math6"
   depends_on "ignition-tools"
-  depends_on :macos => :high_sierra # c++17
+  depends_on macos: :high_sierra # c++17
   depends_on "pkg-config"
   depends_on "protobuf"
 

--- a/Formula/ignition-msgs4.rb
+++ b/Formula/ignition-msgs4.rb
@@ -12,7 +12,7 @@ class IgnitionMsgs4 < Formula
   depends_on "ignition-cmake2"
   depends_on "ignition-math6"
   depends_on "ignition-tools"
-  depends_on :macos => :high_sierra # c++17
+  depends_on macos: :high_sierra # c++17
   depends_on "pkg-config"
   depends_on "protobuf"
 

--- a/Formula/ignition-msgs5.rb
+++ b/Formula/ignition-msgs5.rb
@@ -12,7 +12,7 @@ class IgnitionMsgs5 < Formula
   depends_on "ignition-cmake2"
   depends_on "ignition-math6"
   depends_on "ignition-tools"
-  depends_on :macos => :high_sierra # c++17
+  depends_on macos: :high_sierra # c++17
   depends_on "pkg-config"
   depends_on "protobuf"
   depends_on "tinyxml2"

--- a/Formula/ignition-msgs6.rb
+++ b/Formula/ignition-msgs6.rb
@@ -6,14 +6,14 @@ class IgnitionMsgs6 < Formula
   sha256 "33aa8c96218f24b8f994659a5edb36f460937e46b95c9d53fba1734bbe7e3ab9"
   license "Apache-2.0"
 
-  head "https://github.com/ignitionrobotics/ign-msgs", :branch => "master"
+  head "https://github.com/ignitionrobotics/ign-msgs", branch: "master"
 
   depends_on "protobuf-c" => :build
   depends_on "cmake"
   depends_on "ignition-cmake2"
   depends_on "ignition-math6"
   depends_on "ignition-tools"
-  depends_on :macos => :high_sierra # c++17
+  depends_on macos: :high_sierra # c++17
   depends_on "pkg-config"
   depends_on "protobuf"
   depends_on "tinyxml2"

--- a/Formula/ignition-physics1.rb
+++ b/Formula/ignition-physics1.rb
@@ -21,7 +21,7 @@ class IgnitionPhysics1 < Formula
   depends_on "ignition-common3"
   depends_on "ignition-math6"
   depends_on "ignition-plugin1"
-  depends_on :macos => :mojave # c++17
+  depends_on macos: :mojave # c++17
   depends_on "pkg-config"
   depends_on "sdformat8"
 

--- a/Formula/ignition-physics2.rb
+++ b/Formula/ignition-physics2.rb
@@ -21,7 +21,7 @@ class IgnitionPhysics2 < Formula
   depends_on "ignition-common3"
   depends_on "ignition-math6"
   depends_on "ignition-plugin1"
-  depends_on :macos => :mojave # c++17
+  depends_on macos: :mojave # c++17
   depends_on "pkg-config"
   depends_on "sdformat9"
 

--- a/Formula/ignition-physics3.rb
+++ b/Formula/ignition-physics3.rb
@@ -2,8 +2,8 @@ class IgnitionPhysics3 < Formula
   desc "Physics library for robotics applications"
   homepage "https://github.com/ignitionrobotics/ign-physics"
   url "https://github.com/ignitionrobotics/ign-physics/archive/061965f69be7077c2ec3732ef4ef6b07f1a8cf06.tar.gz"
-  sha256 "fac94bdc0fb61b0bd6fe398ebce9b6a2525a421e134747772ee0fb7e633e7233"
   version "2.999.999~0~20200731~061965f"
+  sha256 "fac94bdc0fb61b0bd6fe398ebce9b6a2525a421e134747772ee0fb7e633e7233"
   license "Apache-2.0"
   revision 1
 

--- a/Formula/ignition-plugin1.rb
+++ b/Formula/ignition-plugin1.rb
@@ -14,7 +14,7 @@ class IgnitionPlugin1 < Formula
 
   depends_on "cmake"
   depends_on "ignition-cmake2"
-  depends_on :macos => :high_sierra # c++17
+  depends_on macos: :high_sierra # c++17
   depends_on "pkg-config"
 
   def install

--- a/Formula/ignition-rendering0.rb
+++ b/Formula/ignition-rendering0.rb
@@ -6,7 +6,7 @@ class IgnitionRendering0 < Formula
   license "Apache-2.0"
   revision 1
 
-  head "https://github.com/ignitionrobotics/ign-rendering", :branch => "ign-rendering0"
+  head "https://github.com/ignitionrobotics/ign-rendering", branch: "ign-rendering0"
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/ignition-rendering1.rb
+++ b/Formula/ignition-rendering1.rb
@@ -13,7 +13,7 @@ class IgnitionRendering1 < Formula
   depends_on "ignition-common3"
   depends_on "ignition-math6"
   depends_on "ignition-plugin1"
-  depends_on :macos => :high_sierra # c++17
+  depends_on macos: :high_sierra # c++17
   depends_on "ogre1.9"
   depends_on "ogre2.1"
   depends_on "pkg-config"

--- a/Formula/ignition-rendering2.rb
+++ b/Formula/ignition-rendering2.rb
@@ -18,7 +18,7 @@ class IgnitionRendering2 < Formula
   depends_on "ignition-common3"
   depends_on "ignition-math6"
   depends_on "ignition-plugin1"
-  depends_on :macos => :mojave # OpenGL problem on 10.13
+  depends_on macos: :mojave # OpenGL problem on 10.13
   depends_on "ogre1.9"
   depends_on "ogre2.1"
 

--- a/Formula/ignition-rendering3.rb
+++ b/Formula/ignition-rendering3.rb
@@ -18,7 +18,7 @@ class IgnitionRendering3 < Formula
   depends_on "ignition-common3"
   depends_on "ignition-math6"
   depends_on "ignition-plugin1"
-  depends_on :macos => :mojave # c++17
+  depends_on macos: :mojave # c++17
   depends_on "ogre1.9"
   depends_on "ogre2.1"
 

--- a/Formula/ignition-rendering4.rb
+++ b/Formula/ignition-rendering4.rb
@@ -19,7 +19,7 @@ class IgnitionRendering4 < Formula
   depends_on "ignition-common3"
   depends_on "ignition-math6"
   depends_on "ignition-plugin1"
-  depends_on :macos => :mojave # c++17
+  depends_on macos: :mojave # c++17
   depends_on "ogre1.9"
   depends_on "ogre2.1"
 

--- a/Formula/ignition-rndf0.rb
+++ b/Formula/ignition-rndf0.rb
@@ -5,7 +5,7 @@ class IgnitionRndf0 < Formula
   sha256 "ae108308d8a7b4dddfd3a5d23eb3d8a844e1760bf01cb3066cdd45570cf6c26f"
   license "Apache-2.0"
 
-  head "https://github.com/ignitionrobotics/ign-rndf", :branch => "master"
+  head "https://github.com/ignitionrobotics/ign-rndf", branch: "master"
 
   depends_on "cmake" => :build
   depends_on "ignition-cmake0"

--- a/Formula/ignition-sensors1.rb
+++ b/Formula/ignition-sensors1.rb
@@ -6,7 +6,7 @@ class IgnitionSensors1 < Formula
   license "Apache-2.0"
   revision 2
 
-  head "https://github.com/ignitionrobotics/ign-sensors", :branch => "ign-sensors1"
+  head "https://github.com/ignitionrobotics/ign-sensors", branch: "ign-sensors1"
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/ignition-sensors2.rb
+++ b/Formula/ignition-sensors2.rb
@@ -6,7 +6,7 @@ class IgnitionSensors2 < Formula
   license "Apache-2.0"
   revision 1
 
-  head "https://github.com/ignitionrobotics/ign-sensors", :branch => "ign-sensors2"
+  head "https://github.com/ignitionrobotics/ign-sensors", branch: "ign-sensors2"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ignition-sensors3.rb
+++ b/Formula/ignition-sensors3.rb
@@ -6,7 +6,7 @@ class IgnitionSensors3 < Formula
   license "Apache-2.0"
   revision 1
 
-  head "https://github.com/ignitionrobotics/ign-sensors", :branch => "ign-sensors3"
+  head "https://github.com/ignitionrobotics/ign-sensors", branch: "ign-sensors3"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ignition-sensors4.rb
+++ b/Formula/ignition-sensors4.rb
@@ -7,7 +7,7 @@ class IgnitionSensors4 < Formula
   license "Apache-2.0"
   revision 1
 
-  head "https://github.com/ignitionrobotics/ign-sensors", :branch => "master"
+  head "https://github.com/ignitionrobotics/ign-sensors", branch: "master"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ignition-tools.rb
+++ b/Formula/ignition-tools.rb
@@ -4,7 +4,7 @@ class IgnitionTools < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-tools/releases/ignition-tools-1.0.0.tar.bz2"
   sha256 "491e21e08deeb33958743a757828e589741998e014282bf880cd7db7351ccd6e"
   license "Apache-2.0"
-  head "https://github.com/ignitionrobotics/ign-tools", :branch => "ign-tools1"
+  head "https://github.com/ignitionrobotics/ign-tools", branch: "ign-tools1"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ignition-transport.rb
+++ b/Formula/ignition-transport.rb
@@ -6,7 +6,7 @@ class IgnitionTransport < Formula
   license "Apache-2.0"
   revision 10
 
-  head "https://github.com/ignitionrobotics/ign-transport", :branch => "ign-transport1"
+  head "https://github.com/ignitionrobotics/ign-transport", branch: "ign-transport1"
 
   depends_on "cmake" => :build
   depends_on "doxygen" => [:build, :optional]

--- a/Formula/ignition-transport2.rb
+++ b/Formula/ignition-transport2.rb
@@ -6,7 +6,7 @@ class IgnitionTransport2 < Formula
   license "Apache-2.0"
   revision 6
 
-  head "https://github.com/ignitionrobotics/ign-transport", :branch => "ign-transort2"
+  head "https://github.com/ignitionrobotics/ign-transport", branch: "ign-transort2"
 
   depends_on "cmake" => :build
   depends_on "doxygen" => [:build, :optional]

--- a/Formula/ignition-transport3.rb
+++ b/Formula/ignition-transport3.rb
@@ -6,7 +6,7 @@ class IgnitionTransport3 < Formula
   license "Apache-2.0"
   revision 2
 
-  head "https://github.com/ignitionrobotics/ign-transport", :branch => "ign-transport3"
+  head "https://github.com/ignitionrobotics/ign-transport", branch: "ign-transport3"
 
   depends_on "cmake" => :build
   depends_on "doxygen" => [:build, :optional]

--- a/Formula/ignition-transport4.rb
+++ b/Formula/ignition-transport4.rb
@@ -6,7 +6,7 @@ class IgnitionTransport4 < Formula
   license "Apache-2.0"
   revision 7
 
-  head "https://github.com/ignitionrobotics/ign-transport", :branch => "ign-transport4"
+  head "https://github.com/ignitionrobotics/ign-transport", branch: "ign-transport4"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ignition-transport5.rb
+++ b/Formula/ignition-transport5.rb
@@ -15,7 +15,7 @@ class IgnitionTransport5 < Formula
   depends_on "ignition-cmake1"
   depends_on "ignition-msgs2"
   depends_on "ignition-tools"
-  depends_on :macos => :high_sierra # c++17
+  depends_on macos: :high_sierra # c++17
   depends_on "ossp-uuid"
   depends_on "pkg-config"
   depends_on "protobuf"

--- a/Formula/ignition-transport6.rb
+++ b/Formula/ignition-transport6.rb
@@ -14,7 +14,7 @@ class IgnitionTransport6 < Formula
   depends_on "ignition-cmake2"
   depends_on "ignition-msgs3"
   depends_on "ignition-tools"
-  depends_on :macos => :high_sierra # c++17
+  depends_on macos: :high_sierra # c++17
   depends_on "ossp-uuid"
   depends_on "pkg-config"
   depends_on "protobuf"

--- a/Formula/ignition-transport7.rb
+++ b/Formula/ignition-transport7.rb
@@ -19,7 +19,7 @@ class IgnitionTransport7 < Formula
   depends_on "ignition-cmake2"
   depends_on "ignition-msgs4"
   depends_on "ignition-tools"
-  depends_on :macos => :mojave # c++17
+  depends_on macos: :mojave # c++17
   depends_on "ossp-uuid"
   depends_on "pkg-config"
   depends_on "protobuf"

--- a/Formula/ignition-transport8.rb
+++ b/Formula/ignition-transport8.rb
@@ -20,7 +20,7 @@ class IgnitionTransport8 < Formula
   depends_on "ignition-cmake2"
   depends_on "ignition-msgs5"
   depends_on "ignition-tools"
-  depends_on :macos => :high_sierra # c++17
+  depends_on macos: :high_sierra # c++17
   depends_on "ossp-uuid"
   depends_on "pkg-config"
   depends_on "protobuf"

--- a/Formula/ignition-transport9.rb
+++ b/Formula/ignition-transport9.rb
@@ -6,7 +6,7 @@ class IgnitionTransport9 < Formula
   sha256 "a5ab1c8e23877f4485eeed21243ad3bef284846e4be2a4d550ecfdab648a6017"
   license "Apache-2.0"
 
-  head "https://github.com/ignitionrobotics/ign-transport", :branch => "master"
+  head "https://github.com/ignitionrobotics/ign-transport", branch: "master"
 
   depends_on "doxygen" => [:build, :optional]
   depends_on "protobuf-c" => :build
@@ -16,7 +16,7 @@ class IgnitionTransport9 < Formula
   depends_on "ignition-cmake2"
   depends_on "ignition-msgs6"
   depends_on "ignition-tools"
-  depends_on :macos => :high_sierra # c++17
+  depends_on macos: :high_sierra # c++17
   depends_on "ossp-uuid"
   depends_on "pkg-config"
   depends_on "protobuf"

--- a/Formula/ogre.rb
+++ b/Formula/ogre.rb
@@ -18,7 +18,7 @@ class Ogre < Formula
   depends_on "tbb"
   depends_on :x11
 
-  conflicts_with "ogre1.9", :because => "differing version of the same formula"
+  conflicts_with "ogre1.9", because: "differing version of the same formula"
 
   # https://gist.github.com/4237236
   patch do

--- a/Formula/ogre1.9.rb
+++ b/Formula/ogre1.9.rb
@@ -25,7 +25,7 @@ class Ogre19 < Formula
   depends_on "tbb"
   depends_on :x11
 
-  conflicts_with "ogre", :because => "differing version of the same formula"
+  conflicts_with "ogre", because: "differing version of the same formula"
 
   patch do
     url "https://gist.github.com/NikolausDemmel/2b11d1b49b35cd27a102/raw/bf4a4d16020821218f73db0d56aa111ab2fde679/fix-1.9-HEAD.diff"

--- a/Formula/ogre2.1.rb
+++ b/Formula/ogre2.1.rb
@@ -6,7 +6,7 @@ class Ogre21 < Formula
   sha256 "c9580c2380669c1de170612609f2f122c08cd88393a75ad53535e433c8feb72d"
   license "MIT"
 
-  head "https://github.com/OGRECave/ogre-next", :branch => "v2-1"
+  head "https://github.com/OGRECave/ogre-next", branch: "v2-1"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/sdformat.rb
+++ b/Formula/sdformat.rb
@@ -6,7 +6,7 @@ class Sdformat < Formula
   license "Apache-2.0"
   revision 3
 
-  head "https://github.com/osrf/sdformat", :branch => "sdf_2.3", :using => :git
+  head "https://github.com/osrf/sdformat", branch: "sdf_2.3", using: :git
 
   depends_on "cmake" => :build
 
@@ -16,9 +16,9 @@ class Sdformat < Formula
   depends_on "tinyxml"
   depends_on "urdfdom" => :optional
 
-  conflicts_with "sdformat3", :because => "differing version of the same formula"
-  conflicts_with "sdformat4", :because => "differing version of the same formula"
-  conflicts_with "sdformat5", :because => "differing version of the same formula"
+  conflicts_with "sdformat3", because: "differing version of the same formula"
+  conflicts_with "sdformat4", because: "differing version of the same formula"
+  conflicts_with "sdformat5", because: "differing version of the same formula"
 
   def install
     ENV.m64

--- a/Formula/sdformat10.rb
+++ b/Formula/sdformat10.rb
@@ -16,7 +16,7 @@ class Sdformat10 < Formula
 
   depends_on "doxygen"
   depends_on "ignition-math6"
-  depends_on :macos => :mojave # c++17
+  depends_on macos: :mojave # c++17
   # TODO remove dependency on tinyxml after the following is merged:
   # https://github.com/osrf/sdformat/pull/264
   depends_on "tinyxml"

--- a/Formula/sdformat3.rb
+++ b/Formula/sdformat3.rb
@@ -6,7 +6,7 @@ class Sdformat3 < Formula
   license "Apache-2.0"
   revision 5
 
-  head "https://github.com/osrf/sdformat", :branch => "sdf3", :using => :git
+  head "https://github.com/osrf/sdformat", branch: "sdf3", using: :git
 
   depends_on "cmake" => :build
 
@@ -17,9 +17,9 @@ class Sdformat3 < Formula
   depends_on "tinyxml"
   depends_on "urdfdom" => :optional
 
-  conflicts_with "sdformat", :because => "differing version of the same formula"
-  conflicts_with "sdformat4", :because => "differing version of the same formula"
-  conflicts_with "sdformat5", :because => "differing version of the same formula"
+  conflicts_with "sdformat", because: "differing version of the same formula"
+  conflicts_with "sdformat4", because: "differing version of the same formula"
+  conflicts_with "sdformat5", because: "differing version of the same formula"
 
   patch do
     # Fix for cmake 3.9

--- a/Formula/sdformat4.rb
+++ b/Formula/sdformat4.rb
@@ -6,7 +6,7 @@ class Sdformat4 < Formula
   license "Apache-2.0"
   revision 5
 
-  head "https://github.com/osrf/sdformat", :branch => "sdf4", :using => :git
+  head "https://github.com/osrf/sdformat", branch: "sdf4", using: :git
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
@@ -24,11 +24,11 @@ class Sdformat4 < Formula
   depends_on "tinyxml"
   depends_on "urdfdom" => :optional
 
-  conflicts_with "sdformat", :because => "differing version of the same formula"
-  conflicts_with "sdformat3", :because => "differing version of the same formula"
-  conflicts_with "sdformat5", :because => "differing version of the same formula"
-  conflicts_with "sdformat6", :because => "differing version of the same formula"
-  conflicts_with "sdformat7", :because => "differing version of the same formula"
+  conflicts_with "sdformat", because: "differing version of the same formula"
+  conflicts_with "sdformat3", because: "differing version of the same formula"
+  conflicts_with "sdformat5", because: "differing version of the same formula"
+  conflicts_with "sdformat6", because: "differing version of the same formula"
+  conflicts_with "sdformat7", because: "differing version of the same formula"
 
   def install
     ENV.m64

--- a/Formula/sdformat5.rb
+++ b/Formula/sdformat5.rb
@@ -6,7 +6,7 @@ class Sdformat5 < Formula
   license "Apache-2.0"
   revision 5
 
-  head "https://github.com/osrf/sdformat", :branch => "sdf5", :using => :git
+  head "https://github.com/osrf/sdformat", branch: "sdf5", using: :git
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
@@ -24,11 +24,11 @@ class Sdformat5 < Formula
   depends_on "tinyxml"
   depends_on "urdfdom" => :optional
 
-  conflicts_with "sdformat", :because => "differing version of the same formula"
-  conflicts_with "sdformat3", :because => "differing version of the same formula"
-  conflicts_with "sdformat4", :because => "differing version of the same formula"
-  conflicts_with "sdformat6", :because => "differing version of the same formula"
-  conflicts_with "sdformat7", :because => "differing version of the same formula"
+  conflicts_with "sdformat", because: "differing version of the same formula"
+  conflicts_with "sdformat3", because: "differing version of the same formula"
+  conflicts_with "sdformat4", because: "differing version of the same formula"
+  conflicts_with "sdformat6", because: "differing version of the same formula"
+  conflicts_with "sdformat7", because: "differing version of the same formula"
 
   def install
     ENV.m64

--- a/Formula/sdformat6.rb
+++ b/Formula/sdformat6.rb
@@ -6,7 +6,7 @@ class Sdformat6 < Formula
   license "Apache-2.0"
   revision 1
 
-  head "https://github.com/osrf/sdformat", :branch => "sdf6", :using => :git
+  head "https://github.com/osrf/sdformat", branch: "sdf6", using: :git
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
@@ -25,11 +25,11 @@ class Sdformat6 < Formula
   depends_on "tinyxml"
   depends_on "urdfdom" => :optional
 
-  conflicts_with "sdformat", :because => "differing version of the same formula"
-  conflicts_with "sdformat3", :because => "differing version of the same formula"
-  conflicts_with "sdformat4", :because => "differing version of the same formula"
-  conflicts_with "sdformat5", :because => "differing version of the same formula"
-  conflicts_with "sdformat7", :because => "differing version of the same formula"
+  conflicts_with "sdformat", because: "differing version of the same formula"
+  conflicts_with "sdformat3", because: "differing version of the same formula"
+  conflicts_with "sdformat4", because: "differing version of the same formula"
+  conflicts_with "sdformat5", because: "differing version of the same formula"
+  conflicts_with "sdformat7", because: "differing version of the same formula"
 
   def install
     ENV.m64

--- a/Formula/sdformat7.rb
+++ b/Formula/sdformat7.rb
@@ -6,7 +6,7 @@ class Sdformat7 < Formula
   sha256 "f6b67acabb22194ef33df5ef95646ad717f59d737e9e8d473b0d9b674d4c199f"
   license "Apache-2.0"
 
-  head "https://github.com/osrf/sdformat", :branch => "sdf7", :using => :git
+  head "https://github.com/osrf/sdformat", branch: "sdf7", using: :git
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
@@ -25,11 +25,11 @@ class Sdformat7 < Formula
   depends_on "tinyxml"
   depends_on "urdfdom" => :optional
 
-  conflicts_with "sdformat", :because => "differing version of the same formula"
-  conflicts_with "sdformat3", :because => "differing version of the same formula"
-  conflicts_with "sdformat4", :because => "differing version of the same formula"
-  conflicts_with "sdformat5", :because => "differing version of the same formula"
-  conflicts_with "sdformat6", :because => "differing version of the same formula"
+  conflicts_with "sdformat", because: "differing version of the same formula"
+  conflicts_with "sdformat3", because: "differing version of the same formula"
+  conflicts_with "sdformat4", because: "differing version of the same formula"
+  conflicts_with "sdformat5", because: "differing version of the same formula"
+  conflicts_with "sdformat6", because: "differing version of the same formula"
 
   def install
     ENV.m64

--- a/Formula/sdformat8.rb
+++ b/Formula/sdformat8.rb
@@ -16,7 +16,7 @@ class Sdformat8 < Formula
 
   depends_on "doxygen"
   depends_on "ignition-math6"
-  depends_on :macos => :mojave # c++17
+  depends_on macos: :mojave # c++17
   depends_on "tinyxml"
   depends_on "urdfdom"
 

--- a/Formula/sdformat9.rb
+++ b/Formula/sdformat9.rb
@@ -16,7 +16,7 @@ class Sdformat9 < Formula
 
   depends_on "doxygen"
   depends_on "ignition-math6"
-  depends_on :macos => :mojave # c++17
+  depends_on macos: :mojave # c++17
   depends_on "tinyxml"
   depends_on "urdfdom"
 

--- a/Formula/simbody.rb
+++ b/Formula/simbody.rb
@@ -5,7 +5,7 @@ class Simbody < Formula
   sha256 "d371a92d440991400cb8e8e2473277a75307abb916e5aabc14194bea841b804a"
   license "Apache-2.0"
 
-  head "https://github.com/simbody/simbody.git", :branch => "master"
+  head "https://github.com/simbody/simbody.git", branch: "master"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"


### PR DESCRIPTION
A subset of the changes in #1082 that fixes the Ruby 1.9 hash syntax.

I'm submitting as a PR for visibility, but I will merge without CI since it will take too long, and I only used `brew style --fix`