### PR TITLE
gz-tools2: don't install bin/ign symlink

### DIFF
--- a/Formula/ignition-tools2.rb
+++ b/Formula/ignition-tools2.rb
@@ -15,6 +15,7 @@ class IgnitionTools2 < Formula
       system "cmake", "..", *std_cmake_args
       system "make", "install"
     end
+    rm bin/"ign"
   end
 
   test do


### PR DESCRIPTION
This allows garden to be installed side-by-side with citadel and fortress.

Though it currently errors if I try to run either command:

~~~
$ gz
Configuration error: File [/usr/local/share/ignition/transport12.yaml] contains a command already registered by ignition-transport.
$ ign
Configuration error: File [/usr/local/share/ignition/transport12.yaml] contains a command already registered by ignition-transport.
~~~