### PR TITLE
gazebo9: revision bump for ffmpeg4

### DIFF
--- a/Formula/gazebo9.rb
+++ b/Formula/gazebo9.rb
@@ -4,7 +4,7 @@ class Gazebo9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/gazebo-9.19.0.tar.bz2"
   sha256 "1f3ca430824b120ae0c7c4c0037a1a56e7b6bf6c50731b148b5c75bfc46d7fe7"
   license "Apache-2.0"
-  revision 11
+  revision 12
 
   head "https://github.com/osrf/gazebo.git", branch: "gazebo9"
 
@@ -104,6 +104,7 @@ class Gazebo9 < Formula
     #                "-lc++",
     #                "-o", "test"
     # system "./test"
+    ENV.append_path "CMAKE_PREFIX_PATH", Formula["ffmpeg@4"].opt_prefix
     ENV.append_path "CPATH", Formula["tbb@2020_u3"].opt_include
     mkdir "build" do
       system "cmake", ".."

--- a/Formula/gazebo9.rb
+++ b/Formula/gazebo9.rb
@@ -8,6 +8,12 @@ class Gazebo9 < Formula
 
   head "https://github.com/osrf/gazebo.git", branch: "gazebo9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 big_sur:  "0452ef1dcfa5c87141b07c278114d5c6be6486d81560da63a5efcce576c4e665"
+    sha256 catalina: "5f1ed61e6101f2017f1e98fdd5cbc0b28662b3a20f51aa34ea2545e8d1cfffdb"
+  end
+
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
 


### PR DESCRIPTION
Rebuild gazebo9 bottle using ffmpeg@4. Part of https://github.com/osrf/homebrew-simulation/issues/1800.