### PR TITLE
Rebuild gz-gazebo6 / launch5 to fix linkage

### DIFF
--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -8,8 +8,8 @@ class IgnitionGazebo6 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "a872526fa1a1a3acb48000e2c13d8226f045e4c7030a7b9664219cc7257184a0"
-    sha256 catalina: "a738d36fb9ae22b92c099ad51d6e73aa8d91f393756a52e45ad41f65f9f95eac"
+    sha256 big_sur:  "7476adc8d6e4ea47e0985642710fd934d607d50c6380c0309dee05902ff196eb"
+    sha256 catalina: "bf0427eb758afea693b6728dbda0416e5f743d0292712e285655190b75a2820d"
   end
 
   depends_on "cmake" => :build

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -4,7 +4,7 @@ class IgnitionGazebo6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gazebo/releases/ignition-gazebo6-6.10.0.tar.bz2"
   sha256 "8f5da2ba0c6ff2cbc5f04fb067c935eda4e5b66dbcca38994e3a43ad5840a7cf"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ignition-launch5.rb
+++ b/Formula/ignition-launch5.rb
@@ -4,7 +4,7 @@ class IgnitionLaunch5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-launch/releases/ignition-launch5-5.1.0.tar.bz2"
   sha256 "910f46ecb50503f86ec5753e367108c26bf9d74e9457d01c4099150c982b3e87"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ignition-launch5.rb
+++ b/Formula/ignition-launch5.rb
@@ -8,8 +8,8 @@ class IgnitionLaunch5 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "9c46c82b5fd3d98ddb3e6385f611e6917a70053bc71d4cf3868a76018dc730d7"
-    sha256 catalina: "5fba33408871a7117f2a758a5dbb3116e8e3998ffcea537d9e85d1c4c634a4e9"
+    sha256 big_sur:  "4fc04d4a1b7aa7cb3c62934c5156b96ec6bc60043ecb2d937fd31deb1b8a45a8"
+    sha256 catalina: "5a8b7c71e8b6bc596cf0849b3133edf9273f98ba9774cc6930c0b3e26fbc0b2e"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
There are some persistent bottle failures due to broken linkage, so bump revisions and try again.

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gazebo6-install_bottle-homebrew-amd64&build=307)](https://build.osrfoundation.org/job/ignition_gazebo6-install_bottle-homebrew-amd64/307/) https://build.osrfoundation.org/job/ignition_gazebo6-install_bottle-homebrew-amd64/307/
* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_launch5-install_bottle-homebrew-amd64&build=307)](https://build.osrfoundation.org/job/ignition_launch5-install_bottle-homebrew-amd64/307/) https://build.osrfoundation.org/job/ignition_launch5-install_bottle-homebrew-amd64/307/