### PR TITLE
Revert "gz-common5: depend on libcsv"

### DIFF
--- a/Formula/ignition-common5.rb
+++ b/Formula/ignition-common5.rb
@@ -14,7 +14,6 @@ class IgnitionCommon5 < Formula
   depends_on "gz-cmake3"
   depends_on "gz-math7"
   depends_on "gz-utils2"
-  depends_on "libcsv"
   depends_on macos: :high_sierra # c++17
   depends_on "ossp-uuid"
   depends_on "pkg-config"


### PR DESCRIPTION
Reverts osrf/homebrew-simulation#1976

Signed-off-by: Michael Carroll <michael@openrobotics.org>