### PR TITLE
ignition-common5: Rename CMake project to gz-common5

### DIFF
--- a/Formula/ignition-common5.rb
+++ b/Formula/ignition-common5.rb
@@ -1,6 +1,6 @@
 class IgnitionCommon5 < Formula
   desc "Common libraries for robotics applications"
-  homepage "https://github.com/gazebosim/gz-common"
+  homepage "https://gazebosim.org"
   url "https://github.com/gazebosim/gz-common.git", branch: "main"
   version "4.999.999~0~20220414"
   license "Apache-2.0"
@@ -10,9 +10,9 @@ class IgnitionCommon5 < Formula
   depends_on "freeimage"
   depends_on "gdal"
   depends_on "gts"
-  depends_on "ignition-cmake3"
-  depends_on "ignition-math7"
-  depends_on "ignition-utils2"
+  depends_on "gz-cmake3"
+  depends_on "gz-math7"
+  depends_on "gz-utils2"
   depends_on macos: :high_sierra # c++17
   depends_on "ossp-uuid"
   depends_on "pkg-config"
@@ -29,34 +29,26 @@ class IgnitionCommon5 < Formula
   test do
     (testpath/"test.cpp").write <<-EOS
       #include <iostream>
-      #include <ignition/common.hh>
+      #include <gz/common.hh>
       int main() {
-        igndbg << "debug" << std::endl;
-        ignwarn << "warn" << std::endl;
-        ignerr << "error" << std::endl;
-        // // this example code doesn't compile
-        // try {
-        //   ignthrow("An example exception that is caught.");
-        // }
-        // catch(const ignition::common::exception &_e) {
-        //   std::cerr << "Caught a runtime error " << _e.what() << std::endl;
-        // }
-        // ignassert(0 == 0);
+        gzdbg << "debug" << std::endl;
+        gzwarn << "warn" << std::endl;
+        gzerr << "error" << std::endl;
         return 0;
       }
     EOS
     (testpath/"CMakeLists.txt").write <<-EOS
       cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-      find_package(ignition-common5 QUIET REQUIRED)
+      find_package(gz-common5 QUIET REQUIRED)
       add_executable(test_cmake test.cpp)
-      target_link_libraries(test_cmake ${IGNITION-COMMON_LIBRARIES})
+      target_link_libraries(test_cmake gz-common5::gz-common5)
     EOS
-    system "pkg-config", "ignition-common5"
-    cflags = `pkg-config --cflags ignition-common5`.split
+    system "pkg-config", "gz-common5"
+    cflags = `pkg-config --cflags gz-common5`.split
     system ENV.cc, "test.cpp",
                    *cflags,
                    "-L#{lib}",
-                   "-lignition-common5",
+                   "-lgz-common5",
                    "-lc++",
                    "-o", "test"
     system "./test"


### PR DESCRIPTION
* Part of https://github.com/gazebo-tooling/release-tools/issues/718
* Goes with https://github.com/gazebosim/gz-common/pull/352