### PR TITLE
Remove edifice bottles with unbottled dependencies

### DIFF
--- a/Formula/ignition-edifice.rb
+++ b/Formula/ignition-edifice.rb
@@ -6,15 +6,10 @@ class IgnitionEdifice < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-edifice/releases/ignition-edifice-1.0.3.tar.bz2"
   sha256 "2a8208cc80a8934e64ffa9c79c352ff86c51d0b78ff69931259e3d86cf72fea7"
   license "Apache-2.0"
+  revision 1
   version_scheme 1
 
   head "https://github.com/ignitionrobotics/ign-edifice.git", branch: "main"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, big_sur:  "5e9a904810a2dd899e76ce9fe0cad0cc53d6d19d8aad36b1a2d3e1cb941f1d61"
-    sha256 cellar: :any, catalina: "fd3afb5175ad3f73fda72cd1c37ba4807665388fb01fa54e05963dd5892ce075"
-  end
 
   deprecate! date: "2022-03-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-gazebo5.rb
+++ b/Formula/ignition-gazebo5.rb
@@ -4,14 +4,9 @@ class IgnitionGazebo5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gazebo/releases/ignition-gazebo5-5.4.0.tar.bz2"
   sha256 "05ce86304e1ba435e87aa07c6fc7efebe03ea6a022243d6c0da5a91a409ac9f8"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/ignitionrobotics/ign-gazebo.git", branch: "main"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "212f01964362f04d1060b0e39b96abedc2e9a901cbbdb4c1d0932d31c7068f85"
-    sha256 catalina: "f26ae386ec18b15eee2ab7cce1358e3088390bcb957a6ba743e6fa5dbabb0735"
-  end
 
   deprecate! date: "2022-03-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-launch4.rb
+++ b/Formula/ignition-launch4.rb
@@ -4,15 +4,9 @@ class IgnitionLaunch4 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-launch/releases/ignition-launch4-4.1.0.tar.bz2"
   sha256 "fd1e5a535bafb197360b168bce573bed3c4d7804b76c098d93afc5b17b2bdcef"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   head "https://github.com/ignitionrobotics/ign-launch.git", branch: "main"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "a25aa2ea24d7e47003dc0a0a76e0f597718b6118e68b7b2bf84fe35a6c77c958"
-    sha256 catalina: "6b6f4a48e1d616ce873862e90b9e5af7f4c94e5167b3c6fed76c1e7bad4fd6ec"
-  end
 
   deprecate! date: "2022-03-31", because: "is past end-of-life date"
 


### PR DESCRIPTION
The `ignition-physics4` bottle was disabled in #1907 and was not rebuilt, so the edifice bottles that depend on it should be disabled as well.