### PR TITLE
New formula: Ignition Edifice

### DIFF
--- a/Aliases/ignition-edifice1
+++ b/Aliases/ignition-edifice1
@@ -1,0 +1,1 @@
+../Formula/ignition-edifice.rb

--- a/Formula/ignition-edifice.rb
+++ b/Formula/ignition-edifice.rb
@@ -1,0 +1,43 @@
+class IgnitionEdifice < Formula
+  desc "Collection of gazebo simulation software"
+  homepage "https://github.com/ignitionrobotics/ign-edifice"
+  url "https://github.com/ignitionrobotics/ign-edifice/archive/4d48857070561af742efd68b8d4b13b9903572a8.tar.gz"
+  sha256 "ad648480b1abe1a6bc08c9ece5d422cf21aad4eb27c619fe7519e3673e5b35d5"
+  license "Apache-2.0"
+
+  head "https://github.com/ignitionrobotics/ign-edifice", branch: "main"
+
+  depends_on "cmake" => :build
+  depends_on "ignition-cmake2"
+  depends_on "ignition-common3"
+  depends_on "ignition-fuel-tools5"
+  depends_on "ignition-gazebo4"
+  depends_on "ignition-gui4"
+  depends_on "ignition-launch3"
+  depends_on "ignition-math6"
+  depends_on "ignition-msgs6"
+  depends_on "ignition-physics3"
+  depends_on "ignition-plugin1"
+  depends_on "ignition-rendering4"
+  depends_on "ignition-sensors4"
+  depends_on "ignition-tools"
+  depends_on "ignition-transport9"
+  depends_on macos: :mojave # c++17
+  depends_on "pkg-config"
+  depends_on "sdformat10"
+
+  def install
+    ENV.m64
+
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args
+      system "make", "install"
+    end
+  end
+
+  # Failing test in Mojave
+  # test do
+  # TODO: improve the testing
+  #  system "#{bin}/ign", "gazebo", "--help"
+  # end
+end


### PR DESCRIPTION
At the moment, the dependencies are the same as Dome.

Here's the upstream repo: https://github.com/ignitionrobotics/ign-edifice