### PR TITLE
Set CMAKE_INSTALL_RPATH in many packages

### DIFF
--- a/Formula/ignition-common3.rb
+++ b/Formula/ignition-common3.rb
@@ -25,6 +25,7 @@ class IgnitionCommon3 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
     system "cmake", ".", *cmake_args
     system "make", "install"
   end

--- a/Formula/ignition-common4.rb
+++ b/Formula/ignition-common4.rb
@@ -26,6 +26,7 @@ class IgnitionCommon4 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
     system "cmake", ".", *cmake_args
     system "make", "install"
   end

--- a/Formula/ignition-gazebo3.rb
+++ b/Formula/ignition-gazebo3.rb
@@ -36,6 +36,7 @@ class IgnitionGazebo3 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/ignition-gazebo4.rb
+++ b/Formula/ignition-gazebo4.rb
@@ -36,6 +36,7 @@ class IgnitionGazebo4 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/ignition-gazebo5.rb
+++ b/Formula/ignition-gazebo5.rb
@@ -37,6 +37,7 @@ class IgnitionGazebo5 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -35,6 +35,7 @@ class IgnitionGazebo6 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/ignition-math6.rb
+++ b/Formula/ignition-math6.rb
@@ -20,6 +20,7 @@ class IgnitionMath6 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
     system "cmake", ".", *cmake_args
     system "make", "install"
   end

--- a/Formula/ignition-physics2.rb
+++ b/Formula/ignition-physics2.rb
@@ -28,6 +28,7 @@ class IgnitionPhysics2 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
     system "cmake", ".", *cmake_args
     system "make", "install"
   end

--- a/Formula/ignition-physics3.rb
+++ b/Formula/ignition-physics3.rb
@@ -28,6 +28,7 @@ class IgnitionPhysics3 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
     system "cmake", ".", *cmake_args
     system "make", "install"
   end

--- a/Formula/ignition-physics4.rb
+++ b/Formula/ignition-physics4.rb
@@ -29,6 +29,7 @@ class IgnitionPhysics4 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
     system "cmake", ".", *cmake_args
     system "make", "install"
   end

--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -29,6 +29,7 @@ class IgnitionPhysics5 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
     system "cmake", ".", *cmake_args
     system "make", "install"
   end

--- a/Formula/ignition-plugin1.rb
+++ b/Formula/ignition-plugin1.rb
@@ -20,6 +20,7 @@ class IgnitionPlugin1 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
     system "cmake", ".", *cmake_args
     system "make", "install"
   end

--- a/Formula/ignition-plugin2.rb
+++ b/Formula/ignition-plugin2.rb
@@ -15,6 +15,7 @@ class IgnitionPlugin2 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
     system "cmake", ".", *cmake_args
     system "make", "install"
   end

--- a/Formula/ignition-rendering3.rb
+++ b/Formula/ignition-rendering3.rb
@@ -26,6 +26,7 @@ class IgnitionRendering3 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
     system "cmake", ".", *cmake_args
     system "make", "install"
   end

--- a/Formula/ignition-rendering4.rb
+++ b/Formula/ignition-rendering4.rb
@@ -27,6 +27,7 @@ class IgnitionRendering4 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
     system "cmake", ".", *cmake_args
     system "make", "install"
   end

--- a/Formula/ignition-rendering5.rb
+++ b/Formula/ignition-rendering5.rb
@@ -27,6 +27,7 @@ class IgnitionRendering5 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
     system "cmake", ".", *cmake_args
     system "make", "install"
   end

--- a/Formula/ignition-rendering6.rb
+++ b/Formula/ignition-rendering6.rb
@@ -27,6 +27,7 @@ class IgnitionRendering6 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
     system "cmake", ".", *cmake_args
     system "make", "install"
   end

--- a/Formula/ignition-sensors3.rb
+++ b/Formula/ignition-sensors3.rb
@@ -27,6 +27,7 @@ class IgnitionSensors3 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
 
     system "cmake", ".", *cmake_args
     system "make", "install"

--- a/Formula/ignition-sensors4.rb
+++ b/Formula/ignition-sensors4.rb
@@ -27,6 +27,7 @@ class IgnitionSensors4 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
 
     system "cmake", ".", *cmake_args
     system "make", "install"

--- a/Formula/ignition-sensors5.rb
+++ b/Formula/ignition-sensors5.rb
@@ -27,6 +27,7 @@ class IgnitionSensors5 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
 
     system "cmake", ".", *cmake_args
     system "make", "install"

--- a/Formula/ignition-sensors6.rb
+++ b/Formula/ignition-sensors6.rb
@@ -25,6 +25,7 @@ class IgnitionSensors6 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
 
     system "cmake", ".", *cmake_args
     system "make", "install"

--- a/Formula/ignition-transport10.rb
+++ b/Formula/ignition-transport10.rb
@@ -32,6 +32,7 @@ class IgnitionTransport10 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
 
     system "cmake", ".", *cmake_args
     system "make", "install"

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -30,6 +30,7 @@ class IgnitionTransport11 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
 
     system "cmake", ".", *cmake_args
     system "make", "install"

--- a/Formula/ignition-transport8.rb
+++ b/Formula/ignition-transport8.rb
@@ -29,6 +29,7 @@ class IgnitionTransport8 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
     system "cmake", ".", *cmake_args
     system "make", "install"
   end

--- a/Formula/ignition-transport9.rb
+++ b/Formula/ignition-transport9.rb
@@ -31,6 +31,7 @@ class IgnitionTransport9 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
 
     system "cmake", ".", *cmake_args
     system "make", "install"

--- a/Formula/ignition-utils1.rb
+++ b/Formula/ignition-utils1.rb
@@ -18,6 +18,7 @@ class IgnitionUtils1 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
     system "cmake", ".", *cmake_args
     system "make", "install"
   end


### PR DESCRIPTION
For m1 processors, brew is installed to a non-standard prefix in `/opt`, which requires setting `CMAKE_INSTALL_RPATH`, as was done for dartsim in https://github.com/Homebrew/homebrew-core/pull/79326