### PR TITLE
Add aliases for gz-* packages

### DIFF
--- a/Aliases/gz-cmake3
+++ b/Aliases/gz-cmake3
@@ -1,0 +1,1 @@
+../Formula/ignition-cmake3.rb

--- a/Aliases/gz-common5
+++ b/Aliases/gz-common5
@@ -1,0 +1,1 @@
+../Formula/ignition-common5.rb

--- a/Aliases/gz-fuel-tools8
+++ b/Aliases/gz-fuel-tools8
@@ -1,0 +1,1 @@
+../Formula/ignition-fuel-tools8.rb

--- a/Aliases/gz-garden
+++ b/Aliases/gz-garden
@@ -1,0 +1,1 @@
+../Formula/ignition-garden.rb

--- a/Aliases/gz-gui7
+++ b/Aliases/gz-gui7
@@ -1,0 +1,1 @@
+../Formula/ignition-gui7.rb

--- a/Aliases/gz-launch6
+++ b/Aliases/gz-launch6
@@ -1,0 +1,1 @@
+../Formula/ignition-launch6.rb

--- a/Aliases/gz-math7
+++ b/Aliases/gz-math7
@@ -1,0 +1,1 @@
+../Formula/ignition-math7.rb

--- a/Aliases/gz-msgs9
+++ b/Aliases/gz-msgs9
@@ -1,0 +1,1 @@
+../Formula/ignition-msgs9.rb

--- a/Aliases/gz-physics6
+++ b/Aliases/gz-physics6
@@ -1,0 +1,1 @@
+../Formula/ignition-physics6.rb

--- a/Aliases/gz-plugin2
+++ b/Aliases/gz-plugin2
@@ -1,0 +1,1 @@
+../Formula/ignition-plugin2.rb

--- a/Aliases/gz-rendering7
+++ b/Aliases/gz-rendering7
@@ -1,0 +1,1 @@
+../Formula/ignition-rendering7.rb

--- a/Aliases/gz-sensors7
+++ b/Aliases/gz-sensors7
@@ -1,0 +1,1 @@
+../Formula/ignition-sensors7.rb

--- a/Aliases/gz-sim7
+++ b/Aliases/gz-sim7
@@ -1,0 +1,1 @@
+../Formula/ignition-gazebo7.rb

--- a/Aliases/gz-tools2
+++ b/Aliases/gz-tools2
@@ -1,0 +1,1 @@
+../Formula/ignition-tools2.rb

--- a/Aliases/gz-transport12
+++ b/Aliases/gz-transport12
@@ -1,0 +1,1 @@
+../Formula/ignition-transport12.rb

--- a/Aliases/gz-utils2
+++ b/Aliases/gz-utils2
@@ -1,0 +1,1 @@
+../Formula/ignition-utils2.rb


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/698. The formulae should be renamed at some point, but the aliases are easy to make quickly.