### PR TITLE
Remove ignition-fuel-tools* bottles due to jsoncpp

### DIFF
--- a/Formula/ignition-fuel-tools1.rb
+++ b/Formula/ignition-fuel-tools1.rb
@@ -4,15 +4,8 @@ class IgnitionFuelTools1 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-fuel-tools/releases/ignition-fuel-tools1-1.2.0.tar.bz2"
   sha256 "6b1d631a095e8273dc09be7456758aeaa7582b74bebe983cc14da49063994473"
   license "Apache-2.0"
-  revision 6
+  revision 7
   version_scheme 1
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "9e1b0dde9dd9a357b92764a84ababcf0f1c873d2a1dd3a8baec38126ea212688"
-    sha256 catalina: "abfe0156b787bf4278932b5ad18c8e7408587d4cc51111bf656bb02859cc7c36"
-    sha256 mojave:   "76142e0cfbd80d5090b8e4b0258b6f4bde8d04e960345a232f064cfd68eda5e2"
-  end
 
   depends_on "cmake"
   depends_on "ignition-cmake0"

--- a/Formula/ignition-fuel-tools4.rb
+++ b/Formula/ignition-fuel-tools4.rb
@@ -4,13 +4,7 @@ class IgnitionFuelTools4 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-fuel-tools/releases/ignition-fuel-tools4-4.4.0.tar.bz2"
   sha256 "ac1bd48e87a97e67aff3076d8eb5fa76612afc60be27c2e78daa47542fffa686"
   license "Apache-2.0"
-  revision 2
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, big_sur:  "435e13443b0c37151bdd8a366e95ddb779a3cb837c3274c779a1b5c039785ba4"
-    sha256 cellar: :any, catalina: "3d3ea56c1e010fef1a8e1899f459e52b817ddc380754e4f7b594271bf6a92a51"
-  end
+  revision 3
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-fuel-tools5.rb
+++ b/Formula/ignition-fuel-tools5.rb
@@ -4,15 +4,9 @@ class IgnitionFuelTools5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-fuel-tools/releases/ignition-fuel-tools5-5.2.0.tar.bz2"
   sha256 "857b944aaf3bd205ae51f3629186b044776a10b5ce597f5413d2e0cf5df7e5a1"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/ignitionrobotics/ign-fuel-tools.git", branch: "ign-fuel-tools5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, big_sur:  "ec679e5e115471cea3196e1b69bdaf0d0099d22d82c63778e2ddbde5f0a9541b"
-    sha256 cellar: :any, catalina: "d2011b1cb045968f4d6d8e9a6774ae3fe5a8ea1203d40f7dff1450871c1cc81a"
-  end
 
   deprecate! date: "2021-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-fuel-tools6.rb
+++ b/Formula/ignition-fuel-tools6.rb
@@ -4,15 +4,9 @@ class IgnitionFuelTools6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-fuel-tools/releases/ignition-fuel-tools6-6.1.0.tar.bz2"
   sha256 "68264a13588f068f2f81ce444c4c6f7b75582a5e8263da7b90f23eea04247a03"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/ignitionrobotics/ign-fuel-tools.git", branch: "main"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, big_sur:  "ace55478eb3ee356a5286fbf261ca15b8853e9a3d969e2f6b4812a7a00f33f7e"
-    sha256 cellar: :any, catalina: "a232f83819fcbbf8ecfaa935aef5a06eb3fac7c096dd79f5bdda057a4b43b978"
-  end
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -4,13 +4,7 @@ class IgnitionFuelTools7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-fuel-tools/releases/ignition-fuel-tools7-7.0.0.tar.bz2"
   sha256 "c2952b974d3337140b4fc25523a1b79b69b3b089129bc97675e088307e2dcc37"
   license "Apache-2.0"
-  revision 2
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, big_sur:  "9fd269ee2723d061daed0d0d9f149b14e266c5276cdc3142582f6d530824bf9c"
-    sha256 cellar: :any, catalina: "ceaec0c86e72002fe33243faf2bde4313ce829a1d70c845db953f06a54a3bb62"
-  end
+  revision 3
 
   depends_on "cmake"
   depends_on "ignition-cmake2"


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/1780

Implemented with:

~~~
brew bump-revision --remove-bottle-block --message="for jsoncpp" ignition-fuel-tools1
brew bump-revision --remove-bottle-block --message="for jsoncpp" ignition-fuel-tools4
brew bump-revision --remove-bottle-block --message="for jsoncpp" ignition-fuel-tools5
brew bump-revision --remove-bottle-block --message="for jsoncpp" ignition-fuel-tools6
brew bump-revision --remove-bottle-block --message="for jsoncpp" ignition-fuel-tools7
~~~