### PR TITLE
Add gz- aliases for all stable ignition- versions

### DIFF
--- a/Aliases/gz-citadel
+++ b/Aliases/gz-citadel
@@ -1,0 +1,1 @@
+../Formula/ignition-citadel.rb

--- a/Aliases/gz-cmake0
+++ b/Aliases/gz-cmake0
@@ -1,0 +1,1 @@
+../Formula/ignition-cmake0.rb

--- a/Aliases/gz-cmake2
+++ b/Aliases/gz-cmake2
@@ -1,0 +1,1 @@
+../Formula/ignition-cmake2.rb

--- a/Aliases/gz-common1
+++ b/Aliases/gz-common1
@@ -1,0 +1,1 @@
+../Formula/ignition-common1.rb

--- a/Aliases/gz-common3
+++ b/Aliases/gz-common3
@@ -1,0 +1,1 @@
+../Formula/ignition-common3.rb

--- a/Aliases/gz-common4
+++ b/Aliases/gz-common4
@@ -1,0 +1,1 @@
+../Formula/ignition-common4.rb

--- a/Aliases/gz-fortress
+++ b/Aliases/gz-fortress
@@ -1,0 +1,1 @@
+../Formula/ignition-fortress.rb

--- a/Aliases/gz-fuel-tools1
+++ b/Aliases/gz-fuel-tools1
@@ -1,0 +1,1 @@
+../Formula/ignition-fuel-tools1.rb

--- a/Aliases/gz-fuel-tools4
+++ b/Aliases/gz-fuel-tools4
@@ -1,0 +1,1 @@
+../Formula/ignition-fuel-tools4.rb

--- a/Aliases/gz-fuel-tools7
+++ b/Aliases/gz-fuel-tools7
@@ -1,0 +1,1 @@
+../Formula/ignition-fuel-tools7.rb

--- a/Aliases/gz-gui3
+++ b/Aliases/gz-gui3
@@ -1,0 +1,1 @@
+../Formula/ignition-gui3.rb

--- a/Aliases/gz-gui6
+++ b/Aliases/gz-gui6
@@ -1,0 +1,1 @@
+../Formula/ignition-gui6.rb

--- a/Aliases/gz-launch2
+++ b/Aliases/gz-launch2
@@ -1,0 +1,1 @@
+../Formula/ignition-launch2.rb

--- a/Aliases/gz-launch5
+++ b/Aliases/gz-launch5
@@ -1,0 +1,1 @@
+../Formula/ignition-launch5.rb

--- a/Aliases/gz-math4
+++ b/Aliases/gz-math4
@@ -1,0 +1,1 @@
+../Formula/ignition-math4.rb

--- a/Aliases/gz-math6
+++ b/Aliases/gz-math6
@@ -1,0 +1,1 @@
+../Formula/ignition-math6.rb

--- a/Aliases/gz-msgs1
+++ b/Aliases/gz-msgs1
@@ -1,0 +1,1 @@
+../Formula/ignition-msgs1.rb

--- a/Aliases/gz-msgs5
+++ b/Aliases/gz-msgs5
@@ -1,0 +1,1 @@
+../Formula/ignition-msgs5.rb

--- a/Aliases/gz-msgs8
+++ b/Aliases/gz-msgs8
@@ -1,0 +1,1 @@
+../Formula/ignition-msgs8.rb

--- a/Aliases/gz-physics2
+++ b/Aliases/gz-physics2
@@ -1,0 +1,1 @@
+../Formula/ignition-physics2.rb

--- a/Aliases/gz-physics5
+++ b/Aliases/gz-physics5
@@ -1,0 +1,1 @@
+../Formula/ignition-physics5.rb

--- a/Aliases/gz-plugin1
+++ b/Aliases/gz-plugin1
@@ -1,0 +1,1 @@
+../Formula/ignition-plugin1.rb

--- a/Aliases/gz-rendering3
+++ b/Aliases/gz-rendering3
@@ -1,0 +1,1 @@
+../Formula/ignition-rendering3.rb

--- a/Aliases/gz-rendering6
+++ b/Aliases/gz-rendering6
@@ -1,0 +1,1 @@
+../Formula/ignition-rendering6.rb

--- a/Aliases/gz-sensors3
+++ b/Aliases/gz-sensors3
@@ -1,0 +1,1 @@
+../Formula/ignition-sensors3.rb

--- a/Aliases/gz-sensors6
+++ b/Aliases/gz-sensors6
@@ -1,0 +1,1 @@
+../Formula/ignition-sensors6.rb

--- a/Aliases/gz-sim3
+++ b/Aliases/gz-sim3
@@ -1,0 +1,1 @@
+../Formula/ignition-gazebo3.rb

--- a/Aliases/gz-sim6
+++ b/Aliases/gz-sim6
@@ -1,0 +1,1 @@
+../Formula/ignition-gazebo6.rb

--- a/Aliases/gz-tools
+++ b/Aliases/gz-tools
@@ -1,0 +1,1 @@
+../Formula/ignition-tools.rb

--- a/Aliases/gz-transport11
+++ b/Aliases/gz-transport11
@@ -1,0 +1,1 @@
+../Formula/ignition-transport11.rb

--- a/Aliases/gz-transport4
+++ b/Aliases/gz-transport4
@@ -1,0 +1,1 @@
+../Formula/ignition-transport4.rb

--- a/Aliases/gz-transport8
+++ b/Aliases/gz-transport8
@@ -1,0 +1,1 @@
+../Formula/ignition-transport8.rb

--- a/Aliases/gz-utils1
+++ b/Aliases/gz-utils1
@@ -1,0 +1,1 @@
+../Formula/ignition-utils1.rb


### PR DESCRIPTION
Added aliases for all supported versions according to [this table](https://github.com/gazebosim/docs/blob/master/tools/versions.md).

The goals are:

* Allowing users to start using the `gz` aliases from Citadel and Fortress
* Using `gz` across all our CI for convenience