### PR TITLE
Remove broken bottles for bullet 3.2.4

### DIFF
--- a/Formula/dartsim@6.10.0.rb
+++ b/Formula/dartsim@6.10.0.rb
@@ -6,13 +6,7 @@ class DartsimAT6100 < Formula
   version "6.10.0~20211005~d2b6ee08a60d0dbf71b0f008cd8fed1f611f6e24"
   sha256 "372af181024452418eec95f8a9cd723ceb1ada979208add66c9a4330b9c0fa32"
   license "BSD-2-Clause"
-  revision 4
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "7b732f24d5aa7e15aa3d102b10c7bed9ace1c8c44a359dede2135c1abbc19134"
-    sha256 catalina: "9aa0b21202695f3a569c398fcf8539332581021ec36c9bf1bf0a346ce8542271"
-  end
+  revision 5
 
   keg_only "open robotics fork of dart HEAD + custom changes"
 

--- a/Formula/gazebo11.rb
+++ b/Formula/gazebo11.rb
@@ -4,15 +4,9 @@ class Gazebo11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/gazebo-11.10.2.tar.bz2"
   sha256 "f6c4ea8cd8730c90b14760b3f84d4f362d3786b510fb43a0b77b2c06b8bdd2b6"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   head "https://github.com/osrf/gazebo.git", branch: "gazebo11"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "75571cbfb1175fb0028d607e811c80ed89a747bb1a9713d0f0b428a811de5899"
-    sha256 catalina: "c345dde3a7c6c1a7cee8753953712f85d22926e318eb64ad7ab8f7e5b4b096ea"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/gazebo9.rb
+++ b/Formula/gazebo9.rb
@@ -4,15 +4,9 @@ class Gazebo9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/gazebo-9.19.0.tar.bz2"
   sha256 "1f3ca430824b120ae0c7c4c0037a1a56e7b6bf6c50731b148b5c75bfc46d7fe7"
   license "Apache-2.0"
-  revision 14
+  revision 15
 
   head "https://github.com/osrf/gazebo.git", branch: "gazebo9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "ea434ce36ce0661d7236682d125a52f797300a4339543ec4db42358f3b705399"
-    sha256 catalina: "1b7afc8f3d09d1c7048344508caee13719c57710579b819f8d6ca839a32e8c8b"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/ignition-physics2.rb
+++ b/Formula/ignition-physics2.rb
@@ -4,13 +4,7 @@ class IgnitionPhysics2 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics2-2.5.0.tar.bz2"
   sha256 "a15f1e2c6f23cd3ce6dd284a2d1b9a6317dc188b62d960aec4c26112abcdfcaf"
   license "Apache-2.0"
-  revision 3
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, big_sur:  "ed357e699942d4dccc94d85b089594814efdea76807c44ede9ed01f71a681f8c"
-    sha256 cellar: :any, catalina: "54debc35b23c25e25764514152ee903c76545a61ddb25aa534d06e5d089af828"
-  end
+  revision 4
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -4,13 +4,7 @@ class IgnitionPhysics5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics5-5.1.0.tar.bz2"
   sha256 "653942e8b92b1038ef654995366ce70c57f7a387c6aef5ded443c8855ad1f45a"
   license "Apache-2.0"
-  revision 4
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, big_sur:  "75c34822e476a5cf3e4edab34bbf679f7cc975d0789b14f174b78cc24fa166a7"
-    sha256 cellar: :any, catalina: "44d748917a1c72101398e71d68231eef16933c8b1c9bfc5db37dab7e8e4d00f9"
-  end
+  revision 5
 
   depends_on "cmake" => :build
 


### PR DESCRIPTION
We just removed and rebuilt bottles after bullet 3.22b was released in https://github.com/Homebrew/homebrew-core/pull/99927, but we need to do it again for bullet 3.24 from https://github.com/Homebrew/homebrew-core/pull/100511

This removes the bottles, and they will be rebuilt in a subsequent PR