### PR TITLE
ignition-rendering[235]: rebuild to fix ogre2

### DIFF
--- a/Formula/ignition-rendering2.rb
+++ b/Formula/ignition-rendering2.rb
@@ -8,7 +8,7 @@ class IgnitionRendering2 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "e994f643c4a05720a7d24df9f744a7a39ab94419579293508c5001f939a1de63" => :mojave
+    sha256 "a1bb44fb98ddb3ad873459ab513fe84ef74fbb6d9388d99646ed06543e487eef" => :mojave
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/ignition-rendering2.rb
+++ b/Formula/ignition-rendering2.rb
@@ -4,6 +4,7 @@ class IgnitionRendering2 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-rendering/releases/ignition-rendering2-2.5.1.tar.bz2"
   sha256 "3d1f77d3e8afc86aee31e12e7e096ac5dc9afcb8faa78be63fa90884a68f9e08"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ignition-rendering3.rb
+++ b/Formula/ignition-rendering3.rb
@@ -8,7 +8,7 @@ class IgnitionRendering3 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "616a528c51ee55fbd0a77fa6824a98ec982155c65ff5ad254647210598c9bbf3" => :mojave
+    sha256 "6f808c45f232606055a18ed82f6884428a193b737d32081fed45404139f57403" => :mojave
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/ignition-rendering3.rb
+++ b/Formula/ignition-rendering3.rb
@@ -4,6 +4,7 @@ class IgnitionRendering3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-rendering/releases/ignition-rendering3-3.2.0.tar.bz2"
   sha256 "425ecc78fae067f9e1b97208f84eb36803881c26c6fd464bcacd9321d529c992"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ignition-rendering5.rb
+++ b/Formula/ignition-rendering5.rb
@@ -9,7 +9,7 @@ class IgnitionRendering5 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "35082f18452e773aa38c5ad2852e6d2f12f97e9a2399497436970f75fa5b4957" => :mojave
+    sha256 "4c9c2a7f06a0b1947dd00acebc67b965823ca04c5b17454009fe206d9f41b739" => :mojave
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/ignition-rendering5.rb
+++ b/Formula/ignition-rendering5.rb
@@ -5,6 +5,7 @@ class IgnitionRendering5 < Formula
   version "4.999.999~0~20201028~d18dd1"
   sha256 "4c97c5eb65b3c939db06176b5d1b3728af69ce17a0bb7ba522fcadcbac6b5c2b"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"


### PR DESCRIPTION
Rebuild `ignition-rendering[235]` now that `ignition-cmake2` is finding ogre2 more properly (#1203).