### PR TITLE
Rebuild dartsim@6.10.0, ign-physics* bottles

### DIFF
--- a/Formula/dartsim@6.10.0.rb
+++ b/Formula/dartsim@6.10.0.rb
@@ -6,7 +6,7 @@ class DartsimAT6100 < Formula
   version "6.10.0~20211005~d2b6ee08a60d0dbf71b0f008cd8fed1f611f6e24"
   sha256 "372af181024452418eec95f8a9cd723ceb1ada979208add66c9a4330b9c0fa32"
   license "BSD-2-Clause"
-  revision 3
+  revision 4
 
   keg_only "open robotics fork of dart HEAD + custom changes"
 

--- a/Formula/dartsim@6.10.0.rb
+++ b/Formula/dartsim@6.10.0.rb
@@ -8,6 +8,12 @@ class DartsimAT6100 < Formula
   license "BSD-2-Clause"
   revision 4
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 big_sur:  "7b732f24d5aa7e15aa3d102b10c7bed9ace1c8c44a359dede2135c1abbc19134"
+    sha256 catalina: "9aa0b21202695f3a569c398fcf8539332581021ec36c9bf1bf0a346ce8542271"
+  end
+
   keg_only "open robotics fork of dart HEAD + custom changes"
 
   depends_on "cmake" => :build

--- a/Formula/ignition-physics2.rb
+++ b/Formula/ignition-physics2.rb
@@ -4,7 +4,7 @@ class IgnitionPhysics2 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics2-2.5.0.tar.bz2"
   sha256 "a15f1e2c6f23cd3ce6dd284a2d1b9a6317dc188b62d960aec4c26112abcdfcaf"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-physics2.rb
+++ b/Formula/ignition-physics2.rb
@@ -6,6 +6,12 @@ class IgnitionPhysics2 < Formula
   license "Apache-2.0"
   revision 3
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, big_sur:  "ed357e699942d4dccc94d85b089594814efdea76807c44ede9ed01f71a681f8c"
+    sha256 cellar: :any, catalina: "54debc35b23c25e25764514152ee903c76545a61ddb25aa534d06e5d089af828"
+  end
+
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 
   depends_on "cmake" => :build

--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -6,6 +6,12 @@ class IgnitionPhysics5 < Formula
   license "Apache-2.0"
   revision 4
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, big_sur:  "75c34822e476a5cf3e4edab34bbf679f7cc975d0789b14f174b78cc24fa166a7"
+    sha256 cellar: :any, catalina: "44d748917a1c72101398e71d68231eef16933c8b1c9bfc5db37dab7e8e4d00f9"
+  end
+
   depends_on "cmake" => :build
 
   depends_on "bullet"

--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -4,7 +4,7 @@ class IgnitionPhysics5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics5-5.1.0.tar.bz2"
   sha256 "653942e8b92b1038ef654995366ce70c57f7a387c6aef5ded443c8855ad1f45a"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   depends_on "cmake" => :build
 


### PR DESCRIPTION
Rebuild the `dartsim@6.10.0` and `ignition-physics*` bottles removed in #1907.