### PR TITLE
Remove asymmetric conflicts_with statements

### DIFF
--- a/Formula/gazebo10.rb
+++ b/Formula/gazebo10.rb
@@ -41,16 +41,6 @@ class Gazebo10 < Formula
   depends_on "gdal" => :optional
   depends_on "player" => :optional
 
-  conflicts_with "gazebo2", because: "differing version of the same formula"
-  conflicts_with "gazebo3", because: "differing version of the same formula"
-  conflicts_with "gazebo4", because: "differing version of the same formula"
-  conflicts_with "gazebo5", because: "differing version of the same formula"
-  conflicts_with "gazebo6", because: "differing version of the same formula"
-  conflicts_with "gazebo7", because: "differing version of the same formula"
-  conflicts_with "gazebo8", because: "differing version of the same formula"
-  conflicts_with "gazebo9", because: "differing version of the same formula"
-  conflicts_with "gazebo11", because: "differing version of the same formula"
-
   patch do
     # set CMP0100
     url "https://github.com/osrf/gazebo/commit/2e4f1b185cb46b2c06fe63881d60f3fbeb868923.patch?full_index=1"

--- a/Formula/gazebo11.rb
+++ b/Formula/gazebo11.rb
@@ -46,15 +46,8 @@ class Gazebo11 < Formula
   depends_on "gdal" => :optional
   depends_on "player" => :optional
 
-  conflicts_with "gazebo2", because: "differing version of the same formula"
-  conflicts_with "gazebo3", because: "differing version of the same formula"
-  conflicts_with "gazebo4", because: "differing version of the same formula"
-  conflicts_with "gazebo5", because: "differing version of the same formula"
-  conflicts_with "gazebo6", because: "differing version of the same formula"
   conflicts_with "gazebo7", because: "differing version of the same formula"
-  conflicts_with "gazebo8", because: "differing version of the same formula"
   conflicts_with "gazebo9", because: "differing version of the same formula"
-  conflicts_with "gazebo10", because: "differing version of the same formula"
 
   patch do
     # Fix build when homebrew python is installed

--- a/Formula/gazebo7.rb
+++ b/Formula/gazebo7.rb
@@ -41,7 +41,6 @@ class Gazebo7 < Formula
   conflicts_with "gazebo6", because: "differing version of the same formula"
   conflicts_with "gazebo8", because: "differing version of the same formula"
   conflicts_with "gazebo9", because: "differing version of the same formula"
-  conflicts_with "gazebo10", because: "differing version of the same formula"
   conflicts_with "gazebo11", because: "differing version of the same formula"
 
   patch do

--- a/Formula/gazebo9.rb
+++ b/Formula/gazebo9.rb
@@ -46,14 +46,7 @@ class Gazebo9 < Formula
   depends_on "gdal" => :optional
   depends_on "player" => :optional
 
-  conflicts_with "gazebo2", because: "differing version of the same formula"
-  conflicts_with "gazebo3", because: "differing version of the same formula"
-  conflicts_with "gazebo4", because: "differing version of the same formula"
-  conflicts_with "gazebo5", because: "differing version of the same formula"
-  conflicts_with "gazebo6", because: "differing version of the same formula"
   conflicts_with "gazebo7", because: "differing version of the same formula"
-  conflicts_with "gazebo8", because: "differing version of the same formula"
-  conflicts_with "gazebo10", because: "differing version of the same formula"
   conflicts_with "gazebo11", because: "differing version of the same formula"
 
   patch do

--- a/Formula/ignition-math4.rb
+++ b/Formula/ignition-math4.rb
@@ -19,8 +19,6 @@ class IgnitionMath4 < Formula
   depends_on "doxygen" => :build
   depends_on "ignition-cmake0"
 
-  conflicts_with "ignition-math2", because: "symbols collision between the two libraries"
-
   def install
     system "cmake", ".", *std_cmake_args
     system "make", "install"

--- a/Formula/ignition-math5.rb
+++ b/Formula/ignition-math5.rb
@@ -20,8 +20,6 @@ class IgnitionMath5 < Formula
   depends_on "eigen"
   depends_on "ignition-cmake1"
 
-  conflicts_with "ignition-math2", because: "symbols collision between the two libraries"
-
   def install
     system "cmake", ".", *std_cmake_args
     system "make", "install"

--- a/Formula/ignition-math6.rb
+++ b/Formula/ignition-math6.rb
@@ -17,8 +17,6 @@ class IgnitionMath6 < Formula
   depends_on "ignition-cmake2"
   depends_on "ruby"
 
-  conflicts_with "ignition-math2", because: "symbols collision between the two libraries"
-
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"

--- a/Formula/sdformat6.rb
+++ b/Formula/sdformat6.rb
@@ -24,8 +24,6 @@ class Sdformat6 < Formula
   depends_on "tinyxml"
   depends_on "urdfdom" => :optional
 
-  conflicts_with "sdformat", because: "differing version of the same formula"
-  conflicts_with "sdformat3", because: "differing version of the same formula"
   conflicts_with "sdformat4", because: "differing version of the same formula"
   conflicts_with "sdformat5", because: "differing version of the same formula"
   conflicts_with "sdformat7", because: "differing version of the same formula"

--- a/Formula/sdformat7.rb
+++ b/Formula/sdformat7.rb
@@ -18,8 +18,6 @@ class Sdformat7 < Formula
   depends_on "tinyxml"
   depends_on "urdfdom" => :optional
 
-  conflicts_with "sdformat", because: "differing version of the same formula"
-  conflicts_with "sdformat3", because: "differing version of the same formula"
   conflicts_with "sdformat4", because: "differing version of the same formula"
   conflicts_with "sdformat5", because: "differing version of the same formula"
   conflicts_with "sdformat6", because: "differing version of the same formula"


### PR DESCRIPTION
A recent change to brew audit disallows asymmetric
conflicts_with statements. Since these all involve
old formulae, this removes the conflicts_with
statements rather than trying to make them symmetric.

Fixes #1518.