### PR TITLE
fortress, garden: build/test depend on python@3.9

### DIFF
--- a/Formula/ignition-fortress.rb
+++ b/Formula/ignition-fortress.rb
@@ -18,6 +18,7 @@ class IgnitionFortress < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "python@3.9" => [:build, :test]
   depends_on "ignition-cmake2"
   depends_on "ignition-common4"
   depends_on "ignition-fuel-tools7"

--- a/Formula/ignition-garden.rb
+++ b/Formula/ignition-garden.rb
@@ -10,6 +10,7 @@ class IgnitionGarden < Formula
   head "https://github.com/gazebosim/gz-garden.git", branch: "main"
 
   depends_on "cmake" => :build
+  depends_on "python@3.9" => [:build, :test]
   depends_on "gz-cmake3"
   depends_on "gz-common5"
   depends_on "gz-fuel-tools8"


### PR DESCRIPTION
This should fix the failing bottle tests.

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_fortress-install_bottle-homebrew-amd64&build=479)](https://build.osrfoundation.org/job/ignition_fortress-install_bottle-homebrew-amd64/479/) https://build.osrfoundation.org/job/ignition_fortress-install_bottle-homebrew-amd64/479/