### PR TITLE
ignition-gui[345]: rm qwt dependency

### DIFF
--- a/Formula/ignition-gui3.rb
+++ b/Formula/ignition-gui3.rb
@@ -4,6 +4,7 @@ class IgnitionGui3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gui/releases/ignition-gui3-3.7.0.tar.bz2"
   sha256 "2b0f11cd3de51d5659016526c3858c930dff7c9aee2957a806c875ccf00da03e"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/ignitionrobotics/ign-gui.git", branch: "ign-gui3"
 

--- a/Formula/ignition-gui3.rb
+++ b/Formula/ignition-gui3.rb
@@ -10,8 +10,8 @@ class IgnitionGui3 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 catalina: "01e3c08c28fc320e634ee46c890c319d083e80d6099071e994cd20685d9771e9"
-    sha256 mojave:   "922656b1a397e86023522e82d6727605621603daed23c99fede9bea04cd1e7f0"
+    sha256 catalina: "4839a832edbae59e80735e6e1eac0e6f86355e84ff919664452290e541e9e792"
+    sha256 mojave:   "6d3871242421e00a9968c57d1fa46bb6b8f902895d7a61b4022a6a8c564db333"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/ignition-gui3.rb
+++ b/Formula/ignition-gui3.rb
@@ -23,13 +23,10 @@ class IgnitionGui3 < Formula
   depends_on "ignition-transport8"
   depends_on macos: :mojave # c++17
   depends_on "qt@5"
-  depends_on "qwt"
   depends_on "tinyxml2"
 
   def install
     cmake_args = std_cmake_args
-    cmake_args << "-DQWT_WIN_INCLUDE_DIR=#{HOMEBREW_PREFIX}/lib/qwt.framework/Headers"
-    cmake_args << "-DQWT_WIN_LIBRARY_DIR=#{HOMEBREW_PREFIX}/lib/qwt.framework"
     cmake_args << "-DBUILD_TESTING=Off"
 
     mkdir "build" do

--- a/Formula/ignition-gui4.rb
+++ b/Formula/ignition-gui4.rb
@@ -4,6 +4,7 @@ class IgnitionGui4 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gui/releases/ignition-gui4-4.5.0.tar.bz2"
   sha256 "6b1e96fe502813df10d05569218bc2c64919c879122539b133489b7b5895f2cc"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/ignitionrobotics/ign-gui.git", branch: "ign-gui4"
 

--- a/Formula/ignition-gui4.rb
+++ b/Formula/ignition-gui4.rb
@@ -23,13 +23,10 @@ class IgnitionGui4 < Formula
   depends_on "ignition-transport9"
   depends_on macos: :mojave # c++17
   depends_on "qt@5"
-  depends_on "qwt"
   depends_on "tinyxml2"
 
   def install
     cmake_args = std_cmake_args
-    cmake_args << "-DQWT_WIN_INCLUDE_DIR=#{HOMEBREW_PREFIX}/lib/qwt.framework/Headers"
-    cmake_args << "-DQWT_WIN_LIBRARY_DIR=#{HOMEBREW_PREFIX}/lib/qwt.framework"
     cmake_args << "-DBUILD_TESTING=Off"
 
     mkdir "build" do

--- a/Formula/ignition-gui4.rb
+++ b/Formula/ignition-gui4.rb
@@ -10,8 +10,8 @@ class IgnitionGui4 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 catalina: "902f194db7b36b71759f7395cdfffd5f762fbfa3b0e486ce21109f25cd181aa1"
-    sha256 mojave:   "8fdf616efd1d53f3d1127d5c43115e15938768dbb6376bed5f180688223936d2"
+    sha256 catalina: "b6bc9e87243fab42c034670b92c5425752e1c3f6e4d471b646f776e8efc03587"
+    sha256 mojave:   "2da199bc1ec38f3b80c764192097f40ba1a46afb86370befb1a0ce16b92afbaf"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/ignition-gui5.rb
+++ b/Formula/ignition-gui5.rb
@@ -23,13 +23,10 @@ class IgnitionGui5 < Formula
   depends_on "ignition-transport10"
   depends_on macos: :mojave # c++17
   depends_on "qt@5"
-  depends_on "qwt"
   depends_on "tinyxml2"
 
   def install
     cmake_args = std_cmake_args
-    cmake_args << "-DQWT_WIN_INCLUDE_DIR=#{HOMEBREW_PREFIX}/lib/qwt.framework/Headers"
-    cmake_args << "-DQWT_WIN_LIBRARY_DIR=#{HOMEBREW_PREFIX}/lib/qwt.framework"
     cmake_args << "-DBUILD_TESTING=Off"
 
     mkdir "build" do

--- a/Formula/ignition-gui5.rb
+++ b/Formula/ignition-gui5.rb
@@ -4,6 +4,7 @@ class IgnitionGui5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gui/releases/ignition-gui5-5.2.0.tar.bz2"
   sha256 "386661dea3517919fcf3124ec5791666f561c98a4b0c4b7ec649789d473d4938"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/ignitionrobotics/ign-gui.git", branch: "main"
 

--- a/Formula/ignition-gui5.rb
+++ b/Formula/ignition-gui5.rb
@@ -10,8 +10,8 @@ class IgnitionGui5 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 catalina: "5b122a2a5e25ca2703c4c026040c8f4524d91af3b70f26a47d848d50aaff090f"
-    sha256 mojave:   "550f0954404bfd9d92648c883d3786e534e9460686b7c19eac7bb2d59d59e20c"
+    sha256 catalina: "e6a8e5cb3de5a43e948c30a75b1697ddb07ba06e8ce18975719f97935f85560f"
+    sha256 mojave:   "85123b88f23fdbd53cae081ebe3cf17d2f964ea7dd60f5b53a8824892a06bc59"
   end
 
   depends_on "cmake" => [:build, :test]


### PR DESCRIPTION
There is an open pull request to upgrade `qwt` to use qt version 6, so home-brew formulae that want to use `qwt` with `qt@5` should now depend on the `qwt-qt5` formula ( as of https://github.com/Homebrew/homebrew-core/pull/84275 ). These ignition-gui formulae list `qwt` as a dependency but don't actually use it, so just remove the dependency and bump revision so we can update the bottles.