### PR TITLE
citadel: fix rpath and add ffmpeg dependencies

### DIFF
--- a/Formula/ignition-gazebo3.rb
+++ b/Formula/ignition-gazebo3.rb
@@ -10,8 +10,8 @@ class IgnitionGazebo3 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "f98b48c1b51ba9a3f53b982553fb1a17b6f150d4bbd7845e861b1d28c797080b"
-    sha256 catalina: "4be7429207b23fa59da0c667389e6bd8739defc490123e2763dd12681867f77d"
+    sha256 big_sur:  "01ebae8ea00a61dd28316defe1576692b2523a233bf698ef1d6984a8495fd8ad"
+    sha256 catalina: "43c2a0cfa0b21be0773851d499215414c356a26e3eede82af480911eeab62ef0"
   end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"

--- a/Formula/ignition-gazebo3.rb
+++ b/Formula/ignition-gazebo3.rb
@@ -4,7 +4,7 @@ class IgnitionGazebo3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gazebo/releases/ignition-gazebo3-3.12.0.tar.bz2"
   sha256 "cc89eb24ff7c6177814f44b6b0aeef9efcbec0a242798200ae4d7c44ccec9513"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/ignitionrobotics/ign-gazebo.git", branch: "ign-gazebo3"
 
@@ -17,6 +17,7 @@ class IgnitionGazebo3 < Formula
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 
   depends_on "cmake" => :build
+  depends_on "ffmpeg"
   depends_on "gflags"
   depends_on "google-benchmark"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-gui3.rb
+++ b/Formula/ignition-gui3.rb
@@ -10,8 +10,8 @@ class IgnitionGui3 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "728b83b979522bf004413c857bb3c9456c0d308feef64a5c9fb7e2c575a28409"
-    sha256 catalina: "20670140abf9199b813d13b02473bfd559048efda70aef268510d7af21d4db80"
+    sha256 big_sur:  "c824ddd2dbb2a1fff3a972259dfb2a071fa0fc07fc9144a591d3230d7a054a9d"
+    sha256 catalina: "7f5c750138d660e191c0477a4531a8ee8dec4fb7018c869cde673490c0e21b5d"
   end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"

--- a/Formula/ignition-gui3.rb
+++ b/Formula/ignition-gui3.rb
@@ -4,6 +4,7 @@ class IgnitionGui3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gui/releases/ignition-gui3-3.9.0.tar.bz2"
   sha256 "02d510cbd676eefc117bbea28c9f3f8b904b4c399b915aa03be8ae65136feb1b"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/ignitionrobotics/ign-gui.git", branch: "ign-gui3"
 
@@ -30,6 +31,7 @@ class IgnitionGui3 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/ignition-launch2.rb
+++ b/Formula/ignition-launch2.rb
@@ -10,8 +10,8 @@ class IgnitionLaunch2 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "8f4136b7aa762efca4eeb581b007d549f6804e8aa80673fc1689f32a30a32676"
-    sha256 catalina: "52f51393cce9a1538d1d42ddfc69789f8f9ed862057f7270759330b9553c0be9"
+    sha256 big_sur:  "fbe07312364ad2f6455f017b5656910691a0efc6f07996339c5c7c00a48d2194"
+    sha256 catalina: "39f112249a7ad4c311474fb7b77eff96713ea4f04ffe26206a99001990df568a"
   end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"

--- a/Formula/ignition-launch2.rb
+++ b/Formula/ignition-launch2.rb
@@ -32,8 +32,14 @@ class IgnitionLaunch2 < Formula
   depends_on "tinyxml2"
 
   def install
-    system "cmake", ".", *std_cmake_args
-    system "make", "install"
+    cmake_args = std_cmake_args
+    cmake_args << "-DBUILD_TESTING=OFF"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+
+    mkdir "build" do
+      system "cmake", "..", *cmake_args
+      system "make", "install"
+    end
   end
 
   test do

--- a/Formula/ignition-launch2.rb
+++ b/Formula/ignition-launch2.rb
@@ -4,7 +4,7 @@ class IgnitionLaunch2 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-launch/releases/ignition-launch2-2.2.2.tar.bz2"
   sha256 "121c1a63c519709c057bb2b6d2688b9e8ebe07aa5de2d62205857a7028339779"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/ignitionrobotics/ign-launch.git", branch: "ign-launch2"
 
@@ -19,6 +19,7 @@ class IgnitionLaunch2 < Formula
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
 
+  depends_on "ffmpeg"
   depends_on "ignition-cmake2"
   depends_on "ignition-common3"
   depends_on "ignition-gazebo3"

--- a/Formula/ignition-msgs5.rb
+++ b/Formula/ignition-msgs5.rb
@@ -4,6 +4,7 @@ class IgnitionMsgs5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs5-5.9.0.tar.bz2"
   sha256 "42f7cb0afa62130f0e1a45a0bf8be7b633594152257fc8dfa72d6d5dd13770f4"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
@@ -25,6 +26,8 @@ class IgnitionMsgs5 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+
     system "cmake", ".", *cmake_args
     system "make", "install"
   end

--- a/Formula/ignition-msgs5.rb
+++ b/Formula/ignition-msgs5.rb
@@ -8,8 +8,8 @@ class IgnitionMsgs5 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, big_sur:  "f44ddaa24305313f93cbeeac474eccb3e9be6f54c15354fca752bbbedfce5bbb"
-    sha256 cellar: :any, catalina: "17591797fc674bdaf5ce05cd2a47ae109ffb1ff56b2270c20e1b456aff5ce83b"
+    sha256 cellar: :any, big_sur:  "dddbf4b2272bee4e636e6ec2f1d7bacc75ca61ae129ee54650215ec68d5c062c"
+    sha256 cellar: :any, catalina: "1855e3a9519aa6faf7f201dd6efb1b0031059164ba6362b8050f201c4a094480"
   end
 
   depends_on "protobuf-c" => :build

--- a/Formula/sdformat9.rb
+++ b/Formula/sdformat9.rb
@@ -8,8 +8,8 @@ class Sdformat9 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "36b8d356fff84d85795fb6e12b49b7481269f3f3b984b3b443f1ef5da6213873"
-    sha256 catalina: "667d44e9228aad91098179e84ee199452fb69860c52ed4d30559b9936535ec87"
+    sha256 big_sur:  "9e0f80f1674820b35d1332d5e86fbf036f4b5d3c99b52de983dfb7614f056e14"
+    sha256 catalina: "97c0eb2b97203300377eaaf643f195dceb32cd11e08638281520e6f133399d1c"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/sdformat9.rb
+++ b/Formula/sdformat9.rb
@@ -4,6 +4,7 @@ class Sdformat9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-9.7.0.tar.bz2"
   sha256 "dcfa6faa2a12a6814e8cf020539c351d69c3a1b82092645d0dee3ec7c968b8f0"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
@@ -22,8 +23,12 @@ class Sdformat9 < Formula
   depends_on "urdfdom"
 
   def install
+    cmake_args = std_cmake_args
+    cmake_args << "-DBUILD_TESTING=Off"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "..", *cmake_args
       system "make", "install"
     end
   end


### PR DESCRIPTION
Both ignition-gazebo3 and ignition-launch2 link against ffmpeg but didn't have a declared dependency. When the dependency version was changed from `ffmpeg@4` to `ffmpeg` in #1833, the ignition-gazebo3 and ignition-launch2 bottles should have been rebuilt. The bottle test jobs are now failing:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gazebo3-install_bottle-homebrew-amd64&build=655)](https://build.osrfoundation.org/view/ign-citadel/job/ignition_gazebo3-install_bottle-homebrew-amd64/655/) https://build.osrfoundation.org/view/ign-citadel/job/ignition_gazebo3-install_bottle-homebrew-amd64/655/
* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_launch2-install_bottle-homebrew-amd64&build=645)](https://build.osrfoundation.org/view/ign-citadel/job/ignition_launch2-install_bottle-homebrew-amd64/645/) https://build.osrfoundation.org/view/ign-citadel/job/ignition_launch2-install_bottle-homebrew-amd64/645

This adds the `ffmpeg` dependency to these formulae, and also applies the same fix for RPATH support that has been used in other formulae.