### PR TITLE
ogre1.9: update for compatibility with Apple M1 Chip

### DIFF
--- a/Formula/ogre1.9.rb
+++ b/Formula/ogre1.9.rb
@@ -26,63 +26,71 @@ class Ogre19 < Formula
 
   conflicts_with "ogre", because: "differing version of the same formula"
 
-  patch do
-    url "https://gist.github.com/NikolausDemmel/2b11d1b49b35cd27a102/raw/bf4a4d16020821218f73db0d56aa111ab2fde679/fix-1.9-HEAD.diff"
-    sha256 "15ecd1f12266918650ea789e2f96da4b0ef1a96076d7a671d3c56d98e2459712"
-  end
+  if Hardware::CPU.intel?
+    patch do
+      url "https://gist.github.com/NikolausDemmel/2b11d1b49b35cd27a102/raw/bf4a4d16020821218f73db0d56aa111ab2fde679/fix-1.9-HEAD.diff"
+      sha256 "15ecd1f12266918650ea789e2f96da4b0ef1a96076d7a671d3c56d98e2459712"
+    end
 
-  patch do
-    # retain osx cocoa window
-    url "https://gist.githubusercontent.com/NikolausDemmel/927bd7bb3f14c1788599/raw/c9a5ba88b758e80d3f46511629c4e8026b92c462/ogre1.9.patch"
-    sha256 "e82d842138f7f5ff4637ed313d1140c3b868c8425d4cdba7a71e0a9d7f7e0fd6"
-  end
+    patch do
+      # retain osx cocoa window
+      url "https://gist.githubusercontent.com/NikolausDemmel/927bd7bb3f14c1788599/raw/c9a5ba88b758e80d3f46511629c4e8026b92c462/ogre1.9.patch"
+      sha256 "e82d842138f7f5ff4637ed313d1140c3b868c8425d4cdba7a71e0a9d7f7e0fd6"
+    end
 
-  patch do
-    # disable building samples if ois is not available
-    url "https://gist.githubusercontent.com/iche033/68349eebfc436e484b70e6e3508ae27b/raw/d96227cd79ed1d63f051689a18c95a1c174a4efa/ogre-1.9-ois.patch"
-    sha256 "7ad630740217ccb9f48898507e9c6713dcd37a677a9669cdc16ef39afbf68826"
-  end
+    patch do
+      # disable building samples if ois is not available
+      url "https://gist.githubusercontent.com/iche033/68349eebfc436e484b70e6e3508ae27b/raw/d96227cd79ed1d63f051689a18c95a1c174a4efa/ogre-1.9-ois.patch"
+      sha256 "7ad630740217ccb9f48898507e9c6713dcd37a677a9669cdc16ef39afbf68826"
+    end
 
-  patch do
-    # link against AGL framework
-    url "https://gist.githubusercontent.com/iche033/b73766fac9ab3d628a79b5ed986677cd/raw/878d0902704c7fb51511163052c95294361f1dbe/ogre-1.9-agl.patch"
-    sha256 "8122c7eb52faae0fdedb70278d24e2581c88d1181de4d6e94d27bc1b3e596181"
-  end
+    patch do
+      # link against AGL framework
+      url "https://gist.githubusercontent.com/iche033/b73766fac9ab3d628a79b5ed986677cd/raw/878d0902704c7fb51511163052c95294361f1dbe/ogre-1.9-agl.patch"
+      sha256 "8122c7eb52faae0fdedb70278d24e2581c88d1181de4d6e94d27bc1b3e596181"
+    end
 
-  patch do
-    # backport cocoa window fix to support contents scaling factor (for retina displays)
-    url "https://gist.githubusercontent.com/iche033/e0080a592c890cc9a4fce31f6863a5ed/raw/875ae8ad1d9f0eaa271fd44eab8e0979bac74119/ogre-1.9-cocoa_window_scale.patch"
-    sha256 "c20c288530ea4d11b37f9c8b30cb43c89722c85eac0af3b6520cd89c37014e5b"
-  end
+    patch do
+      # backport cocoa window fix to support contents scaling factor (for retina displays)
+      url "https://gist.githubusercontent.com/iche033/e0080a592c890cc9a4fce31f6863a5ed/raw/875ae8ad1d9f0eaa271fd44eab8e0979bac74119/ogre-1.9-cocoa_window_scale.patch"
+      sha256 "c20c288530ea4d11b37f9c8b30cb43c89722c85eac0af3b6520cd89c37014e5b"
+    end
 
-  patch do
-    # add libc++ flag
-    url "https://gist.githubusercontent.com/iche033/e2b152d9df080b21f71ba3b65aa39922/raw/5397fa149c7570c17f2d78421d44b12dfa175387/ogre-1.9-cxx_flags.patch"
-    sha256 "7dc77285029c34b4a6adb52b0d4b9c40578526a5e9764d0a7091c6a4cb63fa78"
-  end
+    patch do
+      # add libc++ flag
+      url "https://gist.githubusercontent.com/iche033/e2b152d9df080b21f71ba3b65aa39922/raw/5397fa149c7570c17f2d78421d44b12dfa175387/ogre-1.9-cxx_flags.patch"
+      sha256 "7dc77285029c34b4a6adb52b0d4b9c40578526a5e9764d0a7091c6a4cb63fa78"
+    end
 
-  patch do
-    # fix FindOGRE.cmake for non-framework builds
-    url "https://gist.githubusercontent.com/iche033/2b5e2ba31436881f1db29f9b60c7a5b2/raw/b6ab953ebd82127ad1177744f367a36e059312a9/ogre-1.9-findogre.patch"
-    sha256 "7ca6f549fbdff7b7fc334f06da4547e071ec0e3f2733897fc6ef0d2bfa1716a3"
-  end
+    patch do
+      # fix FindOGRE.cmake for non-framework builds
+      url "https://gist.githubusercontent.com/iche033/2b5e2ba31436881f1db29f9b60c7a5b2/raw/b6ab953ebd82127ad1177744f367a36e059312a9/ogre-1.9-findogre.patch"
+      sha256 "7ca6f549fbdff7b7fc334f06da4547e071ec0e3f2733897fc6ef0d2bfa1716a3"
+    end
 
-  patch do
-    # fix for boost 1.65
-    url "https://github.com/OGRECave/ogre/commit/cade48b4c2215dd77ea74b7aa219a22c2a5d6654.patch?full_index=1"
-    sha256 "d30c9a941b436c920cdb7a56e870e6a07921d1188ba3e0d8934323fdd28fc7c2"
-  end
+    patch do
+      # fix for boost 1.65
+      url "https://github.com/OGRECave/ogre/commit/cade48b4c2215dd77ea74b7aa219a22c2a5d6654.patch?full_index=1"
+      sha256 "d30c9a941b436c920cdb7a56e870e6a07921d1188ba3e0d8934323fdd28fc7c2"
+    end
 
-  patch do
-    # fix for boost 1.67
-    url "https://github.com/OGRECave/ogre/commit/2371c8d001725190a9cda62dc5df282cde78f951.patch?full_index=1"
-    sha256 "28d418f7c978bedcf26c7a53c0f621fd5d9a2f27e5b838ea03af00e062f65470"
-  end
+    patch do
+      # fix for boost 1.67
+      url "https://github.com/OGRECave/ogre/commit/2371c8d001725190a9cda62dc5df282cde78f951.patch?full_index=1"
+      sha256 "28d418f7c978bedcf26c7a53c0f621fd5d9a2f27e5b838ea03af00e062f65470"
+    end
 
-  # fix for finding ZZip
-  patch do
-    url "https://github.com/scpeters/ogre/commit/8fcfe0885e6bd98d971250d4a3fb9a23e3743dfd.patch?full_index=1"
-    sha256 "3a69a4ed9e86887d3a23b0882c9868e994ab710205bb2e4b87204a8c89f1a3c5"
+    # fix for finding ZZip
+    patch do
+      url "https://github.com/scpeters/ogre/commit/8fcfe0885e6bd98d971250d4a3fb9a23e3743dfd.patch?full_index=1"
+      sha256 "3a69a4ed9e86887d3a23b0882c9868e994ab710205bb2e4b87204a8c89f1a3c5"
+    end
+  else
+    # full fix for Apple Mac M1 chip
+    patch do
+      url "https://raw.githubusercontent.com/zarathustr/sinbad-ogre/master/mac-m1-full.patch"
+      sha256 "a842b9507dc4e539ec6257c045897a68da311b960585b221a899d63ec672efe3"
+    end
   end
 
   def install


### PR DESCRIPTION
The commit includes a full patch for successful compilation of ogre1.9 on the Apple M1 chip. THe main modifications are that in the SIMD instruction include headers of M1 Mac systems (macOS Big Sur and macOS Monterey), there are some incompatabilities with the ogre1.9 source files. The compiled state has been fully validated via the ROS RViz robotics visualization tool.