### PR TITLE
gazebo11: use new tbb and recent patch

### DIFF
--- a/Formula/gazebo11.rb
+++ b/Formula/gazebo11.rb
@@ -4,7 +4,7 @@ class Gazebo11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/gazebo-11.10.1.tar.bz2"
   sha256 "349cbd73965f6e71784283f9b9b69f2cd43162c613642fd388d3f648f9caccf2"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/osrf/gazebo.git", branch: "gazebo11"
 
@@ -40,7 +40,7 @@ class Gazebo11 < Formula
   depends_on "qwt-qt5"
   depends_on "sdformat9"
   depends_on "simbody"
-  depends_on "tbb@2020_u3"
+  depends_on "tbb"
   depends_on "tinyxml"
   depends_on "tinyxml2"
   depends_on "zeromq" => :linked
@@ -50,6 +50,13 @@ class Gazebo11 < Formula
 
   conflicts_with "gazebo7", because: "differing version of the same formula"
   conflicts_with "gazebo9", because: "differing version of the same formula"
+
+  patch do
+    # Fix build with new tbb
+    # remove with next release
+    url "https://github.com/osrf/gazebo/commit/ea956014ed45906dda21e1ee682d297189cb4a7b.patch?full_index=1"
+    sha256 "24af2fc83aaf6816d289d588d7aa9142c9bd28eb9819f344d55770ee4fe9fd4c"
+  end
 
   patch do
     # Fix build when homebrew python is installed
@@ -103,7 +110,6 @@ class Gazebo11 < Formula
     #                "-o", "test"
     # system "./test"
     ENV.append_path "CPATH", Formula["ffmpeg@4"].opt_include
-    ENV.append_path "CPATH", Formula["tbb@2020_u3"].opt_include
     mkdir "build" do
       system "cmake", ".."
       system "make"

--- a/Formula/gazebo11.rb
+++ b/Formula/gazebo11.rb
@@ -52,6 +52,12 @@ class Gazebo11 < Formula
   conflicts_with "gazebo9", because: "differing version of the same formula"
 
   patch do
+    # patch needed for the following tbb patch to apply
+    url "https://github.com/osrf/gazebo/commit/34ebf4e4ee48d1a4e4f08d2f76fdb0a471717019.patch?full_index=1"
+    sha256 "4984b897365c3c3bffd0a35df706621d822f61c1cf7ca6c0ac4f11f1cab7e108"
+  end
+
+  patch do
     # Fix build with new tbb
     # remove with next release
     url "https://github.com/osrf/gazebo/commit/ea956014ed45906dda21e1ee682d297189cb4a7b.patch?full_index=1"

--- a/Formula/gazebo11.rb
+++ b/Formula/gazebo11.rb
@@ -10,8 +10,8 @@ class Gazebo11 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "dd9dafaa80cc3cd9f08aadfa6572d12963222fd08b8f924736e5cfb209c99727"
-    sha256 catalina: "fb555b5965b6c89c4541f3b26d1056422cb374ce49a5dd1262822a67c5bbce15"
+    sha256 big_sur:  "0b78de4cf8e8f82b6309ff5ae2051a69b9b4211aaf70ef5f7bd5e71a12c80dc3"
+    sha256 catalina: "0ab42c6f33ce0eaf8290662ce28b4d131ad2219bf1110258dcbf081b95eb6d1f"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
Use patch from https://github.com/osrf/gazebo/pull/3174 and switch to the current version of `tbb`.