### PR TITLE
gazebo11: revision bump for bullet again

### DIFF
--- a/Formula/gazebo11.rb
+++ b/Formula/gazebo11.rb
@@ -10,8 +10,8 @@ class Gazebo11 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "ea08432cfb7f42e466d0bf44e194769e066b45caceded8dc708c10ab4e47498d"
-    sha256 catalina: "7c1c3bbccded895751d091883956547f04217a92cde1b55dc62aa325fcba1bdb"
+    sha256 big_sur:  "0fff248f7e55aac0bf3d09973331cc086ba8fba0a21e1428e5d1fe484808cbda"
+    sha256 catalina: "0a20b34b3616d55820be2ac8f5b71ba5bed34a547393ca8a096af26bf5bf94f4"
   end
 
   depends_on "cmake" => :build

--- a/Formula/gazebo11.rb
+++ b/Formula/gazebo11.rb
@@ -4,7 +4,7 @@ class Gazebo11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/gazebo-11.10.2.tar.bz2"
   sha256 "f6c4ea8cd8730c90b14760b3f84d4f362d3786b510fb43a0b77b2c06b8bdd2b6"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   head "https://github.com/osrf/gazebo.git", branch: "gazebo11"
 


### PR DESCRIPTION
The gazebo11 Big Sur bottle wasn't properly built in #1915 , so rebuild both

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo-install-one_liner-homebrew-amd64&build=2417)](https://build.osrfoundation.org/job/gazebo-install-one_liner-homebrew-amd64/2417/) https://build.osrfoundation.org/job/gazebo-install-one_liner-homebrew-amd64/2417/