### PR TITLE
ignition-launch4: bump edifice dependencies

### DIFF
--- a/Formula/ignition-launch4.rb
+++ b/Formula/ignition-launch4.rb
@@ -1,9 +1,9 @@
 class IgnitionLaunch4 < Formula
   desc "Launch libraries for robotics applications"
   homepage "https://github.com/ignitionrobotics/ign-launch"
-  url "https://github.com/ignitionrobotics/ign-launch/archive/29823c79fa313c67ee50ec6589a656e60f2667a1.tar.gz"
-  version "3.999.999~0~20201028~29823c"
-  sha256 "c2a28509cad17b26bca726c7ae030585c6f9df34c7cdc8481874821fcbbd94ad"
+  url "https://github.com/ignitionrobotics/ign-launch/archive/a097685e4008b1c0331f30d6341ab6e6ea31ed58.tar.gz"
+  version "3.999.999~0~20210111~a09768"
+  sha256 "74250cfafdbe23103282f142b61049ef408af4b5244b35bceb235c6f7669f46c"
   license "Apache-2.0"
   revision 1
 
@@ -21,10 +21,10 @@ class IgnitionLaunch4 < Formula
   depends_on "ignition-common3"
   depends_on "ignition-gazebo5"
   depends_on "ignition-gui5"
-  depends_on "ignition-msgs6"
+  depends_on "ignition-msgs7"
   depends_on "ignition-plugin1"
   depends_on "ignition-tools"
-  depends_on "ignition-transport9"
+  depends_on "ignition-transport10"
   depends_on "qt@5"
   depends_on "tinyxml2"
 

--- a/Formula/ignition-launch4.rb
+++ b/Formula/ignition-launch4.rb
@@ -8,6 +8,11 @@ class IgnitionLaunch4 < Formula
 
   head "https://github.com/ignitionrobotics/ign-launch", branch: "main"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 "5753e590f1d281090c45bb950ff8458dbdcc6985d2af2ce0580c5293d3d97e12" => :mojave
+  end
+
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
 

--- a/Formula/ignition-launch4.rb
+++ b/Formula/ignition-launch4.rb
@@ -5,7 +5,6 @@ class IgnitionLaunch4 < Formula
   version "3.999.999~0~20210111~a09768"
   sha256 "74250cfafdbe23103282f142b61049ef408af4b5244b35bceb235c6f7669f46c"
   license "Apache-2.0"
-  revision 1
 
   head "https://github.com/ignitionrobotics/ign-launch", branch: "main"
 


### PR DESCRIPTION
Addresses https://github.com/ignition-tooling/release-tools/issues/362

Uses commit from https://github.com/ignitionrobotics/ign-launch/pull/86/