### PR TITLE
ignition-physics5: don't use dartsim fork

### DIFF
--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -4,7 +4,7 @@ class IgnitionPhysics5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics5-5.1.0.tar.bz2"
   sha256 "653942e8b92b1038ef654995366ce70c57f7a387c6aef5ded443c8855ad1f45a"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
@@ -15,7 +15,7 @@ class IgnitionPhysics5 < Formula
   depends_on "cmake" => :build
 
   depends_on "bullet"
-  depends_on "dartsim@6.10.0"
+  depends_on "dartsim"
   depends_on "google-benchmark"
   depends_on "ignition-cmake2"
   depends_on "ignition-common4"

--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -8,8 +8,8 @@ class IgnitionPhysics5 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, big_sur:  "1c4f74b532fd2897a557238396906caa5665b304cc12a6e87f516b0e3e4d0622"
-    sha256 cellar: :any, catalina: "42a242a5e3a69e0432ac9e5b80977e273ea2da9a7ac2547f24ce14e7e0dba8c8"
+    sha256 cellar: :any, big_sur:  "1abce09230b6d3fc757defe42add3dc0e1d8f9f97ae3807422d4c3e5319c6fdb"
+    sha256 cellar: :any, catalina: "36581605812fcf5e47c023e1a0484a6877fa1c13ca345b658741e8fd42b5d5f9"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
Switch from dartsim@6.10.0 back to upstream dartsim to see if that fixes linking problems documented in #1884.