### PR TITLE
Add aliases for versions post-Garden

### DIFF
--- a/Aliases/gz-cmake4
+++ b/Aliases/gz-cmake4
@@ -1,0 +1,1 @@
+../Formula/ignition-cmake3.rb

--- a/Aliases/gz-common6
+++ b/Aliases/gz-common6
@@ -1,0 +1,1 @@
+../Formula/ignition-common5.rb

--- a/Aliases/gz-fuel-tools9
+++ b/Aliases/gz-fuel-tools9
@@ -1,0 +1,1 @@
+../Formula/ignition-fuel-tools8.rb

--- a/Aliases/gz-gui8
+++ b/Aliases/gz-gui8
@@ -1,0 +1,1 @@
+../Formula/ignition-gui7.rb

--- a/Aliases/gz-launch7
+++ b/Aliases/gz-launch7
@@ -1,0 +1,1 @@
+../Formula/ignition-launch6.rb

--- a/Aliases/gz-math8
+++ b/Aliases/gz-math8
@@ -1,0 +1,1 @@
+../Formula/ignition-math7.rb

--- a/Aliases/gz-msgs10
+++ b/Aliases/gz-msgs10
@@ -1,0 +1,1 @@
+../Formula/ignition-msgs9.rb

--- a/Aliases/gz-physics7
+++ b/Aliases/gz-physics7
@@ -1,0 +1,1 @@
+../Formula/ignition-physics6.rb

--- a/Aliases/gz-plugin3
+++ b/Aliases/gz-plugin3
@@ -1,0 +1,1 @@
+../Formula/ignition-plugin2.rb

--- a/Aliases/gz-rendering8
+++ b/Aliases/gz-rendering8
@@ -1,0 +1,1 @@
+../Formula/ignition-rendering7.rb

--- a/Aliases/gz-sensors8
+++ b/Aliases/gz-sensors8
@@ -1,0 +1,1 @@
+../Formula/ignition-sensors7.rb

--- a/Aliases/gz-sim8
+++ b/Aliases/gz-sim8
@@ -1,0 +1,1 @@
+../Formula/ignition-gazebo7.rb

--- a/Aliases/gz-tools3
+++ b/Aliases/gz-tools3
@@ -1,0 +1,1 @@
+../Formula/ignition-tools2.rb

--- a/Aliases/gz-transport13
+++ b/Aliases/gz-transport13
@@ -1,0 +1,1 @@
+../Formula/ignition-transport12.rb

--- a/Aliases/gz-utils3
+++ b/Aliases/gz-utils3
@@ -1,0 +1,1 @@
+../Formula/ignition-utils2.rb


### PR DESCRIPTION
* Part of https://github.com/gazebo-tooling/release-tools/issues/578

I think we eventually should flip the Garden formulae to be `gz` and the aliases to be `ignition`.