### PR TITLE
sdformat12: build from source

### DIFF
--- a/Formula/sdformat12.rb
+++ b/Formula/sdformat12.rb
@@ -2,7 +2,7 @@ class Sdformat12 < Formula
   desc "Simulation Description Format"
   homepage "http://sdformat.org"
   url "https://github.com/osrf/sdformat.git", branch: "main"
-  version "11.999.999~2"
+  version "11.999.999~1"
   license "Apache-2.0"
   revision 1
 

--- a/Formula/sdformat12.rb
+++ b/Formula/sdformat12.rb
@@ -2,15 +2,9 @@ class Sdformat12 < Formula
   desc "Simulation Description Format"
   homepage "http://sdformat.org"
   url "https://github.com/osrf/sdformat.git", branch: "main"
-  version "11.999.999~1"
+  version "11.999.999~2"
   license "Apache-2.0"
   revision 1
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 catalina: "3bb0ef4fc4774d980775dcb66a8fdf0eddca9dbfa62f63df4d7b591dcbbe0730"
-    sha256 mojave:   "630966a6f083fef0b9d59764cac893e530e77e54ad521625fa4b727c85b542e6"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]


### PR DESCRIPTION
Since https://github.com/osrf/homebrew-simulation/pull/1459 the bottle is being built from main, which is much easier than picking a commit and getting the hash.

But since a bottle is built, I think we still need to open this kind of PR to update the revision. Can we just not build a bottle, @scpeters ?

This is needed by https://github.com/ignitionrobotics/ign-gazebo/pull/888