### PR TITLE
gazebo11: bump revision and don't use cmake@3.21.4

### DIFF
--- a/Formula/gazebo11.rb
+++ b/Formula/gazebo11.rb
@@ -4,7 +4,7 @@ class Gazebo11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/gazebo-11.10.2.tar.bz2"
   sha256 "f6c4ea8cd8730c90b14760b3f84d4f362d3786b510fb43a0b77b2c06b8bdd2b6"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/osrf/gazebo.git", branch: "gazebo11"
 
@@ -19,7 +19,6 @@ class Gazebo11 < Formula
 
   depends_on "boost"
   depends_on "bullet"
-  depends_on "cmake@3.21.4"
   depends_on "dartsim"
   depends_on "doxygen"
   depends_on "ffmpeg@4"

--- a/Formula/gazebo11.rb
+++ b/Formula/gazebo11.rb
@@ -10,8 +10,8 @@ class Gazebo11 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "8e9329b678ba542a318ceb4e55aab15c940902197a2ea1491492a6a89c0fd9d1"
-    sha256 catalina: "46dd8fb6f27e058fde771762e472e6d1b1666041f27e83c2e5a37c90a928608d"
+    sha256 big_sur:  "75571cbfb1175fb0028d607e811c80ed89a747bb1a9713d0f0b428a811de5899"
+    sha256 catalina: "c345dde3a7c6c1a7cee8753953712f85d22926e318eb64ad7ab8f7e5b4b096ea"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
Since gazebo11 supports the most recent `tbb`, it shouldn't need to use the old version of cmake.