### PR TITLE
Rebuild fortress bottles after protobuf bump.

### DIFF
--- a/Formula/ignition-fortress.rb
+++ b/Formula/ignition-fortress.rb
@@ -11,6 +11,12 @@ class IgnitionFortress < Formula
 
   head "https://github.com/gazebosim/gz-fortress.git", branch: "main"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, big_sur:  "fa5f4afc3f351b3dd4aaa7ed75f46ba9547a5c23e0100307ac2906fb607a3cc7"
+    sha256 cellar: :any, catalina: "c99f3a4c56ecbaf7b0fe6584e79dd7520be8094f890200ddef292e22c5e7790f"
+  end
+
   depends_on "cmake" => :build
   depends_on "ignition-cmake2"
   depends_on "ignition-common4"

--- a/Formula/ignition-fortress.rb
+++ b/Formula/ignition-fortress.rb
@@ -6,7 +6,7 @@ class IgnitionFortress < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-fortress/releases/ignition-fortress-1.0.3.tar.bz2"
   sha256 "eedbfb01e18038756eb596fa8f1c8aa955ca2be029fe40bb842ffee4d4452323"
   license "Apache-2.0"
-  revision 1
+  revision 2
   version_scheme 1
 
   head "https://github.com/gazebosim/gz-fortress.git", branch: "main"

--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -4,7 +4,7 @@ class IgnitionFuelTools7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-fuel-tools/releases/ignition-fuel-tools7-7.0.0.tar.bz2"
   sha256 "c2952b974d3337140b4fc25523a1b79b69b3b089129bc97675e088307e2dcc37"
   license "Apache-2.0"
-  revision 6
+  revision 7
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -6,6 +6,12 @@ class IgnitionFuelTools7 < Formula
   license "Apache-2.0"
   revision 7
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, big_sur:  "821b1cf9f063833ba8ac687071bbcb10428537eb106c6af879a680cc6c1de4d7"
+    sha256 cellar: :any, catalina: "aa9096bb1df9654c62ff27ec900e4c039475a40368fa4908d36853ff298debec"
+  end
+
   depends_on "cmake"
   depends_on "ignition-cmake2"
   depends_on "ignition-common4"

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -6,6 +6,12 @@ class IgnitionGazebo6 < Formula
   license "Apache-2.0"
   revision 2
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 big_sur:  "a872526fa1a1a3acb48000e2c13d8226f045e4c7030a7b9664219cc7257184a0"
+    sha256 catalina: "a738d36fb9ae22b92c099ad51d6e73aa8d91f393756a52e45ad41f65f9f95eac"
+  end
+
   depends_on "cmake" => :build
   depends_on "pybind11" => :build
   depends_on "ffmpeg"

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -4,7 +4,7 @@ class IgnitionGazebo6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gazebo/releases/ignition-gazebo6-6.10.0.tar.bz2"
   sha256 "8f5da2ba0c6ff2cbc5f04fb067c935eda4e5b66dbcca38994e3a43ad5840a7cf"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -4,7 +4,7 @@ class IgnitionGui6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gui/releases/ignition-gui6-6.4.0.tar.bz2"
   sha256 "ae6422ae78faa321df55e18fa436cfd2a85d19106460ea68eeb454d2e48f5b97"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -6,6 +6,12 @@ class IgnitionGui6 < Formula
   license "Apache-2.0"
   revision 3
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 big_sur:  "938e8aaeeeb975bcb5e880f5e5eb7d675ab049be1ab26f4ae562e1d8f0976e0c"
+    sha256 catalina: "c9b605aeca5f7f57b2f432972aa6e8659b4e14d88d68916aaca02c6eba678019"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
   depends_on "ignition-cmake2"

--- a/Formula/ignition-launch5.rb
+++ b/Formula/ignition-launch5.rb
@@ -4,7 +4,7 @@ class IgnitionLaunch5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-launch/releases/ignition-launch5-5.1.0.tar.bz2"
   sha256 "910f46ecb50503f86ec5753e367108c26bf9d74e9457d01c4099150c982b3e87"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/ignition-launch5.rb
+++ b/Formula/ignition-launch5.rb
@@ -6,6 +6,12 @@ class IgnitionLaunch5 < Formula
   license "Apache-2.0"
   revision 3
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 big_sur:  "9c46c82b5fd3d98ddb3e6385f611e6917a70053bc71d4cf3868a76018dc730d7"
+    sha256 catalina: "5fba33408871a7117f2a758a5dbb3116e8e3998ffcea537d9e85d1c4c634a4e9"
+  end
+
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
 

--- a/Formula/ignition-sensors6.rb
+++ b/Formula/ignition-sensors6.rb
@@ -4,7 +4,7 @@ class IgnitionSensors6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-sensors/releases/ignition-sensors6-6.6.0.tar.bz2"
   sha256 "a73b9a4b81b195dda5bf269deb9fb7151bbf8c9dbec7ed18aaed15def6538e56"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/ignition-sensors6.rb
+++ b/Formula/ignition-sensors6.rb
@@ -6,6 +6,12 @@ class IgnitionSensors6 < Formula
   license "Apache-2.0"
   revision 2
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, big_sur:  "021fcddc3bbb1bf4bba53d14e46d16503d32a26df459ea347a1e52e559661b3d"
+    sha256 cellar: :any, catalina: "e2fd696851e4a7d9f86c63b7ed76fe8b0513102fc52a943df508eef96399ceeb"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
 

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -4,7 +4,7 @@ class IgnitionTransport11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases/ignition-transport11-11.1.0.tar.bz2"
   sha256 "e02d65374817db971ac46e2a49eae2799fb00bffae9db65cc847a33046746ec6"
   license "Apache-2.0"
-  revision 1
+  revision 2
   version_scheme 1
 
   depends_on "doxygen" => [:build, :optional]

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -7,6 +7,12 @@ class IgnitionTransport11 < Formula
   revision 2
   version_scheme 1
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 big_sur:  "b6c5408ae01f434f78299c2bca8569a96ddd59b18abb6e16d8e7370289f33108"
+    sha256 catalina: "31ad4554a2d75263620edfe5b252733ba0042fbda3d8254ae75149b0217d159f"
+  end
+
   depends_on "doxygen" => [:build, :optional]
   depends_on "protobuf-c" => :build
 


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/1860.

Since `ignition-msgs8` had already been rebuilt, its dependents could be bumped with:

~~~
for f in $(brew uses ignition-msgs8)
do
  echo $f
  brew bump-revision --message="rebuild after protobuf" $f
done
~~~