### PR TITLE
ignition-tools: fix default data path

### DIFF
--- a/Formula/ignition-tools.rb
+++ b/Formula/ignition-tools.rb
@@ -4,6 +4,7 @@ class IgnitionTools < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-tools/releases/ignition-tools-1.5.0.tar.bz2"
   sha256 "00cf5d2eb6222784d6db4de6baffc068013b1fd71d733f496c9f99addc12117d"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/gazebosim/gz-tools.git", branch: "ign-tools1"
 
   bottle do

--- a/Formula/ignition-tools.rb
+++ b/Formula/ignition-tools.rb
@@ -17,6 +17,10 @@ class IgnitionTools < Formula
   depends_on "ruby" => :test
 
   def install
+    inreplace "src/ign.in" do |s|
+      s.gsub! "@CMAKE_INSTALL_PREFIX@", HOMEBREW_PREFIX
+    end
+
     mkdir "build" do
       system "cmake", "..", *std_cmake_args
       system "make", "install"

--- a/Formula/ignition-tools.rb
+++ b/Formula/ignition-tools.rb
@@ -9,8 +9,8 @@ class IgnitionTools < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, big_sur:  "d5cf4bb350cc1f04b9827d1518863cca1e58e4f2d16134f8655b183ee8d70978"
-    sha256 cellar: :any, catalina: "cf315d62510544eadc5d01dd3c6041de59c97b8e6e322537f22fef7f9783e0f3"
+    sha256 cellar: :any, big_sur:  "9402482d4365a56f82a98e2ba77bd8dfbccbf13a046b7e8fed764914120509d4"
+    sha256 cellar: :any, catalina: "41f0d2252bf63b397066d8b82b1e48186deac5aabc57cc9a7dbb4b332fa7131f"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
Similar to https://github.com/osrf/homebrew-simulation/pull/2039.

This avoids the need for setting `IGN_CONFIG_PATH` for `ign` libraries installed via homebrew.