### PR TITLE
ignition-gazebo5: update edifice dependencies

### DIFF
--- a/Formula/ignition-gazebo5.rb
+++ b/Formula/ignition-gazebo5.rb
@@ -8,6 +8,11 @@ class IgnitionGazebo5 < Formula
 
   head "https://github.com/ignitionrobotics/ign-gazebo", branch: "main"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 "1e704f8e7eaa8ae857dfceb47c333dd35d657926e07b979aa806279695092a8c" => :mojave
+  end
+
   depends_on "cmake" => :build
   depends_on "gflags"
   depends_on "google-benchmark"

--- a/Formula/ignition-gazebo5.rb
+++ b/Formula/ignition-gazebo5.rb
@@ -5,7 +5,6 @@ class IgnitionGazebo5 < Formula
   version "4.999.999~0~20210111~64aa64"
   sha256 "29f3433bd386f1ef2ae98b847daf65a166782da2cd6a278343e54f994ca5bc0b"
   license "Apache-2.0"
-  revision 2
 
   head "https://github.com/ignitionrobotics/ign-gazebo", branch: "main"
 

--- a/Formula/ignition-gazebo5.rb
+++ b/Formula/ignition-gazebo5.rb
@@ -1,9 +1,9 @@
 class IgnitionGazebo5 < Formula
   desc "Ignition Gazebo robot simulator"
   homepage "https://github.com/ignitionrobotics/ign-gazebo"
-  url "https://github.com/ignitionrobotics/ign-gazebo/archive/e43f7610859fdd2fcc89047483044f86f067ca0e.tar.gz"
-  version "4.999.999~0~20201028~e43f76"
-  sha256 "41e860861a22040892cdbd6c3cf69d10f59ce693eb8078f233fde63c3b16f9bd"
+  url "https://github.com/ignitionrobotics/ign-gazebo/archive/64aa64f993d7698d5a1488523ff7bac185d9b6f2.tar.gz"
+  version "4.999.999~0~20210111~64aa64"
+  sha256 "29f3433bd386f1ef2ae98b847daf65a166782da2cd6a278343e54f994ca5bc0b"
   license "Apache-2.0"
   revision 2
 
@@ -19,16 +19,16 @@ class IgnitionGazebo5 < Formula
   depends_on "google-benchmark"
   depends_on "ignition-cmake2"
   depends_on "ignition-common3"
-  depends_on "ignition-fuel-tools5"
+  depends_on "ignition-fuel-tools6"
   depends_on "ignition-gui5"
   depends_on "ignition-math6"
-  depends_on "ignition-msgs6"
+  depends_on "ignition-msgs7"
   depends_on "ignition-physics3"
   depends_on "ignition-plugin1"
   depends_on "ignition-rendering5"
   depends_on "ignition-sensors5"
   depends_on "ignition-tools"
-  depends_on "ignition-transport9"
+  depends_on "ignition-transport10"
   depends_on macos: :mojave # c++17
   depends_on "pkg-config"
   depends_on "ruby"


### PR DESCRIPTION
Addressing https://github.com/ignition-tooling/release-tools/issues/362

Uses commit from https://github.com/ignitionrobotics/ign-gazebo/pull/546/commits