### PR TITLE
ogre1.9: patch to fix finding ZZip

### DIFF
--- a/Formula/gazebo11.rb
+++ b/Formula/gazebo11.rb
@@ -10,8 +10,8 @@ class Gazebo11 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "61f1bc23f7891500534fc7eeede649f8ff1a63cdfe07d866c1cb5693302ad6bc"
-    sha256 catalina: "a9417d520809f34289aa07c26610b8b360dafe01dfb235861c3b9f5e2350341b"
+    sha256 big_sur:  "d42497ac41969a9ade2aa0ea8413aa4bc01482293092149053faae1851564658"
+    sha256 catalina: "adacc13bbe1afa2c195081df430b635fc72e5b4e0eb32a81f91acb83a9c4a846"
   end
 
   depends_on "cmake" => :build

--- a/Formula/gazebo9.rb
+++ b/Formula/gazebo9.rb
@@ -10,8 +10,8 @@ class Gazebo9 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "1b4c56cc174835ee11ea882d239e2821448652bd14bf6016789e242730b40ffa"
-    sha256 catalina: "e02654dee3ef01f4f335b094b29e9c144341cbb6abb7a8424b767dcd5e9f1a4e"
+    sha256 big_sur:  "b006ef04c3fbd9aecf9e5974e6a7669814ee2ec8e9c61446a01b61de9512c44c"
+    sha256 catalina: "4b46196a18a56ce41f1e113499399cbbdbfd9c6a549f28e1fab5a59c2d5806e7"
   end
 
   depends_on "cmake" => :build

--- a/Formula/ignition-rendering3.rb
+++ b/Formula/ignition-rendering3.rb
@@ -8,8 +8,8 @@ class IgnitionRendering3 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 catalina: "aa879b6b217ec466543ed4174a2e70f259bc92ab9db0f9e6c28cedcc1aa2fb07"
-    sha256 mojave:   "4550fd43279ea83c79212a67342a573a03fd8bb3b322838b455bd01d56d57729"
+    sha256 big_sur:  "5853766552e057d56744c47687448647e9096b90969393abb32540c2409fe699"
+    sha256 catalina: "03d9778ee7cf2001e9d847ae7d379635a08c5302b1198fc29d7f4edec942cb04"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/ignition-rendering4.rb
+++ b/Formula/ignition-rendering4.rb
@@ -8,8 +8,8 @@ class IgnitionRendering4 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 catalina: "460aa51aaabd3d92dc2a2de36234bd7a339363470e3918ecac197104ef38c1fe"
-    sha256 mojave:   "a068bd11e423dcacaace18d95bfc61d2fa95968f822221ddd3b0cc0e15fc7b0c"
+    sha256 big_sur:  "10fce67f14df4cf41971d4a7462de1b346c8ec23a37cf852f8aba17fc62ab1d3"
+    sha256 catalina: "225e39e774f5553e36a1feb33887c63704745ce09d5378a0de8d7ccde906411e"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/ignition-rendering5.rb
+++ b/Formula/ignition-rendering5.rb
@@ -8,8 +8,8 @@ class IgnitionRendering5 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 catalina: "585b1f4c434866143557b9d563f0e4e0195a7063f7ecb5f5ab0b5c7c4d3511c3"
-    sha256 mojave:   "cb712f121f28b230911f558e69796f7c12b316f4984c448bbeb60fd16db0450d"
+    sha256 big_sur:  "501e491769458cd5fef4d0c7280ee5765b48dbb39101bdf399b3e36c553460ab"
+    sha256 catalina: "54bfba445a26fb2ca7e67c6cb194ec4c1a4de099e5d22f1126d8f7a471d83d4f"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/ignition-rendering6.rb
+++ b/Formula/ignition-rendering6.rb
@@ -8,8 +8,8 @@ class IgnitionRendering6 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "ed1fda39d5a476bf1f80b9b805c30772543dab03911ab30e7ac82ab0440e1e34"
-    sha256 catalina: "2f24532be19e8d159abc0382d7ccf12ef068c4e2392dbc2ac4abdc8c786aade7"
+    sha256 big_sur:  "ca0459988f52e871f55503a1d69ebadaa74a6d44a565195cc9418e95f10e60ad"
+    sha256 catalina: "3140a24cfac77808593618af3f76be7a0739ffd766d7df9dfa8ff0cc8e91c4b4"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/ogre1.9.rb
+++ b/Formula/ogre1.9.rb
@@ -9,7 +9,8 @@ class Ogre19 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 mojave: "fd714993552adb0aa6d34eb7b737b929943b88b82daca2b0028586f6ad731ef0"
+    sha256 big_sur:  "d9d4bc2177fda4189a1633a50766e727cfc3a13abbc64a913d08e92657b6ba49"
+    sha256 catalina: "c1e5e0bb08263e3acbf91d1350d02c8f1a9e0c8e124719bd885963b3f1b0a824"
   end
 
   option "with-cg"


### PR DESCRIPTION
Our ogre1.9 bottles did not include ZZip, which causes
heightmap test failures in gazebo. I've added a patch
based on OGRECave/ogre@3599e7069ac092de546201d4763209b1bd4b7e6a
from https://github.com/OGRECave/ogre/pull/998
to fix finding ZZip on macOS.