### PR TITLE
gazebo11: Remove dependency on ossp-uuid

### DIFF
--- a/Formula/gazebo11.rb
+++ b/Formula/gazebo11.rb
@@ -32,7 +32,6 @@ class Gazebo11 < Formula
   depends_on "ignition-transport8"
   depends_on "libtar"
   depends_on "ogre1.9"
-  depends_on "ossp-uuid" => :linked
   depends_on "protobuf"
   depends_on "protobuf-c"
   depends_on "qt@5"


### PR DESCRIPTION
See comment https://github.com/osrf/gazebo/pull/2878#issuecomment-727848922 . The change from PR 2878 is part of Gazebo releases since 11.3.0, see https://github.com/osrf/gazebo/blob/gazebo11_11.3.0/cmake/SearchForStuff.cmake#L706 .