### PR TITLE
ignition-gazebo7: fix test finding ffmpeg@4

### DIFF
--- a/Formula/ignition-gazebo7.rb
+++ b/Formula/ignition-gazebo7.rb
@@ -93,6 +93,7 @@ class IgnitionGazebo7 < Formula
     #                "-o", "test"
     # system "./test"
     # test building with cmake
+    ENV.append_path "CMAKE_PREFIX_PATH", Formula["ffmpeg@4"].opt_prefix
     ENV.append_path "CMAKE_PREFIX_PATH", Formula["qt@5"].opt_prefix
     mkdir "build" do
       system "cmake", ".."


### PR DESCRIPTION
Repeat fixes from #1806 and #1807 for ignition-gazebo7.