### PR TITLE
Garden: build monterey bottles part 4

### DIFF
--- a/Formula/gz-garden.rb
+++ b/Formula/gz-garden.rb
@@ -11,6 +11,7 @@ class GzGarden < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, monterey: "f34f77dac43e0a1d6b86e9daaa408e6de91bd920f6d0ccbaa485e7f0c6917020"
     sha256 cellar: :any, big_sur:  "4452076f47fc8f63e224fdb7032854ba3f44f6312eb25908f0ca2fab73242704"
     sha256 cellar: :any, catalina: "3242a7dd3549e9a2496a6de4b5722f6542216e635cd4ebe2d955a98177f6bae2"
   end

--- a/Formula/gz-garden.rb
+++ b/Formula/gz-garden.rb
@@ -17,6 +17,7 @@ class GzGarden < Formula
 
   depends_on "cmake" => :build
   depends_on "python@3.9" => [:build, :test]
+
   depends_on "gz-cmake3"
   depends_on "gz-common5"
   depends_on "gz-fuel-tools8"

--- a/Formula/gz-launch6.rb
+++ b/Formula/gz-launch6.rb
@@ -10,6 +10,7 @@ class GzLaunch6 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 monterey: "81ab84e45ce0a91c949137a8fff80f0c90d49159d641016922a5c94e3ef521d7"
     sha256 big_sur:  "c536b1ffabdc5032d8eb15bea5ff402ed8dd7261abcf6f433e29923603741892"
     sha256 catalina: "109b1875e105519d453188742765ddeee31728c59f5df0d1e911f33366fa060b"
   end

--- a/Formula/gz-launch6.rb
+++ b/Formula/gz-launch6.rb
@@ -6,6 +6,8 @@ class GzLaunch6 < Formula
   license "Apache-2.0"
   revision 1
 
+  head "https://github.com/gazebosim/gz-math.git", branch: "gz-math7"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 big_sur:  "c536b1ffabdc5032d8eb15bea5ff402ed8dd7261abcf6f433e29923603741892"

--- a/Formula/gz-launch6.rb
+++ b/Formula/gz-launch6.rb
@@ -6,7 +6,7 @@ class GzLaunch6 < Formula
   license "Apache-2.0"
   revision 1
 
-  head "https://github.com/gazebosim/gz-math.git", branch: "gz-math7"
+  head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch6"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/gz-physics6.rb
+++ b/Formula/gz-physics6.rb
@@ -5,8 +5,6 @@ class GzPhysics6 < Formula
   sha256 "04f30a98208b6941096fdb262353452e2326cee9624b63cb4c2389765881e52b"
   license "Apache-2.0"
 
-  head "https://github.com/gazebosim/gz-math.git", branch: "gz-math7"
-
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any, monterey: "101ef48460311088d5a0eb736a76b21325b80c8a4c7434e5fc1453dbbf2425f9"
@@ -32,12 +30,8 @@ class GzPhysics6 < Formula
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
-
-    # Use build folder
-    mkdir "build" do
-      system "cmake", "..", *cmake_args
-      system "make", "install"
-    end
+    system "cmake", ".", *cmake_args
+    system "make", "install"
   end
 
   test do

--- a/Formula/gz-physics6.rb
+++ b/Formula/gz-physics6.rb
@@ -5,6 +5,8 @@ class GzPhysics6 < Formula
   sha256 "e11d001ed3f3f898e93387dda493269e14621b0fe05e18da437036ee2377fb0a"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/gz-math.git", branch: "gz-math7"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any, big_sur:  "0d2410e753318b0ae6f6ed0ce9fe531c9351af20dcd910d948d3c66a09d0586b"
@@ -29,8 +31,12 @@ class GzPhysics6 < Formula
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
-    system "cmake", ".", *cmake_args
-    system "make", "install"
+
+    # Use build folder
+    mkdir "build" do
+      system "cmake", "..", *cmake_args
+      system "make", "install"
+    end
   end
 
   test do

--- a/Formula/gz-sim7.rb
+++ b/Formula/gz-sim7.rb
@@ -10,6 +10,7 @@ class GzSim7 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 monterey: "d874ab3a43a814f1961ecdb69b423db5925c7f40dc33773cbbda21ac12c8a4e0"
     sha256 big_sur:  "e2db53342e720365f5f2b4081407bcf7eaa35b892a651dbbe485ac130409a92e"
     sha256 catalina: "d28e71f5274eddf96991402a076c2bacd3b17c6870b3543940b52d4dd2d744ac"
   end

--- a/Formula/gz-sim7.rb
+++ b/Formula/gz-sim7.rb
@@ -6,7 +6,7 @@ class GzSim7 < Formula
   license "Apache-2.0"
   revision 1
 
-  head "https://github.com/gazebosim/gz-math.git", branch: "gz-math7"
+  head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim7"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"

--- a/Formula/gz-sim7.rb
+++ b/Formula/gz-sim7.rb
@@ -6,6 +6,8 @@ class GzSim7 < Formula
   license "Apache-2.0"
   revision 1
 
+  head "https://github.com/gazebosim/gz-math.git", branch: "gz-math7"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 big_sur:  "e2db53342e720365f5f2b4081407bcf7eaa35b892a651dbbe485ac130409a92e"


### PR DESCRIPTION
Add small change to several formulae (head)
so bottle builds for macOS Monterey can be
triggered.

* gz-physics6, gz-sim7, gz-launch6, gz-garden

Signed-off-by: Steve Peters <scpeters@openrobotics.org>