### PR TITLE
edifice: add deprecate! with EOL date

### DIFF
--- a/Formula/ignition-edifice.rb
+++ b/Formula/ignition-edifice.rb
@@ -17,6 +17,8 @@ class IgnitionEdifice < Formula
     sha256 cellar: :any, catalina: "5e01ce4fad534470a6b5977e20f2d16424abda3715730d43d2dcd8b6bfcd3747"
   end
 
+  deprecate! date: "2022-03-31", because: "is past end-of-life date"
+
   depends_on "cmake" => :build
   depends_on "ignition-cmake2"
   depends_on "ignition-common4"

--- a/Formula/ignition-fuel-tools6.rb
+++ b/Formula/ignition-fuel-tools6.rb
@@ -8,6 +8,8 @@ class IgnitionFuelTools6 < Formula
 
   head "https://github.com/ignitionrobotics/ign-fuel-tools.git", branch: "main"
 
+  deprecate! date: "2022-03-31", because: "is past end-of-life date"
+
   depends_on "cmake"
   depends_on "ignition-cmake2"
   depends_on "ignition-common4"

--- a/Formula/ignition-gazebo5.rb
+++ b/Formula/ignition-gazebo5.rb
@@ -14,6 +14,8 @@ class IgnitionGazebo5 < Formula
     sha256 catalina: "9cb18b427caa8669eae5a05ddd5749229e767ce4d8370bcf15a0f08f28e0b15f"
   end
 
+  deprecate! date: "2022-03-31", because: "is past end-of-life date"
+
   depends_on "cmake" => :build
   depends_on "gflags"
   depends_on "google-benchmark"

--- a/Formula/ignition-gui5.rb
+++ b/Formula/ignition-gui5.rb
@@ -14,6 +14,8 @@ class IgnitionGui5 < Formula
     sha256 catalina: "e00efbd2f9a92306d10d6d612c25838f09cc895b9e2db58f6cf949c183d71b0d"
   end
 
+  deprecate! date: "2022-03-31", because: "is past end-of-life date"
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
   depends_on "ignition-cmake2"

--- a/Formula/ignition-launch4.rb
+++ b/Formula/ignition-launch4.rb
@@ -14,6 +14,8 @@ class IgnitionLaunch4 < Formula
     sha256 catalina: "b52f86cfb8afcf7a33b2b3cff52d35c5e86a9a3f542030383afc08975ee42456"
   end
 
+  deprecate! date: "2022-03-31", because: "is past end-of-life date"
+
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
 

--- a/Formula/ignition-msgs7.rb
+++ b/Formula/ignition-msgs7.rb
@@ -14,6 +14,8 @@ class IgnitionMsgs7 < Formula
     sha256 cellar: :any, catalina: "805d1fac4ba7f15a7d2fe54d65a33f4a96894c0a9c22d8bc35114224cbaa232e"
   end
 
+  deprecate! date: "2022-03-31", because: "is past end-of-life date"
+
   depends_on "protobuf-c" => :build
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-physics4.rb
+++ b/Formula/ignition-physics4.rb
@@ -12,6 +12,8 @@ class IgnitionPhysics4 < Formula
     sha256 cellar: :any, catalina: "7bd9b00ec3c566c93c8c703ed167bab9da4d52634d3e41daec6dae9054003a5a"
   end
 
+  deprecate! date: "2022-03-31", because: "is past end-of-life date"
+
   depends_on "cmake" => :build
 
   depends_on "bullet"

--- a/Formula/ignition-rendering5.rb
+++ b/Formula/ignition-rendering5.rb
@@ -11,6 +11,8 @@ class IgnitionRendering5 < Formula
     sha256 catalina: "0dfb2316c57405b44f96e707663646ee4898bfb2cc33951998c0cf81161dcb87"
   end
 
+  deprecate! date: "2022-03-31", because: "is past end-of-life date"
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
 

--- a/Formula/ignition-sensors5.rb
+++ b/Formula/ignition-sensors5.rb
@@ -14,6 +14,8 @@ class IgnitionSensors5 < Formula
     sha256 catalina: "f222ab32aa3e94f9558f244905c3269858a12b72cfce667edd478b3632f0b6c0"
   end
 
+  deprecate! date: "2022-03-31", because: "is past end-of-life date"
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
 

--- a/Formula/ignition-transport10.rb
+++ b/Formula/ignition-transport10.rb
@@ -15,6 +15,8 @@ class IgnitionTransport10 < Formula
     sha256 catalina: "a058d592f6b6d473b3506ae26b749638dd12cc03cae8b19cb99327f9ca35868c"
   end
 
+  deprecate! date: "2022-03-31", because: "is past end-of-life date"
+
   depends_on "doxygen" => [:build, :optional]
   depends_on "protobuf-c" => :build
 

--- a/Formula/sdformat11.rb
+++ b/Formula/sdformat11.rb
@@ -12,6 +12,8 @@ class Sdformat11 < Formula
     sha256 catalina: "6356028ba97727fa8947c013cfe5362e991855198499e0da8b70fb838baaad85"
   end
 
+  deprecate! date: "2022-03-31", because: "is past end-of-life date"
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
 


### PR DESCRIPTION
Deprecation date taken from https://github.com/ignitionrobotics/docs/blob/master/tools/versions.md

In general, we can add these tags as soon as we know the EOL dates for a given package. After the EOL date has been reached, they can be converted to `disable!` tags.