### PR TITLE
dartsim@6.10.0: revision bump to rebuild bottles

### DIFF
--- a/Formula/dartsim@6.10.0.rb
+++ b/Formula/dartsim@6.10.0.rb
@@ -10,8 +10,8 @@ class DartsimAT6100 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "daec204b146f8a9838218e6f60d9a13ad7fbb7ac83e7c186aa63556356636d9f" => :mojave
-    sha256 "5d8c09a237cdc43d6892ddb95982da27b3de3ee4a164ee933e6f497c2d99fbb1" => :high_sierra
+    sha256 "1ffd432953added3124f5c5637694d86671dfcb783635450731ea4352af9f03b" => :mojave
+    sha256 "df64e9d8765fc3099e9c51d0bc4e52c1e86dcb058799a79d22c272bb0044b8a1" => :high_sierra
   end
 
   keg_only "open robotics fork of dart HEAD + custom changes"

--- a/Formula/dartsim@6.10.0.rb
+++ b/Formula/dartsim@6.10.0.rb
@@ -6,7 +6,7 @@ class DartsimAT6100 < Formula
   version "6.10.0~20200916~1673b0be51fb370023df7490dc49706b590d8f72"
   sha256 "ec2e833d3225ac3f4365cc6d8b2f5511170a47d140ff43dcc7d63a50fbb6bfd5"
   license "BSD-2-Clause"
-  revision 2
+  revision 3
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"


### PR DESCRIPTION
The bottles built in #1148 did not get uploaded properly. Let's try building them again with the branch from https://github.com/ignition-tooling/release-tools/pull/281.