### PR TITLE
acropolis formulae: deprecate and disable soon

### DIFF
--- a/Formula/ignition-acropolis.rb
+++ b/Formula/ignition-acropolis.rb
@@ -6,6 +6,9 @@ class IgnitionAcropolis < Formula
 
   head "https://github.com/ignitionrobotics/ign-acropolis", branch: "master"
 
+  deprecate! date: "2019-09-30"
+  disable! date: "2020-08-31"
+
   depends_on "cmake" => :build
   depends_on "ignition-cmake2"
   depends_on "ignition-common3"

--- a/Formula/ignition-gazebo1.rb
+++ b/Formula/ignition-gazebo1.rb
@@ -8,6 +8,9 @@ class IgnitionGazebo1 < Formula
 
   head "https://github.com/ignitionrobotics/ign-gazebo", branch: "ign-gazebo1"
 
+  deprecate! date: "2019-09-30"
+  disable! date: "2020-08-31"
+
   depends_on "cmake" => :build
   depends_on "gflags"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-gui1.rb
+++ b/Formula/ignition-gui1.rb
@@ -8,6 +8,9 @@ class IgnitionGui1 < Formula
 
   head "https://github.com/ignitionrobotics/ign-gui", branch: "ign-gui1"
 
+  deprecate! date: "2019-09-30"
+  disable! date: "2020-08-31"
+
   depends_on "cmake" => :build
   depends_on "ignition-cmake2"
   depends_on "ignition-common3"

--- a/Formula/ignition-launch0.rb
+++ b/Formula/ignition-launch0.rb
@@ -6,6 +6,9 @@ class IgnitionLaunch0 < Formula
   license "Apache-2.0"
   revision 1
 
+  deprecate! date: "2019-09-30"
+  disable! date: "2020-08-31"
+
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
 

--- a/Formula/ignition-msgs3.rb
+++ b/Formula/ignition-msgs3.rb
@@ -6,6 +6,9 @@ class IgnitionMsgs3 < Formula
   license "Apache-2.0"
   revision 1
 
+  deprecate! date: "2019-09-30"
+  disable! date: "2020-08-31"
+
   depends_on "protobuf-c" => :build
 
   depends_on "cmake"

--- a/Formula/ignition-rendering1.rb
+++ b/Formula/ignition-rendering1.rb
@@ -6,6 +6,9 @@ class IgnitionRendering1 < Formula
   license "Apache-2.0"
   revision 2
 
+  deprecate! date: "2019-09-30"
+  disable! date: "2020-08-31"
+
   depends_on "cmake" => :build
 
   depends_on "freeimage"

--- a/Formula/ignition-sensors1.rb
+++ b/Formula/ignition-sensors1.rb
@@ -8,6 +8,9 @@ class IgnitionSensors1 < Formula
 
   head "https://github.com/ignitionrobotics/ign-sensors", branch: "ign-sensors1"
 
+  deprecate! date: "2019-09-30"
+  disable! date: "2020-08-31"
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
 

--- a/Formula/ignition-transport6.rb
+++ b/Formula/ignition-transport6.rb
@@ -6,6 +6,9 @@ class IgnitionTransport6 < Formula
   license "Apache-2.0"
   revision 2
 
+  deprecate! date: "2019-09-30"
+  disable! date: "2020-08-31"
+
   depends_on "doxygen" => [:build, :optional]
   depends_on "protobuf-c" => :build
 


### PR DESCRIPTION
The software has been EOL since last September, so mark them as deprecated as of that date and that they will be disabled at the end of this month. We will remove them after being disabled for a week or so.