### PR TITLE
Disable broken bottles of protobuf dependents

### DIFF
--- a/Formula/gazebo11.rb
+++ b/Formula/gazebo11.rb
@@ -4,15 +4,9 @@ class Gazebo11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/gazebo-11.11.0.tar.bz2"
   sha256 "0c2637a873ed14e848e79d3edc8672c8fb39001073287ce94e9991aae76dd958"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/osrf/gazebo.git", branch: "gazebo11"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "9ab7ed9519a13e147e807b3580427306c77421dd91819a47099ad52e5c3a0361"
-    sha256 catalina: "72173d0dbd4b7bdd9ec5fb3755af755fc530c9cf5827248e8d283e86e1bed2d3"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/gazebo9.rb
+++ b/Formula/gazebo9.rb
@@ -4,15 +4,9 @@ class Gazebo9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/gazebo-9.19.0.tar.bz2"
   sha256 "1f3ca430824b120ae0c7c4c0037a1a56e7b6bf6c50731b148b5c75bfc46d7fe7"
   license "Apache-2.0"
-  revision 18
+  revision 19
 
   head "https://github.com/osrf/gazebo.git", branch: "gazebo9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "43647f4992b37d467d8370ccb8f99f07a2f1057aefde9710432110d42d65a9c7"
-    sha256 catalina: "4d6699f2b9941a44d4834393f22335567c525a97692690e391346a4583d6f299"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/ignition-citadel.rb
+++ b/Formula/ignition-citadel.rb
@@ -6,16 +6,10 @@ class IgnitionCitadel < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-citadel/releases/ignition-citadel-1.0.2.tar.bz2"
   sha256 "2b99e7476093e78841c63d4ec348c6cf7c9d650a2e5787011723142c9f917659"
   license "Apache-2.0"
-  revision 2
+  revision 3
   version_scheme 1
 
   head "https://github.com/gazebosim/gz-citadel.git", branch: "main"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, big_sur:  "5b18077521af982d193490faff73777ab030a6a8bfecead734de64b9ed2cad34"
-    sha256 cellar: :any, catalina: "77128ee99e7547c05a9bb619a9d382278ca6ba087857ad6805a807e3e1a6d0b3"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-fortress.rb
+++ b/Formula/ignition-fortress.rb
@@ -6,15 +6,10 @@ class IgnitionFortress < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-fortress/releases/ignition-fortress-1.0.3.tar.bz2"
   sha256 "eedbfb01e18038756eb596fa8f1c8aa955ca2be029fe40bb842ffee4d4452323"
   license "Apache-2.0"
+  revision 1
   version_scheme 1
 
   head "https://github.com/gazebosim/gz-fortress.git", branch: "main"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, big_sur:  "6671d6df6f7720ecabb097b8a9805250d8cc16aa588809919ada5c1e306a112d"
-    sha256 cellar: :any, catalina: "3e6f05ed521e353a7efdd963f82e686ff5740853717e73e0d9fcd2b63ee78c11"
-  end
 
   depends_on "cmake" => :build
   depends_on "ignition-cmake2"

--- a/Formula/ignition-fuel-tools4.rb
+++ b/Formula/ignition-fuel-tools4.rb
@@ -4,12 +4,7 @@ class IgnitionFuelTools4 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-fuel-tools/releases/ignition-fuel-tools4-4.5.0.tar.bz2"
   sha256 "70d7c48009b1406726b3844ea746cd50cf6dde5c784e90775c2dfe28cd29d62e"
   license "Apache-2.0"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, big_sur:  "66fbb431ec9f85466894c04e2eb9e576e73a0d0592c0f2e1332d56dbf878b4b1"
-    sha256 cellar: :any, catalina: "fd386a54fefe7e8e073516f05a0eff29222b65840a709b1ee7668a7312cb53c5"
-  end
+  revision 1
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-fuel-tools6.rb
+++ b/Formula/ignition-fuel-tools6.rb
@@ -4,14 +4,9 @@ class IgnitionFuelTools6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-fuel-tools/releases/ignition-fuel-tools6-6.2.0.tar.bz2"
   sha256 "c96101981122956ca501493c3415f22b4b4e24ae85b05585e728729c8dbc042f"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "main"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, big_sur:  "d2f15cd22d922a1cf12b5550ebb86d28549cd6c58958b100f958db1fcdd187ac"
-    sha256 cellar: :any, catalina: "4947147436124840eba3567d4cfc1b7f958e735878a0b71dfbe4327820d7b3ce"
-  end
 
   deprecate! date: "2022-03-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -4,13 +4,7 @@ class IgnitionFuelTools7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-fuel-tools/releases/ignition-fuel-tools7-7.0.0.tar.bz2"
   sha256 "c2952b974d3337140b4fc25523a1b79b69b3b089129bc97675e088307e2dcc37"
   license "Apache-2.0"
-  revision 5
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, big_sur:  "45c782fad020f0db78a0c017070330fb548e615badb1439e06ec0832a2f9c3dc"
-    sha256 cellar: :any, catalina: "ce93f9b1468e0a0196d11dd61b877c61bf4affd594ba94d8176470a7e3c711fe"
-  end
+  revision 6
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-gazebo3.rb
+++ b/Formula/ignition-gazebo3.rb
@@ -4,14 +4,9 @@ class IgnitionGazebo3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gazebo/releases/ignition-gazebo3-3.13.0.tar.bz2"
   sha256 "dabce27f6507f3fd7e97cc1818d2982c8490258a504fa2f1a18b5195b075c1c8"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo3"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "a765cdfb560f871a13b22172f33410b4aa7cb1285cd33ce0e17b202ce1aae84e"
-    sha256 catalina: "f5b33978d66ec4e2b24151d6446b85b0b0317fa59033214867ddc67af68cfa4f"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -4,12 +4,7 @@ class IgnitionGazebo6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gazebo/releases/ignition-gazebo6-6.10.0.tar.bz2"
   sha256 "8f5da2ba0c6ff2cbc5f04fb067c935eda4e5b66dbcca38994e3a43ad5840a7cf"
   license "Apache-2.0"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "b0dc20d090eaf214eb080a2790cebc9726f6768ec3f60b7f8b638846ca96a90e"
-    sha256 catalina: "5ecdf60d7d92c17613e0145ae3326353ea74f18349961e6f045f6cad881eb695"
-  end
+  revision 1
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build

--- a/Formula/ignition-gui3.rb
+++ b/Formula/ignition-gui3.rb
@@ -4,14 +4,9 @@ class IgnitionGui3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gui/releases/ignition-gui3-3.10.0.tar.bz2"
   sha256 "7f48b7440b937cef2eb66ab433cc0f4d7db0cb5aad76c3d88f97bc0bc3ced470"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui3"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "7e36257982f16d8a787bf9c00d849a90e35ede620bb4dd0ba4703dd4a9d84388"
-    sha256 catalina: "51c92f8874347f0e7f94acdd86f00804bda00e88628114c898401eebd3c320f9"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-gui5.rb
+++ b/Formula/ignition-gui5.rb
@@ -4,14 +4,9 @@ class IgnitionGui5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gui/releases/ignition-gui5-5.5.0.tar.bz2"
   sha256 "e3d397ab79a5ac74999a5e6976abb2ae265ebc935526cb1a1b27dfc488b8fabe"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "main"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "ea4239c34db689bda8bd6d1344ff45910ee97b6c7e20565d1094f65b1c6d80b1"
-    sha256 catalina: "f89fa1d03a9709bfb96b959060d508d19fe01b27b9f4d95e800c46935db55948"
-  end
 
   deprecate! date: "2022-03-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -4,13 +4,7 @@ class IgnitionGui6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gui/releases/ignition-gui6-6.4.0.tar.bz2"
   sha256 "ae6422ae78faa321df55e18fa436cfd2a85d19106460ea68eeb454d2e48f5b97"
   license "Apache-2.0"
-  revision 1
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "0fcb958351137d96e5318707d9e8975c6fc2a646ea3d40573c2771ded624e089"
-    sha256 catalina: "3f408467686918e895940a88b4fccb690852ea160c221af421411301ce4714cd"
-  end
+  revision 2
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/ignition-launch2.rb
+++ b/Formula/ignition-launch2.rb
@@ -4,15 +4,9 @@ class IgnitionLaunch2 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-launch/releases/ignition-launch2-2.2.2.tar.bz2"
   sha256 "121c1a63c519709c057bb2b6d2688b9e8ebe07aa5de2d62205857a7028339779"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "ign-launch2"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "fbe07312364ad2f6455f017b5656910691a0efc6f07996339c5c7c00a48d2194"
-    sha256 catalina: "39f112249a7ad4c311474fb7b77eff96713ea4f04ffe26206a99001990df568a"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-launch5.rb
+++ b/Formula/ignition-launch5.rb
@@ -4,13 +4,7 @@ class IgnitionLaunch5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-launch/releases/ignition-launch5-5.1.0.tar.bz2"
   sha256 "910f46ecb50503f86ec5753e367108c26bf9d74e9457d01c4099150c982b3e87"
   license "Apache-2.0"
-  revision 1
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "35d8e8e3c2964b6eea39479aed0ac08279567667b58476d40aed5535771ebcae"
-    sha256 catalina: "a96e4a26afffc6dac3af20e187eb4ab1d09d1f7575352615a13c3fa145aa7f00"
-  end
+  revision 2
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/ignition-msgs1.rb
+++ b/Formula/ignition-msgs1.rb
@@ -4,16 +4,10 @@ class IgnitionMsgs1 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs-1.0.0.tar.bz2"
   sha256 "fed54d079a58087fa83cc871f01ba2919866292ba949b6b8f37a0cb3d7186b4b"
   license "Apache-2.0"
-  revision 15
+  revision 16
   version_scheme 1
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs1"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, big_sur:  "c0f8f11c0ab513762c77608d5c440671cae9e0979a7d4ebb4d65de0ba385731d"
-    sha256 cellar: :any, catalina: "70280492fcfe5fc24d58f96cd2596395a8fae62d4422fc765f9bbcf6227b4d3d"
-  end
 
   depends_on "protobuf-c" => :build
   depends_on "cmake"

--- a/Formula/ignition-msgs5.rb
+++ b/Formula/ignition-msgs5.rb
@@ -4,13 +4,7 @@ class IgnitionMsgs5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs5-5.9.0.tar.bz2"
   sha256 "42f7cb0afa62130f0e1a45a0bf8be7b633594152257fc8dfa72d6d5dd13770f4"
   license "Apache-2.0"
-  revision 1
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, big_sur:  "dddbf4b2272bee4e636e6ec2f1d7bacc75ca61ae129ee54650215ec68d5c062c"
-    sha256 cellar: :any, catalina: "1855e3a9519aa6faf7f201dd6efb1b0031059164ba6362b8050f201c4a094480"
-  end
+  revision 2
 
   depends_on "protobuf-c" => :build
 

--- a/Formula/ignition-msgs7.rb
+++ b/Formula/ignition-msgs7.rb
@@ -4,14 +4,9 @@ class IgnitionMsgs7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs7-7.3.0.tar.bz2"
   sha256 "eed26fb10cb80212e5198d98a98d3ebe852ebf7ed993786f8d22a5c01802d607"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "main"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, big_sur:  "e7aad9c736b37e23ad3bc97e7c3bdaf29d95211cae51de4d2abce95fd33ce767"
-    sha256 cellar: :any, catalina: "cfd22dd4e4093aecfe393c68f2ac86fc9472a7954c5f5b6389d9d842453d0a0b"
-  end
 
   deprecate! date: "2022-03-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-msgs8.rb
+++ b/Formula/ignition-msgs8.rb
@@ -4,12 +4,7 @@ class IgnitionMsgs8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs8-8.5.0.tar.bz2"
   sha256 "0dc11364e66a77bb10d160503688ed56ef4fb753778a53d4fdd96c0c348b1022"
   license "Apache-2.0"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, big_sur:  "e17c5718c9bc939a4c916fd8f91a38b1367ea5ae704468176368a354346cd0e3"
-    sha256 cellar: :any, catalina: "157a84a5766f02faae7920338fcf41618d65958d5f0fd622b3efe3114ef95690"
-  end
+  revision 1
 
   depends_on "protobuf-c" => :build
   depends_on "cmake"

--- a/Formula/ignition-sensors3.rb
+++ b/Formula/ignition-sensors3.rb
@@ -4,15 +4,9 @@ class IgnitionSensors3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-sensors/releases/ignition-sensors3-3.3.0.tar.bz2"
   sha256 "a84ce934f2311f4619987d6c251670b478e914b8b0e1741979f96f5e3bf584c6"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors3"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "bd33ee97f587867744a49bd4982f6dcd093f7373cfeec5ffaf7fd1dba50de312"
-    sha256 catalina: "59f35ae1faa32e6a88be50574b13fa8fd6991ecd84f33f24407214dd5f2eae94"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-sensors5.rb
+++ b/Formula/ignition-sensors5.rb
@@ -4,14 +4,9 @@ class IgnitionSensors5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-sensors/releases/ignition-sensors5-5.1.1.tar.bz2"
   sha256 "92943c50e92b02cfef71671939a90f0a35ea17a9237c2ac95b3b2d683c2aa180"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "main"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "bf36e8a6220c5cee9beae83c8ae52f431c7c07ca2d725a44d68fb7fc81f81ce6"
-    sha256 catalina: "834eef78970c07ad11453ac967f240413ed091006bbc90ff51405e0458dc7063"
-  end
 
   deprecate! date: "2022-03-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-sensors6.rb
+++ b/Formula/ignition-sensors6.rb
@@ -4,12 +4,7 @@ class IgnitionSensors6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-sensors/releases/ignition-sensors6-6.6.0.tar.bz2"
   sha256 "a73b9a4b81b195dda5bf269deb9fb7151bbf8c9dbec7ed18aaed15def6538e56"
   license "Apache-2.0"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, big_sur:  "1d65b39f3f595fe1f9b8378e8f5afea8fdaa2bb4b88c8b2dcf5e3604f79a3271"
-    sha256 cellar: :any, catalina: "f63b1090cdbbf9350a9eb9cda4718f858e394d3a38bca556a61c03f0b48d0cfc"
-  end
+  revision 1
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/ignition-transport10.rb
+++ b/Formula/ignition-transport10.rb
@@ -4,15 +4,10 @@ class IgnitionTransport10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases/ignition-transport10-10.2.0.tar.bz2"
   sha256 "cb9b304a18438f714691385810edb5627f7aedf6e606bdb00f639c57a3b52d9f"
   license "Apache-2.0"
+  revision 1
   version_scheme 2
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "main"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "b95b5741779b396eb84d68625b987420103805ba977a35ba01db039df528642a"
-    sha256 catalina: "aa34650614c04282f5870246c08a953cc67070f42eaadeff734eba068cc71189"
-  end
 
   deprecate! date: "2022-03-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -4,13 +4,8 @@ class IgnitionTransport11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases/ignition-transport11-11.1.0.tar.bz2"
   sha256 "e02d65374817db971ac46e2a49eae2799fb00bffae9db65cc847a33046746ec6"
   license "Apache-2.0"
+  revision 1
   version_scheme 1
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "2d55d68050b239d712ed04727b7dbb836b4f95b956e14bbf897e02a216641201"
-    sha256 catalina: "8c43f4a473ae10a83296d4dc9883e1d625547a6c6e66bea8431ff74a1fc892d5"
-  end
 
   depends_on "doxygen" => [:build, :optional]
   depends_on "protobuf-c" => :build

--- a/Formula/ignition-transport4.rb
+++ b/Formula/ignition-transport4.rb
@@ -4,15 +4,9 @@ class IgnitionTransport4 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases/ignition-transport4-4.0.0.tar.bz2"
   sha256 "b0d8d3d4b0d4fbb06ed293955f5dfe2f840fe510daec867422676b41fc3824b4"
   license "Apache-2.0"
-  revision 13
+  revision 14
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport4"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, big_sur:  "55b6d6fcd4297267e9d21669700b24f505559d85f74a3a2e7a35dedd7350897d"
-    sha256 cellar: :any, catalina: "309bf0a129675bba891d15d90403db55204340bb2ae886151a93aaa7677adce4"
-  end
 
   depends_on "doxygen" => [:build, :optional]
 

--- a/Formula/ignition-transport8.rb
+++ b/Formula/ignition-transport8.rb
@@ -4,13 +4,7 @@ class IgnitionTransport8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases/ignition-transport8-8.2.1.tar.bz2"
   sha256 "bf7e1a06034f180d4e8f97a72219f8bfb73693685cc61ee788821e47612dcab9"
   license "Apache-2.0"
-  revision 2
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "ea523e54b02b1ddc663f39863a687c82cd7dfceb71db981f6d68b2fc47452276"
-    sha256 catalina: "10fedeac1789e57d5c6aa802293f94ced02074468cea254afb53841efcb6d1fd"
-  end
+  revision 3
 
   depends_on "doxygen" => [:build, :optional]
   depends_on "protobuf-c" => :build


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/1860.

Needed to fix [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_fuel-tools4-install_bottle-homebrew-amd64&build=759)](https://build.osrfoundation.org/job/ignition_fuel-tools4-install_bottle-homebrew-amd64/759/) https://build.osrfoundation.org/job/ignition_fuel-tools4-install_bottle-homebrew-amd64/759/

~~~
+ brew linkage --test ignition-fuel-tools4
Broken dependencies:
  /usr/local/opt/ignition-msgs5/lib/libignition-msgs5.5.dylib (ignition-msgs5)
  /usr/local/opt/protobuf/lib/libprotobuf.30.dylib (protobuf)
~~~