### PR TITLE
gazebo9/11: remove broken bottles

### DIFF
--- a/Formula/gazebo11.rb
+++ b/Formula/gazebo11.rb
@@ -4,14 +4,9 @@ class Gazebo11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/gazebo-11.12.0.tar.bz2"
   sha256 "c40ca1ec71b6ab427e7feb83c922bfb262e84e11ebf6bb91f99bc3cca75bcd97"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/osrf/gazebo.git", branch: "gazebo11"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "162bde14cb6cd01cbc23d53e15791159cd6797668c6d06109f81a51d299afd72"
-    sha256 catalina: "8b417c22346ba8a6b1db764dea05d8329942e7ac1248d83e5939b70f1eddf197"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/gazebo9.rb
+++ b/Formula/gazebo9.rb
@@ -4,15 +4,9 @@ class Gazebo9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/gazebo-9.19.0.tar.bz2"
   sha256 "1f3ca430824b120ae0c7c4c0037a1a56e7b6bf6c50731b148b5c75bfc46d7fe7"
   license "Apache-2.0"
-  revision 20
+  revision 21
 
   head "https://github.com/osrf/gazebo.git", branch: "gazebo9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "9fc8bdd2badf92d5e679adea0e80508f2683e4373f4bd0b6f597129576945e27"
-    sha256 catalina: "160b76e23f869cc0d0479b0c82402c817582a57f5762668befd63d317cbb06a5"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build


### PR DESCRIPTION
Boost 1.80 was recently released, and the gazebo9 and gazebo11 bottles are broken at the moment (see #2069). This removes the broken bottles so users will build from source for now.