### PR TITLE
ignition-msgs9: Rename CMake project to gz-msgs9

### DIFF
--- a/Formula/ignition-msgs9.rb
+++ b/Formula/ignition-msgs9.rb
@@ -1,15 +1,15 @@
 class IgnitionMsgs9 < Formula
   desc "Middleware protobuf messages for robotics"
-  homepage "https://github.com/gazebosim/gz-msgs"
+  homepage "https://gazebosim.org"
   url "https://github.com/gazebosim/gz-msgs.git", branch: "main"
   version "8.999.999~0~20220414"
   license "Apache-2.0"
 
   depends_on "protobuf-c" => :build
   depends_on "cmake"
-  depends_on "ignition-cmake3"
-  depends_on "ignition-math7"
-  depends_on "ignition-tools2"
+  depends_on "gz-cmake3"
+  depends_on "gz-math7"
+  depends_on "gz-tools2"
   depends_on macos: :high_sierra # c++17
   depends_on "pkg-config"
   depends_on "protobuf"
@@ -28,28 +28,25 @@ class IgnitionMsgs9 < Formula
 
   test do
     (testpath/"test.cpp").write <<-EOS
-      #include <ignition/msgs.hh>
+      #include <gz/msgs.hh>
       int main() {
-        ignition::msgs::UInt32;
+        gz::msgs::UInt32;
         return 0;
       }
     EOS
     (testpath/"CMakeLists.txt").write <<-EOS
       cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
-      find_package(ignition-msgs9 QUIET REQUIRED)
-      set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${IGNITION-MSGS_CXX_FLAGS}")
-      include_directories(${IGNITION-MSGS_INCLUDE_DIRS})
-      link_directories(${IGNITION-MSGS_LIBRARY_DIRS})
+      find_package(gz-msgs9 QUIET REQUIRED)
       add_executable(test_cmake test.cpp)
-      target_link_libraries(test_cmake ignition-msgs9::ignition-msgs9)
+      target_link_libraries(test_cmake gz-msgs9::gz-msgs9)
     EOS
     # test building with pkg-config
-    system "pkg-config", "ignition-msgs9"
-    cflags = `pkg-config --cflags ignition-msgs9`.split
+    system "pkg-config", "gz-msgs9"
+    cflags = `pkg-config --cflags gz-msgs9`.split
     system ENV.cc, "test.cpp",
                    *cflags,
                    "-L#{lib}",
-                   "-lignition-msgs9",
+                   "-lgz-msgs9",
                    "-lc++",
                    "-o", "test"
     system "./test"


### PR DESCRIPTION
* Part of https://github.com/gazebo-tooling/release-tools/issues/718
* Goes with https://github.com/gazebosim/gz-msgs/pull/250