### PR TITLE
gazebo{9,11}: depend on cmake@3.21.4

### DIFF
--- a/Formula/gazebo11.rb
+++ b/Formula/gazebo11.rb
@@ -13,7 +13,7 @@ class Gazebo11 < Formula
     sha256 catalina: "f67625c2257946aae8cc094dd20b80e45acb597f3e3f920cce0b2f1861048096"
   end
 
-  depends_on "cmake" => :build
+  depends_on "cmake@3.21.4" => :build
   depends_on "pkg-config" => :build
 
   depends_on "boost"

--- a/Formula/gazebo9.rb
+++ b/Formula/gazebo9.rb
@@ -8,7 +8,7 @@ class Gazebo9 < Formula
 
   head "https://github.com/osrf/gazebo.git", branch: "gazebo9"
 
-  depends_on "cmake" => :build
+  depends_on "cmake@3.21.4" => :build
   depends_on "pkg-config" => :build
 
   depends_on "boost"


### PR DESCRIPTION
Needed to fix CI. Workaround for https://github.com/ignition-tooling/release-tools/issues/573, follow-up to #1696.