### PR TITLE
Garden: build monterey bottles part 3

### DIFF
--- a/Formula/gz-fuel-tools8.rb
+++ b/Formula/gz-fuel-tools8.rb
@@ -5,6 +5,8 @@ class GzFuelTools8 < Formula
   sha256 "8bc7d92e4944359fe429fdaa59819c76a6d718e58d237aa153c960768553af90"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools8"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any, big_sur:  "939d83b11996e22338befb47031f43acdc70c94276abcd69c7b00ef690dd2a03"

--- a/Formula/gz-fuel-tools8.rb
+++ b/Formula/gz-fuel-tools8.rb
@@ -9,6 +9,7 @@ class GzFuelTools8 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, monterey: "53d3eb337bb9259fcc586fc74c90ce6aa89174ba8e9fd9aeada4f40c7a8f7f83"
     sha256 cellar: :any, big_sur:  "939d83b11996e22338befb47031f43acdc70c94276abcd69c7b00ef690dd2a03"
     sha256 cellar: :any, catalina: "6a7049eae76bd6da7a439fb7cd58516e2700e10d63c8945fa3b4f6129dccd01d"
   end

--- a/Formula/gz-gui7.rb
+++ b/Formula/gz-gui7.rb
@@ -5,6 +5,8 @@ class GzGui7 < Formula
   sha256 "da1b431991a7ddf803ffd454007ba2c114747882f502c2c9d1066636b1480bf4"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui7"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 big_sur:  "a720f9aaa07802aa930123a3aa6e9bf24b195d6644fecd4104e5d8a6f534e79d"

--- a/Formula/gz-gui7.rb
+++ b/Formula/gz-gui7.rb
@@ -9,6 +9,7 @@ class GzGui7 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 monterey: "b4057dbf892c6e1b49a2df741f82d1d87409997c3953dc7c6ed37fbfafe51819"
     sha256 big_sur:  "a720f9aaa07802aa930123a3aa6e9bf24b195d6644fecd4104e5d8a6f534e79d"
     sha256 catalina: "af618c1a74b9da56dba4a10b193f95cb650e96fa1e29aec18eb50bfc9dbb72a5"
   end

--- a/Formula/gz-rendering7.rb
+++ b/Formula/gz-rendering7.rb
@@ -9,6 +9,7 @@ class GzRendering7 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 monterey: "7fa3ef272de9abacdccf93d99716e5e6297128d8b5f84c876c32ce385914d3b1"
     sha256 big_sur:  "0aacd27855d7d469e52d9cb7b9d8faee38eb1a5ae376c992af0b6277825517e9"
     sha256 catalina: "52d12014696c4bc5d3dcca563979f96c8d32478cb0e5bd09d2f317fcfeb583da"
   end

--- a/Formula/gz-rendering7.rb
+++ b/Formula/gz-rendering7.rb
@@ -5,6 +5,8 @@ class GzRendering7 < Formula
   sha256 "f8f50717ff687eead0967c8478313194a66d8c0fc8564539815218782cdfe349"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering7"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 big_sur:  "0aacd27855d7d469e52d9cb7b9d8faee38eb1a5ae376c992af0b6277825517e9"
@@ -28,8 +30,11 @@ class GzRendering7 < Formula
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
-    system "cmake", ".", *cmake_args
-    system "make", "install"
+
+    mkdir "build" do
+      system "cmake", "..", *cmake_args
+      system "make", "install"
+    end
   end
 
   test do

--- a/Formula/gz-sensors7.rb
+++ b/Formula/gz-sensors7.rb
@@ -9,6 +9,7 @@ class GzSensors7 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, monterey: "c68b368e29b379702fcfbce8d9c66218d36350210236d91f5c667cec8e56ab37"
     sha256 cellar: :any, big_sur:  "c3a886834684ae5a3b86de9c16b17b7f01e93b9c5a6503858be1dc4034be0926"
     sha256 cellar: :any, catalina: "921397a3c1ad14f3ab799e1ce6156d9193624d3248842a420ab3818e3a4a6ae1"
   end

--- a/Formula/gz-sensors7.rb
+++ b/Formula/gz-sensors7.rb
@@ -5,6 +5,8 @@ class GzSensors7 < Formula
   sha256 "1ce2bfcdc3893db9240d1d9f6def00fe920405cae82a903851f7f210fc1373ae"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors7"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any, big_sur:  "c3a886834684ae5a3b86de9c16b17b7f01e93b9c5a6503858be1dc4034be0926"
@@ -27,8 +29,10 @@ class GzSensors7 < Formula
     cmake_args << "-DBUILD_TESTING=OFF"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
 
-    system "cmake", ".", *cmake_args
-    system "make", "install"
+    mkdir "build" do
+      system "cmake", "..", *cmake_args
+      system "make", "install"
+    end
   end
 
   test do


### PR DESCRIPTION
Add small change to several formulae (head)
so bottle builds for macOS Monterey can be
triggered.

* gz-fuel-tools8, gz-gui7, gz-rendering7, gz-sensors7
