### PR TITLE
gz-tools1: add alias

### DIFF
--- a/Aliases/gz-tools1
+++ b/Aliases/gz-tools1
@@ -1,0 +1,1 @@
+../Formula/ignition-tools.rb


### PR DESCRIPTION
This is similar to ignition-tools1. CI is currently failing for PRs targetting (e.g., https://github.com/gazebosim/gz-tools/pull/104) the `gz-tools1` branch with the following error:

```
# BEGIN SECTION: install gz-tools1 dependencies
+ brew install gz-tools1 --only-dependencies
Warning: No available formula with the name "gz-tools1".
==> Searching for similarly named formulae...
```
https://build.osrfoundation.org/job/ignition_tools-ci-pr_any-homebrew-amd64/292/