### PR TITLE
ignition-transport12: Rename CMake project to gz-transport12

### DIFF
--- a/Formula/ignition-transport12.rb
+++ b/Formula/ignition-transport12.rb
@@ -1,6 +1,6 @@
 class IgnitionTransport12 < Formula
   desc "Transport middleware for robotics"
-  homepage "https://ignitionrobotics.org"
+  homepage "https://gazebosim.org"
   url "https://github.com/gazebosim/gz-transport.git", branch: "main"
   version "11.999.999~0~20220414"
   license "Apache-2.0"
@@ -11,10 +11,10 @@ class IgnitionTransport12 < Formula
 
   depends_on "cmake"
   depends_on "cppzmq"
-  depends_on "ignition-cmake3"
-  depends_on "ignition-msgs9"
-  depends_on "ignition-tools2"
-  depends_on "ignition-utils2"
+  depends_on "gz-cmake3"
+  depends_on "gz-msgs9"
+  depends_on "gz-tools2"
+  depends_on "gz-utils2"
   depends_on macos: :mojave # c++17
   depends_on "ossp-uuid"
   depends_on "pkg-config"
@@ -33,27 +33,27 @@ class IgnitionTransport12 < Formula
   test do
     (testpath/"test.cpp").write <<-EOS
       #include <iostream>
-      #include <ignition/transport.hh>
+      #include <gz/transport.hh>
       int main() {
-        ignition::transport::NodeOptions options;
+        gz::transport::NodeOptions options;
         return 0;
       }
     EOS
     (testpath/"CMakeLists.txt").write <<-EOS
       cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
-      find_package(ignition-transport12 QUIET REQUIRED)
+      find_package(gz-transport12 QUIET REQUIRED)
       add_executable(test_cmake test.cpp)
-      target_link_libraries(test_cmake ignition-transport12::ignition-transport12)
+      target_link_libraries(test_cmake gz-transport12::gz-transport12)
     EOS
-    system "pkg-config", "ignition-transport12"
-    cflags = `pkg-config --cflags ignition-transport12`.split
+    system "pkg-config", "gz-transport12"
+    cflags = `pkg-config --cflags gz-transport12`.split
     system ENV.cc, "test.cpp",
                    *cflags,
                    "-L#{lib}",
-                   "-lignition-transport12",
+                   "-lgz-transport12",
                    "-lc++",
                    "-o", "test"
-    ENV["IGN_PARTITION"] = rand((1 << 32) - 1).to_s
+    ENV["GZ_PARTITION"] = rand((1 << 32) - 1).to_s
     system "./test"
     mkdir "build" do
       system "cmake", ".."


### PR DESCRIPTION
* Part of https://github.com/gazebo-tooling/release-tools/issues/718
* Goes with https://github.com/gazebosim/gz-transport/pull/320