### PR TITLE
ignition-math6: fix build with ruby

### DIFF
--- a/Formula/ignition-math6.rb
+++ b/Formula/ignition-math6.rb
@@ -7,6 +7,7 @@ class IgnitionMath6 < Formula
 
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
+  depends_on "swig" => :build
   depends_on "eigen"
   depends_on "ignition-cmake2"
 

--- a/Formula/ignition-math6.rb
+++ b/Formula/ignition-math6.rb
@@ -10,6 +10,7 @@ class IgnitionMath6 < Formula
   depends_on "swig" => :build
   depends_on "eigen"
   depends_on "ignition-cmake2"
+  depends_on "ruby"
 
   conflicts_with "ignition-math2", because: "symbols collision between the two libraries"
 


### PR DESCRIPTION
Fix the build issue with ruby reported in #1120. Start by adding a `:build` dependency on `swig`.