### PR TITLE
Add python dependency to packages with bindings

### DIFF
--- a/Formula/gz-math7.rb
+++ b/Formula/gz-math7.rb
@@ -11,6 +11,7 @@ class GzMath7 < Formula
   depends_on "eigen"
   depends_on "gz-cmake3"
   depends_on "gz-utils2"
+  depends_on "python"
   depends_on "ruby"
 
   def install

--- a/Formula/ignition-math6.rb
+++ b/Formula/ignition-math6.rb
@@ -16,6 +16,7 @@ class IgnitionMath6 < Formula
   depends_on "pybind11" => :build
   depends_on "eigen"
   depends_on "ignition-cmake2"
+  depends_on "python"
   depends_on "ruby"
 
   def install

--- a/Formula/sdformat13.rb
+++ b/Formula/sdformat13.rb
@@ -14,6 +14,7 @@ class Sdformat13 < Formula
   depends_on "gz-tools2"
   depends_on "gz-utils2"
   depends_on macos: :mojave # c++17
+  depends_on "python"
   depends_on "tinyxml2"
   depends_on "urdfdom"
 


### PR DESCRIPTION
I think this is related to python test failures like the following:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci-sdformat13-homebrew-amd64&build=6)](https://build.osrfoundation.org/job/sdformat-ci-sdformat13-homebrew-amd64/6/) https://build.osrfoundation.org/job/sdformat-ci-sdformat13-homebrew-amd64/6/

~~~
282:     from gz.math import Pose3d, Color
282: E   ModuleNotFoundError: No module named 'gz'
~~~
