### PR TITLE
ignition-physics[23]: rebuild bottles

### DIFF
--- a/Formula/ignition-physics2.rb
+++ b/Formula/ignition-physics2.rb
@@ -4,7 +4,7 @@ class IgnitionPhysics2 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics2-2.3.0.tar.bz2"
   sha256 "c8df67d75d2f299c0f33c06c51844e23155910a9c046612ceaadc7e0d27f0273"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ignition-physics2.rb
+++ b/Formula/ignition-physics2.rb
@@ -6,6 +6,12 @@ class IgnitionPhysics2 < Formula
   license "Apache-2.0"
   revision 3
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, catalina: "eb2e6416103036bf1501d614bc6c0f4a0fba61c582c07163771203f9c2d3e559"
+    sha256 cellar: :any, mojave:   "f76dd223defc2e6d9bfaec325bbd1ed44cc014641dab9020466f2e42d95273a3"
+  end
+
   depends_on "cmake" => :build
 
   depends_on "bullet"

--- a/Formula/ignition-physics3.rb
+++ b/Formula/ignition-physics3.rb
@@ -4,7 +4,7 @@ class IgnitionPhysics3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics3-3.1.0.tar.bz2"
   sha256 "1e914482c636fa35bb79c17d97a908c69aea4e6a8968e70b39b101b185c7132d"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ignition-physics3.rb
+++ b/Formula/ignition-physics3.rb
@@ -6,6 +6,12 @@ class IgnitionPhysics3 < Formula
   license "Apache-2.0"
   revision 3
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, catalina: "da41573a4c1f58d0b009869530da598c1be844abd4c44745f39589a97909db21"
+    sha256 cellar: :any, mojave:   "645551bb4475adb4eead79fe0a653922ce74b7e357d771e0571d04e84c7a4779"
+  end
+
   depends_on "cmake" => :build
 
   depends_on "bullet"


### PR DESCRIPTION
There was unintentional linkage to `icu4c` in these bottles due to https://github.com/Homebrew/homebrew-core/issues/67427. They are now failing due to a new version of `icu4c`, so we need to rebuild them now, but it should only be this once.