### PR TITLE
Make doxygen an optional build dependency

### DIFF
--- a/Formula/ignition-math6.rb
+++ b/Formula/ignition-math6.rb
@@ -13,7 +13,7 @@ class IgnitionMath6 < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "doxygen" => :build
+  depends_on "doxygen" => [:build, :optional]
   depends_on "eigen"
   depends_on "ignition-cmake2"
   depends_on "ruby"

--- a/Formula/ogre1.9.rb
+++ b/Formula/ogre1.9.rb
@@ -15,8 +15,8 @@ class Ogre19 < Formula
   option "with-cg"
 
   depends_on "cmake" => :build
-  depends_on "boost"
   depends_on "doxygen" => [:build, :optional]
+  depends_on "boost"
   depends_on "freeimage"
   depends_on "freetype"
   depends_on "libx11"

--- a/Formula/ogre1.9.rb
+++ b/Formula/ogre1.9.rb
@@ -16,7 +16,7 @@ class Ogre19 < Formula
 
   depends_on "cmake" => :build
   depends_on "boost"
-  depends_on "doxygen"
+  depends_on "doxygen" => [:build, :optional]
   depends_on "freeimage"
   depends_on "freetype"
   depends_on "libx11"

--- a/Formula/ogre2.1.rb
+++ b/Formula/ogre2.1.rb
@@ -17,7 +17,7 @@ class Ogre21 < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :test
-  depends_on "doxygen"
+  depends_on "doxygen" => [:build, :optional]
   depends_on "freeimage"
   depends_on "freetype"
   depends_on "libx11"

--- a/Formula/ogre2.1.rb
+++ b/Formula/ogre2.1.rb
@@ -16,8 +16,8 @@ class Ogre21 < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "pkg-config" => :test
   depends_on "doxygen" => [:build, :optional]
+  depends_on "pkg-config" => :test
   depends_on "freeimage"
   depends_on "freetype"
   depends_on "libx11"

--- a/Formula/sdformat10.rb
+++ b/Formula/sdformat10.rb
@@ -13,7 +13,7 @@ class Sdformat10 < Formula
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
 
-  depends_on "doxygen"
+  depends_on "doxygen" => [:build, :optional]
   depends_on "ignition-math6"
   depends_on macos: :mojave # c++17
   depends_on "tinyxml2"

--- a/Formula/sdformat10.rb
+++ b/Formula/sdformat10.rb
@@ -11,9 +11,9 @@ class Sdformat10 < Formula
   end
 
   depends_on "cmake" => [:build, :test]
+  depends_on "doxygen" => [:build, :optional]
   depends_on "pkg-config" => [:build, :test]
 
-  depends_on "doxygen" => [:build, :optional]
   depends_on "ignition-math6"
   depends_on macos: :mojave # c++17
   depends_on "tinyxml2"

--- a/Formula/sdformat8.rb
+++ b/Formula/sdformat8.rb
@@ -15,7 +15,7 @@ class Sdformat8 < Formula
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
 
-  depends_on "doxygen"
+  depends_on "doxygen" => [:build, :optional]
   depends_on "ignition-math6"
   depends_on macos: :mojave # c++17
   depends_on "tinyxml"

--- a/Formula/sdformat8.rb
+++ b/Formula/sdformat8.rb
@@ -13,9 +13,9 @@ class Sdformat8 < Formula
   deprecate! date: "2020-12-31", because: "is past end-of-life date"
 
   depends_on "cmake" => [:build, :test]
+  depends_on "doxygen" => [:build, :optional]
   depends_on "pkg-config" => [:build, :test]
 
-  depends_on "doxygen" => [:build, :optional]
   depends_on "ignition-math6"
   depends_on macos: :mojave # c++17
   depends_on "tinyxml"

--- a/Formula/sdformat9.rb
+++ b/Formula/sdformat9.rb
@@ -12,9 +12,9 @@ class Sdformat9 < Formula
   end
 
   depends_on "cmake" => [:build, :test]
+  depends_on "doxygen" => [:build, :optional]
   depends_on "pkg-config" => [:build, :test]
 
-  depends_on "doxygen" => [:build, :optional]
   depends_on "ignition-math6"
   depends_on macos: :mojave # c++17
   depends_on "tinyxml"

--- a/Formula/sdformat9.rb
+++ b/Formula/sdformat9.rb
@@ -14,7 +14,7 @@ class Sdformat9 < Formula
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
 
-  depends_on "doxygen"
+  depends_on "doxygen" => [:build, :optional]
   depends_on "ignition-math6"
   depends_on macos: :mojave # c++17
   depends_on "tinyxml"


### PR DESCRIPTION
This is an attempt at fixing https://github.com/ignitionrobotics/ign-gazebo/issues/520 and unblocking https://github.com/osrf/homebrew-simulation/pull/1254

I think these are the Blueprint / Citadel / Dome formulae which may be bringing doxygen to `ign-gazebo` builds.