### PR TITLE
Depend on qt@5 instead of qt

### DIFF
--- a/Formula/gazebo8.rb
+++ b/Formula/gazebo8.rb
@@ -26,7 +26,7 @@ class Gazebo8 < Formula
   depends_on "ogre1.9"
   depends_on "ossp-uuid" => :linked
   depends_on "protobuf"
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "qwt"
   depends_on "sdformat5"
   depends_on "tbb"

--- a/Formula/ignition-gui0.rb
+++ b/Formula/ignition-gui0.rb
@@ -18,7 +18,7 @@ class IgnitionGui0 < Formula
   depends_on "ignition-rendering2"
   depends_on "ignition-transport5"
   depends_on macos: :high_sierra # c++17
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "qwt"
   depends_on "tinyxml2"
 
@@ -71,7 +71,7 @@ class IgnitionGui0 < Formula
       add_executable(test_cmake test.cpp)
       target_link_libraries(test_cmake ignition-gui0::ignition-gui0)
     EOS
-    ENV.append_path "PKG_CONFIG_PATH", Formula["qt"].opt_lib/"pkgconfig"
+    ENV.append_path "PKG_CONFIG_PATH", Formula["qt@5"].opt_lib/"pkgconfig"
     system "pkg-config", "ignition-gui0"
     cflags   = `pkg-config --cflags ignition-gui0`.split
     ldflags  = `pkg-config --libs ignition-gui0`.split
@@ -83,7 +83,7 @@ class IgnitionGui0 < Formula
     ENV["IGN_PARTITION"] = rand((1 << 32) - 1).to_s
     system "./test"
     # test building with cmake
-    ENV.append_path "CMAKE_PREFIX_PATH", Formula["qt"].opt_prefix
+    ENV.append_path "CMAKE_PREFIX_PATH", Formula["qt@5"].opt_prefix
     mkdir "build" do
       system "cmake", ".."
       system "make"

--- a/Formula/ignition-gui2.rb
+++ b/Formula/ignition-gui2.rb
@@ -26,7 +26,7 @@ class IgnitionGui2 < Formula
   depends_on "ignition-rendering2"
   depends_on "ignition-transport7"
   depends_on macos: :mojave # c++17
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "qwt"
   depends_on "tinyxml2"
 
@@ -87,7 +87,7 @@ class IgnitionGui2 < Formula
       add_executable(test_cmake test.cpp)
       target_link_libraries(test_cmake ignition-gui2::ignition-gui2)
     EOS
-    ENV.append_path "PKG_CONFIG_PATH", Formula["qt"].opt_lib/"pkgconfig"
+    ENV.append_path "PKG_CONFIG_PATH", Formula["qt@5"].opt_lib/"pkgconfig"
     system "pkg-config", "ignition-gui2"
     cflags   = `pkg-config --cflags ignition-gui2`.split
     ldflags  = `pkg-config --libs ignition-gui2`.split
@@ -99,7 +99,7 @@ class IgnitionGui2 < Formula
     ENV["IGN_PARTITION"] = rand((1 << 32) - 1).to_s
     system "./test"
     # test building with cmake
-    ENV.append_path "CMAKE_PREFIX_PATH", Formula["qt"].opt_prefix
+    ENV.append_path "CMAKE_PREFIX_PATH", Formula["qt@5"].opt_prefix
     mkdir "build" do
       system "cmake", ".."
       system "make"

--- a/Formula/ignition-gui3.rb
+++ b/Formula/ignition-gui3.rb
@@ -21,7 +21,7 @@ class IgnitionGui3 < Formula
   depends_on "ignition-rendering3"
   depends_on "ignition-transport8"
   depends_on macos: :mojave # c++17
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "qwt"
   depends_on "tinyxml2"
 
@@ -82,7 +82,7 @@ class IgnitionGui3 < Formula
       add_executable(test_cmake test.cpp)
       target_link_libraries(test_cmake ignition-gui3::ignition-gui3)
     EOS
-    ENV.append_path "PKG_CONFIG_PATH", Formula["qt"].opt_lib/"pkgconfig"
+    ENV.append_path "PKG_CONFIG_PATH", Formula["qt@5"].opt_lib/"pkgconfig"
     system "pkg-config", "ignition-gui3"
     cflags   = `pkg-config --cflags ignition-gui3`.split
     ldflags  = `pkg-config --libs ignition-gui3`.split
@@ -94,7 +94,7 @@ class IgnitionGui3 < Formula
     ENV["IGN_PARTITION"] = rand((1 << 32) - 1).to_s
     system "./test"
     # test building with cmake
-    ENV.append_path "CMAKE_PREFIX_PATH", Formula["qt"].opt_prefix
+    ENV.append_path "CMAKE_PREFIX_PATH", Formula["qt@5"].opt_prefix
     mkdir "build" do
       system "cmake", ".."
       system "make"

--- a/Formula/ignition-gui4.rb
+++ b/Formula/ignition-gui4.rb
@@ -21,7 +21,7 @@ class IgnitionGui4 < Formula
   depends_on "ignition-rendering4"
   depends_on "ignition-transport9"
   depends_on macos: :mojave # c++17
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "qwt"
   depends_on "tinyxml2"
 
@@ -82,7 +82,7 @@ class IgnitionGui4 < Formula
       add_executable(test_cmake test.cpp)
       target_link_libraries(test_cmake ignition-gui4::ignition-gui4)
     EOS
-    ENV.append_path "PKG_CONFIG_PATH", Formula["qt"].opt_lib/"pkgconfig"
+    ENV.append_path "PKG_CONFIG_PATH", Formula["qt@5"].opt_lib/"pkgconfig"
     system "pkg-config", "ignition-gui4"
     cflags   = `pkg-config --cflags ignition-gui4`.split
     ldflags  = `pkg-config --libs ignition-gui4`.split
@@ -94,7 +94,7 @@ class IgnitionGui4 < Formula
     ENV["IGN_PARTITION"] = rand((1 << 32) - 1).to_s
     system "./test"
     # test building with cmake
-    ENV.append_path "CMAKE_PREFIX_PATH", Formula["qt"].opt_prefix
+    ENV.append_path "CMAKE_PREFIX_PATH", Formula["qt@5"].opt_prefix
     mkdir "build" do
       system "cmake", ".."
       system "make"

--- a/Formula/ignition-gui5.rb
+++ b/Formula/ignition-gui5.rb
@@ -23,7 +23,7 @@ class IgnitionGui5 < Formula
   depends_on "ignition-rendering5"
   depends_on "ignition-transport9"
   depends_on macos: :mojave # c++17
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "qwt"
   depends_on "tinyxml2"
 
@@ -84,7 +84,7 @@ class IgnitionGui5 < Formula
       add_executable(test_cmake test.cpp)
       target_link_libraries(test_cmake ignition-gui5::ignition-gui5)
     EOS
-    ENV.append_path "PKG_CONFIG_PATH", Formula["qt"].opt_lib/"pkgconfig"
+    ENV.append_path "PKG_CONFIG_PATH", Formula["qt@5"].opt_lib/"pkgconfig"
     system "pkg-config", "ignition-gui5"
     cflags   = `pkg-config --cflags ignition-gui5`.split
     ldflags  = `pkg-config --libs ignition-gui5`.split
@@ -96,7 +96,7 @@ class IgnitionGui5 < Formula
     ENV["IGN_PARTITION"] = rand((1 << 32) - 1).to_s
     system "./test"
     # test building with cmake
-    ENV.append_path "CMAKE_PREFIX_PATH", Formula["qt"].opt_prefix
+    ENV.append_path "CMAKE_PREFIX_PATH", Formula["qt@5"].opt_prefix
     mkdir "build" do
       system "cmake", ".."
       system "make"

--- a/Formula/ignition-launch2.rb
+++ b/Formula/ignition-launch2.rb
@@ -24,7 +24,7 @@ class IgnitionLaunch2 < Formula
   depends_on "ignition-plugin1"
   depends_on "ignition-tools"
   depends_on "ignition-transport8"
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "tinyxml2"
 
   def install

--- a/Formula/ignition-launch3.rb
+++ b/Formula/ignition-launch3.rb
@@ -23,7 +23,7 @@ class IgnitionLaunch3 < Formula
   depends_on "ignition-plugin1"
   depends_on "ignition-tools"
   depends_on "ignition-transport9"
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "tinyxml2"
 
   def install

--- a/Formula/ignition-launch4.rb
+++ b/Formula/ignition-launch4.rb
@@ -25,7 +25,7 @@ class IgnitionLaunch4 < Formula
   depends_on "ignition-plugin1"
   depends_on "ignition-tools"
   depends_on "ignition-transport9"
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "tinyxml2"
 
   def install

--- a/Formula/sofa.rb
+++ b/Formula/sofa.rb
@@ -15,7 +15,7 @@ class Sofa < Formula
   depends_on "libpng"
   depends_on "libtiff"
   depends_on "libx11"
-  depends_on "qt"
+  depends_on "qt@5"
 
   def install
     # For some reason, cmake must be invoked twice


### PR DESCRIPTION
There is now a qt@5 alias, so use that instead of qt.
Skipping formulae that have active pull requests open.
Part of #1245.