### PR TITLE
ignition-blueprint: remove disable!

### DIFF
--- a/Formula/ignition-blueprint.rb
+++ b/Formula/ignition-blueprint.rb
@@ -16,8 +16,6 @@ class IgnitionBlueprint < Formula
     sha256 "454a2f24373107bf43de3f449c06a2b99456b0dfc911891919378e9306d1bb99" => :mojave
   end
 
-  disable! date: "2021-01-31", because: "is past end-of-life date"
-
   deprecate! date: "2020-12-31", because: "is past end-of-life date"
 
   depends_on "cmake" => :build

--- a/Formula/ignition-fuel-tools3.rb
+++ b/Formula/ignition-fuel-tools3.rb
@@ -13,8 +13,6 @@ class IgnitionFuelTools3 < Formula
     sha256 "265b4c77b041777ca699bd39263e80fb3b77adb5a7323d64cb303fd545e6c5a6" => :high_sierra
   end
 
-  disable! date: "2021-01-31", because: "is past end-of-life date"
-
   deprecate! date: "2020-12-31", because: "is past end-of-life date"
 
   depends_on "cmake"

--- a/Formula/ignition-gazebo2.rb
+++ b/Formula/ignition-gazebo2.rb
@@ -13,8 +13,6 @@ class IgnitionGazebo2 < Formula
     sha256 "0be73f21beab891fd7ef73d85df055cfe5026f79ce18c38927ced1e84e8998f3" => :mojave
   end
 
-  disable! date: "2021-01-31", because: "is past end-of-life date"
-
   deprecate! date: "2020-12-31", because: "is past end-of-life date"
 
   depends_on "cmake" => :build

--- a/Formula/ignition-gui2.rb
+++ b/Formula/ignition-gui2.rb
@@ -13,8 +13,6 @@ class IgnitionGui2 < Formula
     sha256 "44d542b938257c46e4dbe966fe0fc761bf57d939b4d18399fed52eb006c0ae4c" => :mojave
   end
 
-  disable! date: "2021-01-31", because: "is past end-of-life date"
-
   deprecate! date: "2020-12-31", because: "is past end-of-life date"
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/ignition-launch1.rb
+++ b/Formula/ignition-launch1.rb
@@ -11,8 +11,6 @@ class IgnitionLaunch1 < Formula
     sha256 "89f281e5b8e9f15a800858c668043f2ba237149e1760c851abe3545c0be7f63d" => :mojave
   end
 
-  disable! date: "2021-01-31", because: "is past end-of-life date"
-
   deprecate! date: "2020-12-31", because: "is past end-of-life date"
 
   depends_on "cmake" => :build

--- a/Formula/ignition-msgs4.rb
+++ b/Formula/ignition-msgs4.rb
@@ -12,8 +12,6 @@ class IgnitionMsgs4 < Formula
     sha256 "24b32ba1a5344dce35629e3c4b1b48455c596a2be10ed52dac1da5ce77cb455d" => :mojave
   end
 
-  disable! date: "2021-01-31", because: "is past end-of-life date"
-
   deprecate! date: "2020-12-31", because: "is past end-of-life date"
 
   depends_on "protobuf-c" => :build

--- a/Formula/ignition-physics1.rb
+++ b/Formula/ignition-physics1.rb
@@ -12,8 +12,6 @@ class IgnitionPhysics1 < Formula
     sha256 "4b8eba959f866f7a9c306736eab34f4795de8c1801603b64b21d4000593fd167" => :mojave
   end
 
-  disable! date: "2021-01-31", because: "is past end-of-life date"
-
   deprecate! date: "2020-12-31", because: "is past end-of-life date"
 
   depends_on "cmake" => :build

--- a/Formula/ignition-rendering2.rb
+++ b/Formula/ignition-rendering2.rb
@@ -11,8 +11,6 @@ class IgnitionRendering2 < Formula
     sha256 "69cfeffcdb2ddbca21e057eda959332286ef5c07981724d30c67d7b8ff36733a" => :mojave
   end
 
-  disable! date: "2021-01-31", because: "is past end-of-life date"
-
   deprecate! date: "2020-12-31", because: "is past end-of-life date"
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/ignition-sensors2.rb
+++ b/Formula/ignition-sensors2.rb
@@ -12,8 +12,6 @@ class IgnitionSensors2 < Formula
     sha256 "7ee748d0bce398e8a649568050eedd224d3dbe2b05236f8575dfabbe0e2a32a9" => :mojave
   end
 
-  disable! date: "2021-01-31", because: "is past end-of-life date"
-
   deprecate! date: "2020-12-31", because: "is past end-of-life date"
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/ignition-transport7.rb
+++ b/Formula/ignition-transport7.rb
@@ -10,8 +10,6 @@ class IgnitionTransport7 < Formula
     sha256 "5999b409c28740321def45d0288b9587f04f7712b436cc53eb9fdc3a0eedfba5" => :mojave
   end
 
-  disable! date: "2021-01-31", because: "is past end-of-life date"
-
   deprecate! date: "2020-12-31", because: "is past end-of-life date"
 
   depends_on "doxygen" => [:build, :optional]

--- a/Formula/sdformat8.rb
+++ b/Formula/sdformat8.rb
@@ -11,8 +11,6 @@ class Sdformat8 < Formula
     sha256 "e4e3dc57a7643f665aec5c3ca09e804cfdf8522f8cf23c893e4231570b91dc37" => :mojave
   end
 
-  disable! date: "2021-01-31", because: "is past end-of-life date"
-
   deprecate! date: "2020-12-31", because: "is past end-of-life date"
 
   depends_on "cmake" => [:build, :test]


### PR DESCRIPTION
All the install jobs for the bottles deprecated in #1242 are now failing because the `disable!` method deprecates if it is before the specified date, so it was deprecating them a bit too early. This removes the `disable!` call, so it will not be deprecated until after the deprecate! date. We can re-add the `disable!` line after the deprecation date has passed.