### PR TITLE
Add cocoa windowing patch to ogre 2.1 formula

### DIFF
--- a/Formula/ogre2.1.rb
+++ b/Formula/ogre2.1.rb
@@ -36,6 +36,12 @@ class Ogre21 < Formula
     sha256 "8fe5beab9e50dfe1f0164e8dbffd20a79f5e9afe79802ab0ce29d8d83e4e0fe8"
   end
 
+  patch do
+    # [GL3+] add support for currentGLContext for macOS
+    url "https://github.com/OGRECave/ogre-next/commit/79be9e99991c61d39c52588f24443cf36d621f0b.patch?full_index=1"
+    sha256 "2e45ea3025062d6ac26946716318dd9e0f5625977513463a5c151d2049bf316c"
+  end
+
   def install
     cmake_args = [
       "-DOGRE_LIB_DIRECTORY=lib/OGRE-2.1",

--- a/Formula/ogre2.1.rb
+++ b/Formula/ogre2.1.rb
@@ -37,9 +37,9 @@ class Ogre21 < Formula
   end
 
   patch do
-    # [GL3+] add support for currentGLContext for macOS
-    url "https://github.com/OGRECave/ogre-next/commit/79be9e99991c61d39c52588f24443cf36d621f0b.patch?full_index=1"
-    sha256 "2e45ea3025062d6ac26946716318dd9e0f5625977513463a5c151d2049bf316c"
+    # fix GL3+ cocoa window and useCurrentGLContext
+    url "https://github.com/ignition-forks/ogre-2.1-release/compare/b4c4fa785c03c2d4ba2a1d28d94394c7ca000358..81632330e3ab041345c7fa1075022cf6af30c658.diff"
+    sha256 "9a855a9e60bc81874e3d1501094e1fcc46d296ac964ca8985ddeb1035fe05cd2"
   end
 
   def install

--- a/Formula/ogre2.1.rb
+++ b/Formula/ogre2.1.rb
@@ -11,7 +11,9 @@ class Ogre21 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, mojave: "4641e0d611d87f9c063b26cb11d61c7ad32be62448c6fcd6fc75339c42f563ba"
+    rebuild 1
+    sha256 cellar: :any, catalina: "d29874b82f0f942bd7d2453e145cd74382734a1d4161b25d7ac0e8efd4b41928"
+    sha256 cellar: :any, mojave:   "f0b505985d282e7dd8b1aecc7daf51ff15c8fbb58b4b30c556fbc139ec878075"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
Adds changes from ~~this pull request: https://github.com/OGRECave/ogre-next/pull/216~~
https://github.com/ignition-forks/ogre-2.1-release/compare/b4c4fa785c03c2d4ba2a1d28d94394c7ca000358..81632330e3ab041345c7fa1075022cf6af30c658

This allows the ignition gazebo gui to work on macOS.

Signed-off-by: Ian Chen <ichen@osrfoundation.org>