### PR TITLE
Garden: build monterey bottles part 2

### DIFF
--- a/Formula/gz-common5.rb
+++ b/Formula/gz-common5.rb
@@ -9,6 +9,7 @@ class GzCommon5 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, monterey: "c35d710ee066a1b67abba357733d649acfaa78e20034685e807e18753d31c064"
     sha256 cellar: :any, big_sur:  "a362fbac6778758ba023675c08780bddedd25a4f1d52eea3b13ef8b6caf7a2fc"
     sha256 cellar: :any, catalina: "ee69b523fb2846d93571f6191439031ed0f29b00489f634a59bb59073d358bcb"
   end

--- a/Formula/gz-common5.rb
+++ b/Formula/gz-common5.rb
@@ -5,7 +5,7 @@ class GzCommon5 < Formula
   sha256 "2b1ef73d22e672bed80d1356d49e85c3e043206e3b274f6f52c6a5fc335ac22d"
   license "Apache-2.0"
 
-  head "https//github.com/gazebosim/gz-common.git", branch: "gz-common5"
+  head "https://github.com/gazebosim/gz-common.git", branch: "gz-common5"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/gz-common5.rb
+++ b/Formula/gz-common5.rb
@@ -5,6 +5,8 @@ class GzCommon5 < Formula
   sha256 "2b1ef73d22e672bed80d1356d49e85c3e043206e3b274f6f52c6a5fc335ac22d"
   license "Apache-2.0"
 
+  head "https//github.com/gazebosim/gz-common.git", branch: "gz-common5"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any, big_sur:  "a362fbac6778758ba023675c08780bddedd25a4f1d52eea3b13ef8b6caf7a2fc"
@@ -29,8 +31,12 @@ class GzCommon5 < Formula
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
-    system "cmake", ".", *cmake_args
-    system "make", "install"
+
+    # Use build folder
+    mkdir "build" do
+      system "cmake", "..", *cmake_args
+      system "make", "install"
+    end
   end
 
   test do

--- a/Formula/gz-msgs9.rb
+++ b/Formula/gz-msgs9.rb
@@ -5,6 +5,8 @@ class GzMsgs9 < Formula
   sha256 "f53db2fc9fec5473515cc82f62f415a5963a28485bdb37dbfe2a322bd0cf17b8"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs9"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any, big_sur:  "1c170c88ab483149748016650542336c34c29b247552f7c4e8ba6f90f98a4946"

--- a/Formula/gz-msgs9.rb
+++ b/Formula/gz-msgs9.rb
@@ -9,6 +9,7 @@ class GzMsgs9 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, monterey: "ae5ed5223aae116d8fd2a0fe4bc48ce939d9d8bc4144c63290d201b1b1ec71cd"
     sha256 cellar: :any, big_sur:  "1c170c88ab483149748016650542336c34c29b247552f7c4e8ba6f90f98a4946"
     sha256 cellar: :any, catalina: "f969d1ad6a6bb056b9f1ef2e6a551da5294a1e072f69a2be2f762865048cfc4d"
   end

--- a/Formula/gz-transport12.rb
+++ b/Formula/gz-transport12.rb
@@ -5,6 +5,8 @@ class GzTransport12 < Formula
   sha256 "5b49397cb4d31aa870f3c837f8c7393301ddc03ff7b45240b67570fd9c634f1a"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport12"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 big_sur:  "b2c7fa076bfa48e2de6bd5e7e427bc8728bc0fdf8da570f91d620f3994cacfa8"
@@ -31,8 +33,12 @@ class GzTransport12 < Formula
     cmake_args << "-DBUILD_TESTING=Off"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
 
-    system "cmake", ".", *cmake_args
-    system "make", "install"
+
+    # Use build folder
+    mkdir "build" do
+      system "cmake", "..", *cmake_args
+      system "make", "install"
+    end
   end
 
   test do

--- a/Formula/gz-transport12.rb
+++ b/Formula/gz-transport12.rb
@@ -9,6 +9,7 @@ class GzTransport12 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 monterey: "7b69d65349fd0087646f6545a18f2ae6827eb9367e745861662a54ebb171b5d8"
     sha256 big_sur:  "b2c7fa076bfa48e2de6bd5e7e427bc8728bc0fdf8da570f91d620f3994cacfa8"
     sha256 catalina: "3ea54104a57c49eb1f1f9620887729189b357838cf32e30d38c738bfdf28bdee"
   end

--- a/Formula/gz-transport12.rb
+++ b/Formula/gz-transport12.rb
@@ -33,7 +33,6 @@ class GzTransport12 < Formula
     cmake_args << "-DBUILD_TESTING=Off"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
 
-
     # Use build folder
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/sdformat13.rb
+++ b/Formula/sdformat13.rb
@@ -5,6 +5,8 @@ class Sdformat13 < Formula
   sha256 "60b77d9844b48349b97e12a555614463a42f601efaad51052d6b9d2c67476b5d"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/sdformat.git", branch: "sdf13"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 big_sur:  "24a66d46c3b48aee3c69278f9933315d2a6f6033094666025a6f11c8ace72ae6"

--- a/Formula/sdformat13.rb
+++ b/Formula/sdformat13.rb
@@ -9,6 +9,7 @@ class Sdformat13 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 monterey: "ed371809c85aa0519ab661b0c1b5b520a4f40fedc81742be82633ec6e5e2151c"
     sha256 big_sur:  "24a66d46c3b48aee3c69278f9933315d2a6f6033094666025a6f11c8ace72ae6"
     sha256 catalina: "c5935c64ea78d756b02ae0b2e719d34ebfe3ca3989eef849a3a866871e97ac60"
   end


### PR DESCRIPTION
Add small change to several formulae (head)
so bottle builds for macOS Monterey can be
triggered.

* gz-common5, gz-msgs9, gz-transport12, sdformat13
