### PR TITLE
Remove bottles broken by bullet 3.22b

### DIFF
--- a/Formula/dartsim@6.10.0.rb
+++ b/Formula/dartsim@6.10.0.rb
@@ -6,13 +6,7 @@ class DartsimAT6100 < Formula
   version "6.10.0~20211005~d2b6ee08a60d0dbf71b0f008cd8fed1f611f6e24"
   sha256 "372af181024452418eec95f8a9cd723ceb1ada979208add66c9a4330b9c0fa32"
   license "BSD-2-Clause"
-  revision 2
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "195a103c78ab73939d6e457f481e2b65a83042d476a23e65bafd300f1ddeb402"
-    sha256 catalina: "801c7524c34049cf573744fc3c13de9da7c8c208faf249726a9635278992656a"
-  end
+  revision 3
 
   keg_only "open robotics fork of dart HEAD + custom changes"
 

--- a/Formula/gazebo11.rb
+++ b/Formula/gazebo11.rb
@@ -4,14 +4,9 @@ class Gazebo11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/gazebo-11.10.2.tar.bz2"
   sha256 "f6c4ea8cd8730c90b14760b3f84d4f362d3786b510fb43a0b77b2c06b8bdd2b6"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/osrf/gazebo.git", branch: "gazebo11"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "03528c304a832dba761d25b93d5e5d24d5b161ecb2145970bb0085c9637a7a13"
-    sha256 catalina: "8abe5d4ac0a9a7134319c00a554f2b5a42c2471d0a81415d8cd14cdc3199cbb2"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/ignition-physics2.rb
+++ b/Formula/ignition-physics2.rb
@@ -4,13 +4,7 @@ class IgnitionPhysics2 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics2-2.5.0.tar.bz2"
   sha256 "a15f1e2c6f23cd3ce6dd284a2d1b9a6317dc188b62d960aec4c26112abcdfcaf"
   license "Apache-2.0"
-  revision 1
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, big_sur:  "c05a0e6349ece8f5fca4aeaa3a71232f083a2452281b4fdbd18c17cd5370863d"
-    sha256 cellar: :any, catalina: "1326a81a70b5cf03f40625060254c65f33deadde56d423a89a6390c254f00504"
-  end
+  revision 2
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-physics4.rb
+++ b/Formula/ignition-physics4.rb
@@ -4,13 +4,7 @@ class IgnitionPhysics4 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics4-4.3.0.tar.bz2"
   sha256 "66efb3f4e4f9f10b591200fea52f4d44297c596d26f8a88f951bb645c6fab7c2"
   license "Apache-2.0"
-  revision 1
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, big_sur:  "8b88318ef686a9dc28a6bc8189ba0390715e142a46fdac30678ace947bcb2dd6"
-    sha256 cellar: :any, catalina: "7bd9b00ec3c566c93c8c703ed167bab9da4d52634d3e41daec6dae9054003a5a"
-  end
+  revision 2
 
   deprecate! date: "2022-03-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -4,13 +4,7 @@ class IgnitionPhysics5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics5-5.1.0.tar.bz2"
   sha256 "653942e8b92b1038ef654995366ce70c57f7a387c6aef5ded443c8855ad1f45a"
   license "Apache-2.0"
-  revision 2
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, big_sur:  "1abce09230b6d3fc757defe42add3dc0e1d8f9f97ae3807422d4c3e5319c6fdb"
-    sha256 cellar: :any, catalina: "36581605812fcf5e47c023e1a0484a6877fa1c13ca345b658741e8fd42b5d5f9"
-  end
+  revision 3
 
   depends_on "cmake" => :build
 


### PR DESCRIPTION
A new version of bullet was merged in https://github.com/Homebrew/homebrew-core/pull/99927 that has broken some of our bottles:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_physics5-install_bottle-homebrew-amd64&build=209)](https://build.osrfoundation.org/job/ignition_physics5-install_bottle-homebrew-amd64/209/) https://build.osrfoundation.org/job/ignition_physics5-install_bottle-homebrew-amd64/209/

~~~
+ brew linkage --test ignition-physics5
Broken dependencies:
  /usr/local/opt/bullet/lib/libBulletCollision.3.20.dylib (bullet)
  /usr/local/opt/bullet/lib/libBulletDynamics.3.20.dylib (bullet)
  /usr/local/opt/bullet/lib/libBulletSoftBody.3.20.dylib (bullet)
  /usr/local/opt/bullet/lib/libLinearMath.3.20.dylib (bullet)
~~~