### PR TITLE
ogre1.9, ogre2.1: use libx11 instead of :x11

### DIFF
--- a/Formula/ignition-rendering2.rb
+++ b/Formula/ignition-rendering2.rb
@@ -8,7 +8,7 @@ class IgnitionRendering2 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "a1bb44fb98ddb3ad873459ab513fe84ef74fbb6d9388d99646ed06543e487eef" => :mojave
+    sha256 "69cfeffcdb2ddbca21e057eda959332286ef5c07981724d30c67d7b8ff36733a" => :mojave
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/ignition-rendering2.rb
+++ b/Formula/ignition-rendering2.rb
@@ -4,7 +4,7 @@ class IgnitionRendering2 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-rendering/releases/ignition-rendering2-2.5.1.tar.bz2"
   sha256 "3d1f77d3e8afc86aee31e12e7e096ac5dc9afcb8faa78be63fa90884a68f9e08"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ignition-rendering3.rb
+++ b/Formula/ignition-rendering3.rb
@@ -8,7 +8,7 @@ class IgnitionRendering3 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "6f808c45f232606055a18ed82f6884428a193b737d32081fed45404139f57403" => :mojave
+    sha256 "f14def506cd46dee2f30fe76c558833983792e2d87b70f90dbf0e80e47357433" => :mojave
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/ignition-rendering3.rb
+++ b/Formula/ignition-rendering3.rb
@@ -4,7 +4,7 @@ class IgnitionRendering3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-rendering/releases/ignition-rendering3-3.2.0.tar.bz2"
   sha256 "425ecc78fae067f9e1b97208f84eb36803881c26c6fd464bcacd9321d529c992"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ignition-rendering4.rb
+++ b/Formula/ignition-rendering4.rb
@@ -4,7 +4,7 @@ class IgnitionRendering4 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-rendering/releases/ignition-rendering4-4.1.0.tar.bz2"
   sha256 "d0648fbc71844ee17b17db7faa5d9ae2bceceb65ea4871ea39e43556a949164f"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ignition-rendering4.rb
+++ b/Formula/ignition-rendering4.rb
@@ -8,7 +8,7 @@ class IgnitionRendering4 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "2b68ee675b1cb34afba1b3a9c16777a29aac2ccba17a740c68faf379ca5609e9" => :mojave
+    sha256 "6a79ec1aa88fbc8ed2003fcb788523b6682403082ac4fb7cd751b5c3b5f9d387" => :mojave
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/ignition-rendering5.rb
+++ b/Formula/ignition-rendering5.rb
@@ -5,6 +5,7 @@ class IgnitionRendering5 < Formula
   version "4.999.999~0~20201130~d4406e"
   sha256 "781a633371a2525ff6f622a275456b72ec40467726dd452deba82aa28422be94"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ignition-rendering5.rb
+++ b/Formula/ignition-rendering5.rb
@@ -9,7 +9,7 @@ class IgnitionRendering5 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "6171f67b376e09c551a6b12c2e87640f27ff0f37859dc0a6e74b16abdf18ddb5" => :mojave
+    sha256 "e0c2d1e10adb832d946831a519a920e6e27c95ee410ea3fd7bf9fd8f4d1f761a" => :mojave
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/ogre1.9.rb
+++ b/Formula/ogre1.9.rb
@@ -5,7 +5,7 @@ class Ogre19 < Formula
   version "1.9-20160714-108ab0bcc69603dba32c0ffd4bbbc39051f421c9"
   sha256 "3ca667b959905b290d782d7f0808e35d075c85db809d3239018e4e10e89b1721"
   license "MIT"
-  revision 8
+  revision 9
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
@@ -21,9 +21,9 @@ class Ogre19 < Formula
   depends_on "doxygen"
   depends_on "freeimage"
   depends_on "freetype"
+  depends_on "libx11"
   depends_on "libzzip"
   depends_on "tbb"
-  depends_on :x11
 
   conflicts_with "ogre", because: "differing version of the same formula"
 

--- a/Formula/ogre1.9.rb
+++ b/Formula/ogre1.9.rb
@@ -9,9 +9,7 @@ class Ogre19 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "a7113b6b6d88fe5755d0c9c809e592d59dcbe99ac7a24a8d76cd0bd69ebbd32f" => :mojave
-    sha256 "0aab13c0c1475912241bb0d26a4148d21e948c025b6b3199715e4e860cb97ef7" => :high_sierra
-    sha256 "ca9a63ea85a41014f49f46de0cb9ef120ae763738313b301e3e91ca09d170f5e" => :sierra
+    sha256 "fd714993552adb0aa6d34eb7b737b929943b88b82daca2b0028586f6ad731ef0" => :mojave
   end
 
   option "with-cg"

--- a/Formula/ogre2.1.rb
+++ b/Formula/ogre2.1.rb
@@ -12,10 +12,7 @@ class Ogre21 < Formula
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     cellar :any
-    rebuild 1
-    sha256 "1c1603e76240f8cccd10f839d67ffa726c8b66b60ceb499249cf84cb850ca2a1" => :mojave
-    sha256 "c300233dd9589c60576fcfb2d4f22dd3c788bdae9cc44550e7d9855bf7ad89e7" => :high_sierra
-    sha256 "553e77a967dbb8e58a2f2033517fe932ad2d6e50ee568e82585b384175eea653" => :sierra
+    sha256 "4641e0d611d87f9c063b26cb11d61c7ad32be62448c6fcd6fc75339c42f563ba" => :mojave
   end
 
   depends_on "cmake" => :build

--- a/Formula/ogre2.1.rb
+++ b/Formula/ogre2.1.rb
@@ -5,6 +5,7 @@ class Ogre21 < Formula
   version "2.0.99999~pre0~0~20180616~06a386f"
   sha256 "c9580c2380669c1de170612609f2f122c08cd88393a75ad53535e433c8feb72d"
   license "MIT"
+  revision 1
 
   head "https://github.com/OGRECave/ogre-next", branch: "v2-1"
 
@@ -22,10 +23,10 @@ class Ogre21 < Formula
   depends_on "doxygen"
   depends_on "freeimage"
   depends_on "freetype"
+  depends_on "libx11"
   depends_on "libzzip"
   depends_on "rapidjson"
   depends_on "tbb"
-  depends_on :x11
 
   patch do
     # fix for cmake3 and c++11


### PR DESCRIPTION
Attempting a fix for #1227.