### PR TITLE
ignition-math6: revert swig dependency

### DIFF
--- a/Formula/ignition-math6.rb
+++ b/Formula/ignition-math6.rb
@@ -7,7 +7,6 @@ class IgnitionMath6 < Formula
 
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
-  depends_on "swig" => :build
   depends_on "eigen"
   depends_on "ignition-cmake2"
   depends_on "ruby"


### PR DESCRIPTION
It's causing CI failures, so revert it for now.