### PR TITLE
Patch ignition-cmake2 and rebuild ignition-rendering4 bottle

### DIFF
--- a/Formula/ignition-cmake2.rb
+++ b/Formula/ignition-cmake2.rb
@@ -9,8 +9,7 @@ class IgnitionCmake2 < Formula
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     cellar :any_skip_relocation
-    sha256 "81d46dfd407bf74609a2f305d07ff1e7d12087620f2618259489d4bbbec043d8" => :mojave
-    sha256 "42dcfa0997f00db2ea5ed3f5799cd75f85c4df0705a8a2de708b2669a1ace055" => :high_sierra
+    sha256 "e6322224f0403c1438ae086fc3d84cc66afede6a3d8f552449f84eefb2549164" => :mojave
   end
 
   depends_on "cmake"

--- a/Formula/ignition-cmake2.rb
+++ b/Formula/ignition-cmake2.rb
@@ -4,7 +4,7 @@ class IgnitionCmake2 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-cmake/releases/ignition-cmake2-2.5.0.tar.bz2"
   sha256 "b5ea81835ea398b378edb818083f9dfc08441fadb721e37fc722d7faa9bd63b2"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
@@ -15,6 +15,12 @@ class IgnitionCmake2 < Formula
 
   depends_on "cmake"
   depends_on "pkg-config"
+
+  patch do
+    # Fix for finding ogre2 Overlay library
+    url "https://github.com/ignitionrobotics/ign-cmake/commit/6a646e9201d84d7945b6aad4c12b0fa43d6af6f0.patch?full_index=1"
+    sha256 "893e4174b470e67f9ff0a41ac20d7642d79e00f14581355ec418098d995337b1"
+  end
 
   def install
     cmake_args = std_cmake_args

--- a/Formula/ignition-rendering4.rb
+++ b/Formula/ignition-rendering4.rb
@@ -4,6 +4,7 @@ class IgnitionRendering4 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-rendering/releases/ignition-rendering4-4.1.0.tar.bz2"
   sha256 "d0648fbc71844ee17b17db7faa5d9ae2bceceb65ea4871ea39e43556a949164f"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ignition-rendering4.rb
+++ b/Formula/ignition-rendering4.rb
@@ -8,7 +8,7 @@ class IgnitionRendering4 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "eec5d6b6c68ce426e98834e348959baad660ba4dbd8838c7cbaf3960b2fd9a96" => :mojave
+    sha256 "2b68ee675b1cb34afba1b3a9c16777a29aac2ccba17a740c68faf379ca5609e9" => :mojave
   end
 
   depends_on "cmake" => [:build, :test]


### PR DESCRIPTION
This patches ignition-cmake2 with https://github.com/ignitionrobotics/ign-cmake/pull/125 to fix `FindIgnOGRE2`, which should fix https://github.com/ignitionrobotics/ign-sensors/issues/62 after we have rebuilt the corresponding ignition-rendering bottles. This PR will rebuild `ignition-rendering4`. If it is successful, I will rebuild the other supported versions as well.