### PR TITLE
dartsim@6.10.0: revision bump for bullet

### DIFF
--- a/Formula/dartsim@6.10.0.rb
+++ b/Formula/dartsim@6.10.0.rb
@@ -10,7 +10,7 @@ class DartsimAT6100 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 "c6fb7fba4f30d1837df5202de130456becdd7cdcd7d50ed8061f1c32675fdc91" => :mojave
+    sha256 "e91ee8164b6caafc7714e852adc1d8ae1080413dc239c7e789f82c8c75ddc882" => :mojave
   end
 
   keg_only "open robotics fork of dart HEAD + custom changes"

--- a/Formula/dartsim@6.10.0.rb
+++ b/Formula/dartsim@6.10.0.rb
@@ -6,7 +6,7 @@ class DartsimAT6100 < Formula
   version "6.10.0~20200916~1673b0be51fb370023df7490dc49706b590d8f72"
   sha256 "ec2e833d3225ac3f4365cc6d8b2f5511170a47d140ff43dcc7d63a50fbb6bfd5"
   license "BSD-2-Clause"
-  revision 6
+  revision 7
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"


### PR DESCRIPTION
Similar to https://github.com/Homebrew/homebrew-core/pull/68877, though I don't think this is currently affecting ignition-physics, since we are only using the ODE collision component, not bullet.