### PR TITLE
Garden: build monterey bottles part 1

### DIFF
--- a/Formula/gz-math7.rb
+++ b/Formula/gz-math7.rb
@@ -5,6 +5,8 @@ class GzMath7 < Formula
   sha256 "007711649c5f419f2b902f32afc126d791d90dbccc8cc9a0a8ea43874fea2e6a"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/gz-math.git", branch: "gz-math7"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any, big_sur:  "168bdcf7acd3bccb5380d160bcb2b87c905ba78a2afaaf00e76ad9cd7f64cfae"
@@ -24,8 +26,12 @@ class GzMath7 < Formula
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
-    system "cmake", ".", *cmake_args
-    system "make", "install"
+
+    # Use build folder
+    mkdir "build" do
+      system "cmake", "..", *cmake_args
+      system "make", "install"
+    end
 
     (lib/"python3.10/site-packages").install Dir[lib/"python/*"]
     rmdir prefix/"lib/python"

--- a/Formula/gz-math7.rb
+++ b/Formula/gz-math7.rb
@@ -9,6 +9,7 @@ class GzMath7 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, monterey: "3eee0dd0dca86b510c8133e2425ab24dd5e6e3847f303c52649cc80a2416d81e"
     sha256 cellar: :any, big_sur:  "168bdcf7acd3bccb5380d160bcb2b87c905ba78a2afaaf00e76ad9cd7f64cfae"
     sha256 cellar: :any, catalina: "5122a24c64b8797c61b811defc451cb8c46080555a5dc058ee3e2590e6593fde"
   end

--- a/Formula/gz-plugin2.rb
+++ b/Formula/gz-plugin2.rb
@@ -5,6 +5,8 @@ class GzPlugin2 < Formula
   sha256 "53ed6739275943dfbc5390f437ea12fdbeaa6dd5ec80347f59e7b4c6f11f3131"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/gz-math.git", branch: "gz-math7"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any, big_sur:  "d8411a99175713a605030f848755154ad8d3c12ad023333e44e243cf2bfa1723"
@@ -22,8 +24,12 @@ class GzPlugin2 < Formula
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
-    system "cmake", ".", *cmake_args
-    system "make", "install"
+
+    # Use build folder
+    mkdir "build" do
+      system "cmake", "..", *cmake_args
+      system "make", "install"
+    end
   end
 
   test do

--- a/Formula/gz-plugin2.rb
+++ b/Formula/gz-plugin2.rb
@@ -9,6 +9,7 @@ class GzPlugin2 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, monterey: "b1f61cb72cf96edc1008a9ad8b3375440cc45a5df8c4d7cbf23584c4c9242af6"
     sha256 cellar: :any, big_sur:  "d8411a99175713a605030f848755154ad8d3c12ad023333e44e243cf2bfa1723"
     sha256 cellar: :any, catalina: "cbb92efd156493eeab4eac4f26f504659b1b2b73906529539acd10d70b035a1d"
   end

--- a/Formula/gz-tools2.rb
+++ b/Formula/gz-tools2.rb
@@ -5,6 +5,8 @@ class GzTools2 < Formula
   sha256 "bcbba3e4d902d7612267c1b6186dc6a84e6f034e6f44679d4bc1bcdc560955cb"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/gz-tools.git", branch: "gz-tools2"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any, big_sur:  "9519599bc5aa05866fe561eda915bcc83543f64be48a90c7ba6d304ce8a2cc42"

--- a/Formula/gz-tools2.rb
+++ b/Formula/gz-tools2.rb
@@ -9,6 +9,7 @@ class GzTools2 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, monterey: "4be43e915e0f6fb8c02eabbc174ffd54270860d0c1fc72cb0c8a6fc20ecc3531"
     sha256 cellar: :any, big_sur:  "9519599bc5aa05866fe561eda915bcc83543f64be48a90c7ba6d304ce8a2cc42"
     sha256 cellar: :any, catalina: "effc20690e226877faf1f2674528a73d22604be503dc25b85c9705355a2ab1d5"
   end

--- a/Formula/gz-utils2.rb
+++ b/Formula/gz-utils2.rb
@@ -5,6 +5,8 @@ class GzUtils2 < Formula
   sha256 "a2fb092f49310c1d61cbdecc4d75d3ffbd4475352d510b8733cde8bc06555e46"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/gz-utils.git", branch: "gz-utils2"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any, big_sur:  "06232e41bb86374561a8b325429be785770fa108644286329f4453f429612d1d"

--- a/Formula/gz-utils2.rb
+++ b/Formula/gz-utils2.rb
@@ -9,6 +9,7 @@ class GzUtils2 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, monterey: "5e3b750887a113b4775d05e6b15a14d3d915f9f0f4029c92109460d837ea0b49"
     sha256 cellar: :any, big_sur:  "06232e41bb86374561a8b325429be785770fa108644286329f4453f429612d1d"
     sha256 cellar: :any, catalina: "b59cfd89d536d1d5c6635f460a61f65649970718798ec2269c3c848be5456443"
   end


### PR DESCRIPTION
Add small change to several formulae (head)
so bottle builds for macOS Monterey can be
triggered.

* gz-tools2
* gz-utils2
* gz-math7
* gz-plugin2

Built using a deployment of https://github.com/gazebo-tooling/release-tools/pull/840.