### PR TITLE
Fix python bindings so PYTHONPATH isn't needed

### DIFF
--- a/Formula/gz-math7.rb
+++ b/Formula/gz-math7.rb
@@ -5,6 +5,7 @@ class GzMath7 < Formula
   version "7.0.0~pre1"
   sha256 "0a8c1184a87a71f8a6a91fa1cec08e7f5f8d5df992abcbceb247226e0e6a20b3"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/gz-math7.rb
+++ b/Formula/gz-math7.rb
@@ -29,7 +29,8 @@ class GzMath7 < Formula
     system "cmake", ".", *cmake_args
     system "make", "install"
 
-    (lib/"python3.10").install Dir[lib/"python/site-packages"]
+    (lib/"python3.10/site-packages").install Dir[lib/"python/*"]
+    rmdir prefix/"lib/python"
   end
 
   test do

--- a/Formula/gz-math7.rb
+++ b/Formula/gz-math7.rb
@@ -22,6 +22,12 @@ class GzMath7 < Formula
   depends_on "python@3.10"
   depends_on "ruby"
 
+  patch do
+    # Don't link to python libraries
+    url "https://github.com/gazebosim/gz-math/commit/bedd27bf88b33693fe2592ee758957479af857de.patch?full_index=1"
+    sha256 "7c4129fe1f99ed60f2d18deef38fcc958a303616b1323dfc22e58e557d481d61"
+  end
+
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"

--- a/Formula/gz-math7.rb
+++ b/Formula/gz-math7.rb
@@ -18,7 +18,7 @@ class GzMath7 < Formula
   depends_on "eigen"
   depends_on "gz-cmake3"
   depends_on "gz-utils2"
-  depends_on "python"
+  depends_on "python@3.10"
   depends_on "ruby"
 
   def install
@@ -27,6 +27,8 @@ class GzMath7 < Formula
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
     system "cmake", ".", *cmake_args
     system "make", "install"
+
+    (lib/"python3.10").install Dir[lib/"python/site-packages"]
   end
 
   test do
@@ -63,5 +65,7 @@ class GzMath7 < Formula
     # check for Xcode frameworks in bottle
     cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
     system cmd_not_grep_xcode
+    # check python import
+    system Formula["python@3.10"].opt_bin/"python3.10", "-c", "import gz.math"
   end
 end

--- a/Formula/gz-math7.rb
+++ b/Formula/gz-math7.rb
@@ -9,8 +9,8 @@ class GzMath7 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, big_sur:  "2dee018ae1e3157ce027cd9f68a133b28851df9f95a34f582cd260e302f0ccdd"
-    sha256 cellar: :any, catalina: "9fa84203302250efbb48ef3b63b3bded9307cfb46f67af4f287565ef35806d5d"
+    sha256 cellar: :any, big_sur:  "80e4c86faa6c669a393198a8ed294528c6868ffca808af2faa95e48781b155f1"
+    sha256 cellar: :any, catalina: "b1ac6faa95684fa51e759a57c9f12209f1501d2831db3bdd5f61b05ebdb8bbe6"
   end
 
   depends_on "cmake" => :build

--- a/Formula/sdformat13.rb
+++ b/Formula/sdformat13.rb
@@ -21,7 +21,7 @@ class Sdformat13 < Formula
   depends_on "gz-tools2"
   depends_on "gz-utils2"
   depends_on macos: :mojave # c++17
-  depends_on "python"
+  depends_on "python@3.10"
   depends_on "tinyxml2"
   depends_on "urdfdom"
 
@@ -34,6 +34,8 @@ class Sdformat13 < Formula
       system "cmake", "..", *cmake_args
       system "make", "install"
     end
+
+    (lib/"python3.10").install Dir[lib/"python/site-packages"]
   end
 
   test do
@@ -78,5 +80,7 @@ class Sdformat13 < Formula
     # check for Xcode frameworks in bottle
     cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
     system cmd_not_grep_xcode
+    # check python import
+    system Formula["python@3.10"].opt_bin/"python3.10", "-c", "import sdformat"
   end
 end

--- a/Formula/sdformat13.rb
+++ b/Formula/sdformat13.rb
@@ -27,6 +27,12 @@ class Sdformat13 < Formula
   depends_on "tinyxml2"
   depends_on "urdfdom"
 
+  patch do
+    # Don't link to python libraries
+    url "https://github.com/gazebosim/sdformat/commit/3b66e510386a5f0dc05f8255aa7f51ebb8463a3e.patch?full_index=1"
+    sha256 "e87d3339bc296670dd90a896b81590a0741ce4bc00b4fae9428d04c616048931"
+  end
+
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"

--- a/Formula/sdformat13.rb
+++ b/Formula/sdformat13.rb
@@ -15,6 +15,7 @@ class Sdformat13 < Formula
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
+  depends_on "pybind11" => :build
 
   depends_on "doxygen"
   depends_on "gz-cmake3"

--- a/Formula/sdformat13.rb
+++ b/Formula/sdformat13.rb
@@ -9,8 +9,8 @@ class Sdformat13 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "b4939109fd145ee3cdf1785ad1590aed9b2f2ec0569c1cd1fd56b96dcd12b8fc"
-    sha256 catalina: "6d897a784ddd7b6d20ed4a81668cbe6e8b189d60ab0c6b530ef098143f224e7f"
+    sha256 big_sur:  "f46b6232c1dcded2128aa2753ac3dfbb4cf51f82f618d55442a75e4f92848f79"
+    sha256 catalina: "a5310f21f9be0337d8556bf794af5451336f3e6ddcf41ff37ca77f9216c93539"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/sdformat13.rb
+++ b/Formula/sdformat13.rb
@@ -5,6 +5,7 @@ class Sdformat13 < Formula
   version "13.0.0~pre1"
   sha256 "742afdd8c2eaaf5c2d339c238726258ece4109851a97812874a9b8823a6304a6"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/sdformat13.rb
+++ b/Formula/sdformat13.rb
@@ -36,7 +36,8 @@ class Sdformat13 < Formula
       system "make", "install"
     end
 
-    (lib/"python3.10").install Dir[lib/"python/site-packages"]
+    (lib/"python3.10/site-packages").install Dir[lib/"python/*"]
+    rmdir prefix/"lib/python"
   end
 
   test do


### PR DESCRIPTION
This installs the python bindings for `gz-math7` and `sdformat13` to `lib/python3.10` instead of `lib/python` and explicitly depends on the `python@3.10` formula. This should allow our bindings to be used with home-brew's `python@3.10` without setting `PYTHONPATH`.