### PR TITLE
Fix python path, rename gz-garden formula

### DIFF
--- a/Aliases/gz-garden
+++ b/Aliases/gz-garden
@@ -1,1 +1,0 @@
-../Formula/ignition-garden.rb

--- a/Aliases/gz-garden1
+++ b/Aliases/gz-garden1
@@ -1,0 +1,1 @@
+../Formula/gz-garden.rb

--- a/Aliases/ignition-garden
+++ b/Aliases/ignition-garden
@@ -1,0 +1,1 @@
+../Formula/gz-garden.rb

--- a/Aliases/ignition-garden1
+++ b/Aliases/ignition-garden1
@@ -1,1 +1,0 @@
-../Formula/ignition-garden.rb

--- a/Formula/gz-garden.rb
+++ b/Formula/gz-garden.rb
@@ -1,4 +1,4 @@
-class IgnitionGarden < Formula
+class GzGarden < Formula
   include Language::Python::Virtualenv
 
   desc "Collection of gazebo simulation software"

--- a/Formula/ignition-citadel.rb
+++ b/Formula/ignition-citadel.rb
@@ -50,7 +50,7 @@ class IgnitionCitadel < Formula
       system "make", "install"
     end
 
-    venv = virtualenv_create(libexec, Formula["python@3.9"].opt_bin/"python3")
+    venv = virtualenv_create(libexec, Formula["python@3.9"].opt_libexec/"bin/python3")
     %w[PyYAML vcstool].each do |pkg|
       venv.pip_install pkg
     end

--- a/Formula/ignition-fortress.rb
+++ b/Formula/ignition-fortress.rb
@@ -48,7 +48,7 @@ class IgnitionFortress < Formula
       system "make", "install"
     end
 
-    venv = virtualenv_create(libexec, Formula["python@3.9"].opt_bin/"python3")
+    venv = virtualenv_create(libexec, Formula["python@3.9"].opt_libexec/"bin/python3")
     %w[PyYAML vcstool].each do |pkg|
       venv.pip_install pkg
     end

--- a/Formula/ignition-garden.rb
+++ b/Formula/ignition-garden.rb
@@ -41,7 +41,7 @@ class IgnitionGarden < Formula
       system "make", "install"
     end
 
-    venv = virtualenv_create(libexec, Formula["python@3.9"].opt_bin/"python3")
+    venv = virtualenv_create(libexec, Formula["python@3.9"].opt_libexec/"bin/python3")
     %w[PyYAML vcstool].each do |pkg|
       venv.pip_install pkg
     end


### PR DESCRIPTION
I've noticed some failures building the `gz-garden` formula:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_garden-install_bottle-homebrew-amd64&build=282)](https://build.osrfoundation.org/view/ign-garden/job/ignition_garden-install_bottle-homebrew-amd64/282/) https://build.osrfoundation.org/view/ign-garden/job/ignition_garden-install_bottle-homebrew-amd64/282/

~~~
Last 15 lines from /Users/jenkins/Library/Logs/Homebrew/ignition-garden/03.python3:
2022-08-16 15:14:19 +0000

/usr/local/opt/python@3.9/bin/python3
-m
venv
--system-site-packages
/usr/local/Cellar/ignition-garden/0.999.999~0~20220414/libexec
~~~

The issue is that the `python@3.9` formula no longer provides a `python3` symlink in the `bin` folder (see https://github.com/Homebrew/homebrew-core/commit/24aa6070176384ca52d01aa76707586be4f2cc12); it can now be accessed in `libexec/bin`.

This also renames the `ignition-garden` formula to `gz-garden`, which I forgot to include in #1994.