### PR TITLE
ogre*: build monterey bottles

### DIFF
--- a/Formula/ogre1.9.rb
+++ b/Formula/ogre1.9.rb
@@ -7,6 +7,8 @@ class Ogre19 < Formula
   license "MIT"
   revision 10
 
+  head "https://github.com/OGRECave/ogre.git", branch: "master"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 big_sur:  "d9d4bc2177fda4189a1633a50766e727cfc3a13abbc64a913d08e92657b6ba49"

--- a/Formula/ogre1.9.rb
+++ b/Formula/ogre1.9.rb
@@ -11,8 +11,9 @@ class Ogre19 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 big_sur:  "d9d4bc2177fda4189a1633a50766e727cfc3a13abbc64a913d08e92657b6ba49"
-    sha256 catalina: "c1e5e0bb08263e3acbf91d1350d02c8f1a9e0c8e124719bd885963b3f1b0a824"
+    sha256 cellar: :any, monterey: "c5fd218d8cfcacea10eabc54837570c4b2fc76024cbf8326e2a716e49096eefe"
+    sha256               big_sur:  "d9d4bc2177fda4189a1633a50766e727cfc3a13abbc64a913d08e92657b6ba49"
+    sha256               catalina: "c1e5e0bb08263e3acbf91d1350d02c8f1a9e0c8e124719bd885963b3f1b0a824"
   end
 
   option "with-cg"

--- a/Formula/ogre2.2.rb
+++ b/Formula/ogre2.2.rb
@@ -37,8 +37,8 @@ class Ogre22 < Formula
     sha256 "38975001bfa903194565ed0bf411cf29857cd5b2f0f71a651d64543f610c4ff6"
   end
 
-  # patch do
   # fix GL3+ compilation with Xcode 10
+  # patch do
   #  url "https://github.com/OGRECave/ogre-next/commit/b00a880a4aea5492615ce8e3363e81631a53bb5c.patch?full_index=1"
   #  sha256 "8fe5beab9e50dfe1f0164e8dbffd20a79f5e9afe79802ab0ce29d8d83e4e0fe8"
   # end

--- a/Formula/ogre2.2.rb
+++ b/Formula/ogre2.2.rb
@@ -11,6 +11,7 @@ class Ogre22 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, monterey: "5cc89ae2a97c6e642f0fe9bbd3587ddeb8544dc278595cc602172fd7890e7e98"
     sha256 cellar: :any, big_sur:  "fae5da6d6bb34344f04e4f78f162f3872124e915fbd50d883e6509c6f1640cbd"
     sha256 cellar: :any, catalina: "222487899f723c60367694395875898f742cd2247e54eaa348f99fcb023c6ebc"
   end

--- a/Formula/ogre2.3.rb
+++ b/Formula/ogre2.3.rb
@@ -6,7 +6,7 @@ class Ogre23 < Formula
   license "MIT"
   revision 1
 
-  head "https://github.com/OGRECave/ogre-next.git", branch: "master"
+  head "https://github.com/OGRECave/ogre-next.git", branch: "v2-3"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/ogre2.3.rb
+++ b/Formula/ogre2.3.rb
@@ -10,6 +10,7 @@ class Ogre23 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, monterey: "c7bc82c7ffed7af79d74e7a9fc84c7c174869bbd797bfb8f818b55a05b36af86"
     sha256 cellar: :any, big_sur:  "d1a6802fc6866492073fa56800424c01e232820f3ab7b00031a1ec00115a73f4"
     sha256 cellar: :any, catalina: "51d97c4d9a057983863425cce7df566fd2665ef81aa1bf7ac4600ecacd1c0252"
   end


### PR DESCRIPTION
Add small change to several formulae
so bottle builds for macOS Monterey can be
triggered.

* ogre1.9, ogre2.2, ogre2.3

Signed-off-by: Steve Peters <scpeters@openrobotics.org>