### PR TITLE
garden: use ffmpeg

### DIFF
--- a/Formula/ignition-common5.rb
+++ b/Formula/ignition-common5.rb
@@ -6,7 +6,7 @@ class IgnitionCommon5 < Formula
   license "Apache-2.0"
 
   depends_on "cmake"
-  depends_on "ffmpeg@4"
+  depends_on "ffmpeg"
   depends_on "freeimage"
   depends_on "gdal"
   depends_on "gts"

--- a/Formula/ignition-gazebo7.rb
+++ b/Formula/ignition-gazebo7.rb
@@ -6,6 +6,7 @@ class IgnitionGazebo7 < Formula
   license "Apache-2.0"
 
   depends_on "cmake" => :build
+  depends_on "ffmpeg"
   depends_on "gflags"
   depends_on "google-benchmark"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-launch6.rb
+++ b/Formula/ignition-launch6.rb
@@ -8,6 +8,7 @@ class IgnitionLaunch6 < Formula
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
 
+  depends_on "ffmpeg"
   depends_on "ignition-cmake2"
   depends_on "ignition-common5"
   depends_on "ignition-gazebo7"


### PR DESCRIPTION
Support for ffmpeg 5.0 has been merged into
ignition-common5, so switch back from ffmpeg@4
to ffmpeg. Also add dependencies for
ignition-gazebo7 and ignition-launch6 on
ffmpeg.