### PR TITLE
Apple M1 fixes

### DIFF
--- a/Formula/ignition-common3.rb
+++ b/Formula/ignition-common3.rb
@@ -26,6 +26,13 @@ class IgnitionCommon3 < Formula
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+
+    if Hardware::CPU.arm?
+      # REVISIT: this works around a crash on Apple M1 processors
+      # https://github.com/osrf/homebrew-simulation/pull/1698#discussion_r774674536
+      cmake_args << "-DIGN_PROFILER_REMOTERY=Off"
+    end
+
     system "cmake", ".", *cmake_args
     system "make", "install"
   end


### PR DESCRIPTION
These fixes (along with https://github.com/Homebrew/homebrew-core/pull/90205) are required to get gazebo11 running on Apple M1 hardware as used by the https://github.com/PX4/PX4-Autopilot project.