### PR TITLE
ignition-garden: revert gz path to ignition

### DIFF
--- a/Formula/ignition-garden.rb
+++ b/Formula/ignition-garden.rb
@@ -47,7 +47,8 @@ class IgnitionGarden < Formula
   end
 
   test do
-    yaml_file = share/"gz/gz-garden/gazebodistro/collection-garden.yaml"
+    # TODO: migrate ignition to gz when IGN_DATA_INSTALL_DIR is migrated
+    yaml_file = share/"ignition/gz-garden/gazebodistro/collection-garden.yaml"
     system libexec/"bin/vcs", "validate", "--input", yaml_file
   end
 end


### PR DESCRIPTION
This hasn't been migrated yet, so revert for now to fix nightly builds.