### PR TITLE
Disable bottles

### DIFF
--- a/Formula/gazebo10.rb
+++ b/Formula/gazebo10.rb
@@ -8,11 +8,6 @@ class Gazebo10 < Formula
 
   head "https://github.com/osrf/gazebo.git", branch: "gazebo10"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 mojave: "1cc8e89ebfb482ff5f1a90537d4d82073733802d0f806ff92a1514e9028d4f48"
-  end
-
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
 

--- a/Formula/gazebo11.rb
+++ b/Formula/gazebo11.rb
@@ -8,11 +8,6 @@ class Gazebo11 < Formula
 
   head "https://github.com/osrf/gazebo.git", branch: "gazebo11"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 mojave: "0ced9d2ef4728d244e419e1eb96ffc9a51edd26de18ac9f09ce5f6811bafaca5"
-  end
-
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
 

--- a/Formula/gazebo9.rb
+++ b/Formula/gazebo9.rb
@@ -8,11 +8,6 @@ class Gazebo9 < Formula
 
   head "https://github.com/osrf/gazebo.git", branch: "gazebo9"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 mojave: "54dfa3cedec6e3261f365f9cb39936e017c25aebdf138bba2eb1d16bae55bc28"
-  end
-
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
 

--- a/Formula/ignition-blueprint.rb
+++ b/Formula/ignition-blueprint.rb
@@ -9,11 +9,6 @@ class IgnitionBlueprint < Formula
 
   head "https://github.com/ignitionrobotics/ign-blueprint.git", branch: "main"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, mojave: "c0667f15a6db2bafaebf0e23110b2260f5830d524a5216d327dbdabe627050ed"
-  end
-
   disable! date: "2021-01-31", because: "is past end-of-life date"
 
   deprecate! date: "2020-12-31", because: "is past end-of-life date"

--- a/Formula/ignition-citadel.rb
+++ b/Formula/ignition-citadel.rb
@@ -11,11 +11,6 @@ class IgnitionCitadel < Formula
 
   head "https://github.com/ignitionrobotics/ign-citadel.git", branch: "main"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, mojave: "7cce188ae4521322df468e003b14b92bebbb4e20eb96def3e33973eeab59b2d8"
-  end
-
   depends_on "cmake" => :build
   depends_on "ignition-cmake2"
   depends_on "ignition-common3"

--- a/Formula/ignition-dome.rb
+++ b/Formula/ignition-dome.rb
@@ -10,11 +10,6 @@ class IgnitionDome < Formula
 
   head "https://github.com/ignitionrobotics/ign-dome.git", branch: "main"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, mojave: "70e25e1b8551dc73da374565ffde84e8727b5b4859e70e17a6664f2287cf154f"
-  end
-
   depends_on "cmake" => :build
   depends_on "ignition-cmake2"
   depends_on "ignition-common3"

--- a/Formula/ignition-edifice.rb
+++ b/Formula/ignition-edifice.rb
@@ -11,12 +11,6 @@ class IgnitionEdifice < Formula
 
   head "https://github.com/ignitionrobotics/ign-edifice.git", branch: "main"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, catalina: "0e000910cc219b0af23600d8dbdfb810cf97ecd1ff3c9944f4bde7d75d61e1e8"
-    sha256 cellar: :any, mojave:   "3b43559eed5846b52d2d43d29a8a34128777d252deabed25c5f30d844f5101c9"
-  end
-
   depends_on "cmake" => :build
   depends_on "ignition-cmake2"
   depends_on "ignition-common4"

--- a/Formula/ignition-fuel-tools4.rb
+++ b/Formula/ignition-fuel-tools4.rb
@@ -5,11 +5,6 @@ class IgnitionFuelTools4 < Formula
   sha256 "9a54bc749a6dc92909107c2a2c382d9e8cfd32ce005165047c3e9e4445d22d01"
   license "Apache-2.0"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, mojave: "f0c65bba1cb2952cfae13b83779930f294c187c3118560e4bf44a7c00ad7a394"
-  end
-
   depends_on "cmake"
   depends_on "ignition-cmake2"
   depends_on "ignition-common3"

--- a/Formula/ignition-fuel-tools5.rb
+++ b/Formula/ignition-fuel-tools5.rb
@@ -7,11 +7,6 @@ class IgnitionFuelTools5 < Formula
 
   head "https://github.com/ignitionrobotics/ign-fuel-tools.git", branch: "ign-fuel-tools5"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, mojave: "b87635aa99ce07850d2e9e6512558fa171f41f6b200e4b630f6a10e47b23b86d"
-  end
-
   depends_on "cmake"
   depends_on "ignition-cmake2"
   depends_on "ignition-common3"

--- a/Formula/ignition-fuel-tools6.rb
+++ b/Formula/ignition-fuel-tools6.rb
@@ -8,12 +8,6 @@ class IgnitionFuelTools6 < Formula
 
   head "https://github.com/ignitionrobotics/ign-fuel-tools.git", branch: "main"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, catalina: "97a3375ba4c993c0e9189a6e0a246e50523d7966228932c777ce450ef73c0091"
-    sha256 cellar: :any, mojave:   "8e7965622fdcc207e79fcd8a55d1711a94704199b6fa702d68835a8f4aa87c83"
-  end
-
   depends_on "cmake"
   depends_on "ignition-cmake2"
   depends_on "ignition-common4"

--- a/Formula/ignition-gazebo2.rb
+++ b/Formula/ignition-gazebo2.rb
@@ -7,11 +7,6 @@ class IgnitionGazebo2 < Formula
 
   head "https://github.com/ignitionrobotics/ign-gazebo.git", branch: "ign-gazebo2"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 mojave: "e523e84e70436612410f55ec29a2ac3dc0641f6d1fdb52906f5eedac11e7d629"
-  end
-
   disable! date: "2021-01-31", because: "is past end-of-life date"
 
   deprecate! date: "2020-12-31", because: "is past end-of-life date"

--- a/Formula/ignition-gazebo3.rb
+++ b/Formula/ignition-gazebo3.rb
@@ -7,11 +7,6 @@ class IgnitionGazebo3 < Formula
 
   head "https://github.com/ignitionrobotics/ign-gazebo.git", branch: "ign-gazebo3"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 mojave: "ba3460b4a3aac67cf326a2bf80e3a658e4191a6d0d7fea3bdbda98d0cd142fb1"
-  end
-
   depends_on "cmake" => :build
   depends_on "gflags"
   depends_on "google-benchmark"

--- a/Formula/ignition-gazebo4.rb
+++ b/Formula/ignition-gazebo4.rb
@@ -7,12 +7,6 @@ class IgnitionGazebo4 < Formula
 
   head "https://github.com/ignitionrobotics/ign-gazebo.git", branch: "ign-gazebo4"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 catalina: "be80037a7f745f62b8fe31e161a8fb91f2cb2302df78ed5b4fe4e3a643487f6d"
-    sha256 mojave:   "03dcd962e90bb3be2ac077a5873eda546e16ef8c0e9fcb631098e24ca050b686"
-  end
-
   depends_on "cmake" => :build
   depends_on "gflags"
   depends_on "google-benchmark"

--- a/Formula/ignition-gazebo5.rb
+++ b/Formula/ignition-gazebo5.rb
@@ -8,12 +8,6 @@ class IgnitionGazebo5 < Formula
 
   head "https://github.com/ignitionrobotics/ign-gazebo.git", branch: "main"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 catalina: "80537c67f3a31e27f5bfa72318b83a6830c9e3d155afd550fadcc9aba60db05e"
-    sha256 mojave:   "1e8e3422601ee3b8659509bfe859a0614c808920fad8e1552801cb146ccbe49d"
-  end
-
   depends_on "cmake" => :build
   depends_on "gflags"
   depends_on "google-benchmark"

--- a/Formula/ignition-gui2.rb
+++ b/Formula/ignition-gui2.rb
@@ -8,11 +8,6 @@ class IgnitionGui2 < Formula
 
   head "https://github.com/ignitionrobotics/ign-gui.git", branch: "ign-gui2"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 mojave: "44d542b938257c46e4dbe966fe0fc761bf57d939b4d18399fed52eb006c0ae4c"
-  end
-
   disable! date: "2021-01-31", because: "is past end-of-life date"
 
   deprecate! date: "2020-12-31", because: "is past end-of-life date"

--- a/Formula/ignition-gui3.rb
+++ b/Formula/ignition-gui3.rb
@@ -7,11 +7,6 @@ class IgnitionGui3 < Formula
 
   head "https://github.com/ignitionrobotics/ign-gui.git", branch: "ign-gui3"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 mojave: "1356b89a863f2dcbdd6695fdcf267567c8376f71c2f50de64ade9d941f490f5f"
-  end
-
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
   depends_on "ignition-cmake2"

--- a/Formula/ignition-gui4.rb
+++ b/Formula/ignition-gui4.rb
@@ -7,12 +7,6 @@ class IgnitionGui4 < Formula
 
   head "https://github.com/ignitionrobotics/ign-gui.git", branch: "ign-gui4"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 catalina: "5fca9b8b9940ea5ef7f42d56671681848852e41288e7da637e5d1f44b19f4a2b"
-    sha256 mojave:   "10534341ec701bdda7d73d31c3327bda5521013922aee9ff905c3f1b933c738e"
-  end
-
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
   depends_on "ignition-cmake2"

--- a/Formula/ignition-gui5.rb
+++ b/Formula/ignition-gui5.rb
@@ -8,12 +8,6 @@ class IgnitionGui5 < Formula
 
   head "https://github.com/ignitionrobotics/ign-gui.git", branch: "main"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 catalina: "3cdc2190e24c50b29539bab0f82fbfcb83e1b169c3840c896554a894a9c7cea4"
-    sha256 mojave:   "fbf227b01e615daed3c4e5a932f385c1a2f3ac308a2e26d49fde8971da820edf"
-  end
-
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
   depends_on "ignition-cmake2"

--- a/Formula/ignition-launch1.rb
+++ b/Formula/ignition-launch1.rb
@@ -5,11 +5,6 @@ class IgnitionLaunch1 < Formula
   sha256 "99fd3dca44c76c312bbf0e328d5fcf64ebfdab26c20f382e9d6bdb61fe1fe203"
   license "Apache-2.0"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 mojave: "dc68ed8ac85e4f87a151efe209745b9f11b62eadf9f8abd0ab22aff93651a69e"
-  end
-
   disable! date: "2021-01-31", because: "is past end-of-life date"
 
   deprecate! date: "2020-12-31", because: "is past end-of-life date"

--- a/Formula/ignition-launch2.rb
+++ b/Formula/ignition-launch2.rb
@@ -7,11 +7,6 @@ class IgnitionLaunch2 < Formula
 
   head "https://github.com/ignitionrobotics/ign-launch.git", branch: "ign-launch2"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 mojave: "2de70b91fcbac76d41f6e52a58744650bba1560724bf6f244efcdafb166eb971"
-  end
-
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
 

--- a/Formula/ignition-launch3.rb
+++ b/Formula/ignition-launch3.rb
@@ -7,11 +7,6 @@ class IgnitionLaunch3 < Formula
 
   head "https://github.com/ignitionrobotics/ign-launch.git", branch: "ign-launch3"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 mojave: "dbeac3991a09b9fa8a51b3403781c7a8dfcd3e7742b9e2a114f10f9d3648165c"
-  end
-
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
 

--- a/Formula/ignition-launch4.rb
+++ b/Formula/ignition-launch4.rb
@@ -8,12 +8,6 @@ class IgnitionLaunch4 < Formula
 
   head "https://github.com/ignitionrobotics/ign-launch.git", branch: "main"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 catalina: "f2d0538deb17348ee1ec17b2fc3fdc8299de05676db507a92d161fd49d86a095"
-    sha256 mojave:   "b772fb787091e7225af50d525b7c111ee999dec733631be882844fcd44aaf903"
-  end
-
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
 

--- a/Formula/ignition-msgs1.rb
+++ b/Formula/ignition-msgs1.rb
@@ -9,11 +9,6 @@ class IgnitionMsgs1 < Formula
 
   head "https://github.com/ignitionrobotics/ign-msgs.git", branch: "ign-msgs1"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, mojave: "07307209f548dd2840f90ca0d6d2f6afe32c4b39dad454e5f8d80f2e200b65bd"
-  end
-
   depends_on "protobuf-c" => :build
   depends_on "cmake"
   depends_on "ignition-cmake0"

--- a/Formula/ignition-msgs4.rb
+++ b/Formula/ignition-msgs4.rb
@@ -6,11 +6,6 @@ class IgnitionMsgs4 < Formula
   license "Apache-2.0"
   revision 5
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, mojave: "24b32ba1a5344dce35629e3c4b1b48455c596a2be10ed52dac1da5ce77cb455d"
-  end
-
   disable! date: "2021-01-31", because: "is past end-of-life date"
 
   deprecate! date: "2020-12-31", because: "is past end-of-life date"

--- a/Formula/ignition-msgs5.rb
+++ b/Formula/ignition-msgs5.rb
@@ -5,11 +5,6 @@ class IgnitionMsgs5 < Formula
   sha256 "54a08e2b194d9d4857f4930f62c1c66ef85a518a742c60597d91908e91b609ba"
   license "Apache-2.0"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, mojave: "cf7a3a4a3a5757931c7a815f1dab2a07ba56bc11dc8eecadb974ea5ae186abd3"
-  end
-
   depends_on "protobuf-c" => :build
 
   depends_on "cmake"

--- a/Formula/ignition-msgs6.rb
+++ b/Formula/ignition-msgs6.rb
@@ -7,12 +7,6 @@ class IgnitionMsgs6 < Formula
 
   head "https://github.com/ignitionrobotics/ign-msgs.git", branch: "ign-msgs6"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, catalina: "d85d27b9073f51b59cb0ced199b8f0cf00fb8ff58b8c21bcc16968806efc3553"
-    sha256 cellar: :any, mojave:   "0c711a94f9771f4677d641887d9835644cf95e12bdae96f9b0a122680a6ae0c8"
-  end
-
   depends_on "protobuf-c" => :build
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-msgs7.rb
+++ b/Formula/ignition-msgs7.rb
@@ -8,12 +8,6 @@ class IgnitionMsgs7 < Formula
 
   head "https://github.com/ignitionrobotics/ign-msgs.git", branch: "main"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, catalina: "bc28c4265ae0ca2312441e1fad831f423f7d830c5e569b6a828b68f7f2eb026a"
-    sha256 cellar: :any, mojave:   "4e2c3297b873e033bd94d64a958c4e6b20f89dc3506fe8752c2e2a74715fb8ac"
-  end
-
   depends_on "protobuf-c" => :build
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-physics2.rb
+++ b/Formula/ignition-physics2.rb
@@ -6,11 +6,6 @@ class IgnitionPhysics2 < Formula
   license "Apache-2.0"
   revision 2
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, mojave: "7ffb1499167f27f5ab35efa3e6239196bae21ba31ec01cd86b504df8eb9d1b04"
-  end
-
   depends_on "cmake" => :build
 
   depends_on "bullet"

--- a/Formula/ignition-physics3.rb
+++ b/Formula/ignition-physics3.rb
@@ -6,11 +6,6 @@ class IgnitionPhysics3 < Formula
   license "Apache-2.0"
   revision 2
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, mojave: "45278b375a9d4ac6f33d27358b6eda90e88312222c09cc2a4248c237952d5c4c"
-  end
-
   depends_on "cmake" => :build
 
   depends_on "bullet"

--- a/Formula/ignition-sensors2.rb
+++ b/Formula/ignition-sensors2.rb
@@ -7,11 +7,6 @@ class IgnitionSensors2 < Formula
 
   head "https://github.com/ignitionrobotics/ign-sensors.git", branch: "ign-sensors2"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 mojave: "7ee748d0bce398e8a649568050eedd224d3dbe2b05236f8575dfabbe0e2a32a9"
-  end
-
   disable! date: "2021-01-31", because: "is past end-of-life date"
 
   deprecate! date: "2020-12-31", because: "is past end-of-life date"

--- a/Formula/ignition-sensors3.rb
+++ b/Formula/ignition-sensors3.rb
@@ -7,12 +7,6 @@ class IgnitionSensors3 < Formula
 
   head "https://github.com/ignitionrobotics/ign-sensors.git", branch: "ign-sensors3"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 catalina: "5eafcebec21ff2a6729cade346ea9ed1f534d55133ba4302dbc282909e34d2ea"
-    sha256 mojave:   "122d304ee9173d09d962c97425cb0480b024858824922bac0cac27d055c73a5c"
-  end
-
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
 

--- a/Formula/ignition-sensors4.rb
+++ b/Formula/ignition-sensors4.rb
@@ -7,12 +7,6 @@ class IgnitionSensors4 < Formula
 
   head "https://github.com/ignitionrobotics/ign-sensors.git", branch: "ign-sensors4"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 catalina: "d7a65596d513d9868b4a6d3f1e8a7f9a326330f2e52fcf4a53a94ac72b92fab6"
-    sha256 mojave:   "7f847b3cb958ed7f2c0ac8477f5e60cca6476b604f95b82c6963cb9971edfa16"
-  end
-
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
 

--- a/Formula/ignition-sensors5.rb
+++ b/Formula/ignition-sensors5.rb
@@ -8,12 +8,6 @@ class IgnitionSensors5 < Formula
 
   head "https://github.com/ignitionrobotics/ign-sensors.git", branch: "main"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 catalina: "9e3bcb76b41e9664ab39ae47ce1f8d7d612f1919e826fd6eb73057cffa66e54c"
-    sha256 mojave:   "59c7c5283974dbfd3af46eb7527f807bd0253f65fd2afccde4fc6d342a26b0e2"
-  end
-
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
 

--- a/Formula/ignition-transport10.rb
+++ b/Formula/ignition-transport10.rb
@@ -9,11 +9,6 @@ class IgnitionTransport10 < Formula
 
   head "https://github.com/ignitionrobotics/ign-transport.git", branch: "main"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 mojave: "4f5755f629417941df79099edc268149aeef5b1238f96eb3ca92a658bba0d542"
-  end
-
   depends_on "doxygen" => [:build, :optional]
   depends_on "protobuf-c" => :build
 

--- a/Formula/ignition-transport4.rb
+++ b/Formula/ignition-transport4.rb
@@ -8,11 +8,6 @@ class IgnitionTransport4 < Formula
 
   head "https://github.com/ignitionrobotics/ign-transport.git", branch: "ign-transport4"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, mojave: "21cfcc7a235d1a1872741092a86495d3200a7c4ce25d2196cde610f682d8ddaf"
-  end
-
   depends_on "doxygen" => [:build, :optional]
 
   depends_on "protobuf-c" => :build

--- a/Formula/ignition-transport7.rb
+++ b/Formula/ignition-transport7.rb
@@ -5,11 +5,6 @@ class IgnitionTransport7 < Formula
   sha256 "7bcf66c1bf2f6d0617240d435df9a4176606f85705ecb82a253a7d54dd2f31e4"
   license "Apache-2.0"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 mojave: "5999b409c28740321def45d0288b9587f04f7712b436cc53eb9fdc3a0eedfba5"
-  end
-
   disable! date: "2021-01-31", because: "is past end-of-life date"
 
   deprecate! date: "2020-12-31", because: "is past end-of-life date"

--- a/Formula/ignition-transport8.rb
+++ b/Formula/ignition-transport8.rb
@@ -5,11 +5,6 @@ class IgnitionTransport8 < Formula
   sha256 "cff732a797ea08fdb4834331bea14ae50d1cbdd63efae613a475bc42f32e29b3"
   license "Apache-2.0"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 mojave: "4866bd005f5b5fe2359362746f929404a5e339180913eb2da107cd8c3213ba67"
-  end
-
   depends_on "doxygen" => [:build, :optional]
   depends_on "protobuf-c" => :build
 

--- a/Formula/ignition-transport9.rb
+++ b/Formula/ignition-transport9.rb
@@ -8,11 +8,6 @@ class IgnitionTransport9 < Formula
 
   head "https://github.com/ignitionrobotics/ign-transport.git", branch: "ign-transport9"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 mojave: "8d438b8b92f979e1b8476481d7d8ede44023db03ba05db33e267e4396205a161"
-  end
-
   depends_on "doxygen" => [:build, :optional]
   depends_on "protobuf-c" => :build
 


### PR DESCRIPTION
We have a lot of broken bottles due to protobuf and an icu4c change. This disables them so they should build from source while we rebuild them.