### PR TITLE
ignition-gazebo[6,7]: depend on pybind11

### DIFF
--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -12,6 +12,7 @@ class IgnitionGazebo6 < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "pybind11" => :build
   depends_on "ffmpeg"
   depends_on "gflags"
   depends_on "google-benchmark"

--- a/Formula/ignition-gazebo7.rb
+++ b/Formula/ignition-gazebo7.rb
@@ -6,6 +6,7 @@ class IgnitionGazebo7 < Formula
   license "Apache-2.0"
 
   depends_on "cmake" => :build
+  depends_on "pybind11" => :build
   depends_on "ffmpeg"
   depends_on "gflags"
   depends_on "google-benchmark"


### PR DESCRIPTION
* Gazebo has pybind11 binds since https://github.com/ignitionrobotics/ign-gazebo/pull/1219
* This PR is similar to https://github.com/osrf/homebrew-simulation/pull/1793
* This is an attempt at fixing build issues downstream in https://github.com/ignitionrobotics/ign-launch/pull/155