### PR TITLE
sdformat[11,12,13]: Explicitly depend on ign-cmake2

### DIFF
--- a/Formula/sdformat11.rb
+++ b/Formula/sdformat11.rb
@@ -17,6 +17,7 @@ class Sdformat11 < Formula
   depends_on "pkg-config" => [:build, :test]
 
   depends_on "doxygen"
+  depends_on "ignition-cmake2"
   depends_on "ignition-math6"
   depends_on "ignition-tools"
   depends_on "ignition-utils1"

--- a/Formula/sdformat12.rb
+++ b/Formula/sdformat12.rb
@@ -15,6 +15,7 @@ class Sdformat12 < Formula
   depends_on "pkg-config" => [:build, :test]
 
   depends_on "doxygen"
+  depends_on "ignition-cmake2"
   depends_on "ignition-math6"
   depends_on "ignition-tools"
   depends_on "ignition-utils1"

--- a/Formula/sdformat13.rb
+++ b/Formula/sdformat13.rb
@@ -9,6 +9,7 @@ class Sdformat13 < Formula
   depends_on "pkg-config" => [:build, :test]
 
   depends_on "doxygen"
+  depends_on "ignition-cmake2"
   depends_on "ignition-math7"
   depends_on "ignition-tools"
   depends_on "ignition-utils2"


### PR DESCRIPTION
The dependency became required since `sdf10`, see

* https://github.com/ignitionrobotics/sdformat/pull/780