### PR TITLE
Citadel: build monterey bottles part 1

### DIFF
--- a/Formula/ignition-cmake2.rb
+++ b/Formula/ignition-cmake2.rb
@@ -9,6 +9,7 @@ class IgnitionCmake2 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any_skip_relocation, monterey: "32c366d1a2f9e51706f2ede76b15411a4c82777a89b24628baabcdb3aacd5ee9"
     sha256 cellar: :any_skip_relocation, big_sur:  "162492daef1fa6a733344efda48f06686f08410c31b32dae28fbdd3828cb6452"
     sha256 cellar: :any_skip_relocation, catalina: "48b0739cfea3330cd6f58f82d8c92c00f87cbbdaf27e353d21336b32659cdeda"
   end

--- a/Formula/ignition-cmake2.rb
+++ b/Formula/ignition-cmake2.rb
@@ -5,6 +5,8 @@ class IgnitionCmake2 < Formula
   sha256 "20a7b0c9e223db65fd3ed3c0a8e57ddafd93282c81badbf8bc3d493eeb5f37e6"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/gz-cmake.git", branch: "ign-cmake2"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any_skip_relocation, big_sur:  "162492daef1fa6a733344efda48f06686f08410c31b32dae28fbdd3828cb6452"

--- a/Formula/ignition-math6.rb
+++ b/Formula/ignition-math6.rb
@@ -9,6 +9,7 @@ class IgnitionMath6 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, monterey: "454848e5baaa89e55aeed4099745cfd7f8f664f37bc1a60c794d131ef7e989fc"
     sha256 cellar: :any, big_sur:  "f0a2c4558bbba2e7d5decf2ca2cdece0126638c50074d29b4f46ae302b5bf0ee"
     sha256 cellar: :any, catalina: "e1b5423ca61a04d4275c60a22f466175bb077addb8c9aef74656b74f46b56997"
   end

--- a/Formula/ignition-math6.rb
+++ b/Formula/ignition-math6.rb
@@ -5,6 +5,8 @@ class IgnitionMath6 < Formula
   sha256 "4d412a53644ecb984a0f64ca5df6e7043514673a406cd6228173278ce4eaf924"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/gz-math.git", branch: "ign-math6"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any, big_sur:  "f0a2c4558bbba2e7d5decf2ca2cdece0126638c50074d29b4f46ae302b5bf0ee"
@@ -23,8 +25,12 @@ class IgnitionMath6 < Formula
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
-    system "cmake", ".", *cmake_args
-    system "make", "install"
+
+    # Use build folder
+    mkdir "build" do
+      system "cmake", "..", *cmake_args
+      system "make", "install"
+    end
   end
 
   test do

--- a/Formula/ignition-plugin1.rb
+++ b/Formula/ignition-plugin1.rb
@@ -5,6 +5,8 @@ class IgnitionPlugin1 < Formula
   sha256 "07f41e0750f4791ffd0c7984257c40b38f266005ad83c0c05a9f17bf48ce3737"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/gz-plugin.git", branch: "ign-plugin1"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any, big_sur:  "5fbf58660d93f35416b9779859b196d9c0df0c7f2106536b9cbae9b74117f2b8"
@@ -21,8 +23,12 @@ class IgnitionPlugin1 < Formula
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
-    system "cmake", ".", *cmake_args
-    system "make", "install"
+
+    # Use build folder
+    mkdir "build" do
+      system "cmake", "..", *cmake_args
+      system "make", "install"
+    end
   end
 
   test do

--- a/Formula/ignition-plugin1.rb
+++ b/Formula/ignition-plugin1.rb
@@ -9,6 +9,7 @@ class IgnitionPlugin1 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, monterey: "37f25dd0d8c9aada54fee3f5885bad4114dc28dae7c48d2f42e7e7b03cb94d47"
     sha256 cellar: :any, big_sur:  "5fbf58660d93f35416b9779859b196d9c0df0c7f2106536b9cbae9b74117f2b8"
     sha256 cellar: :any, catalina: "376288ed35530e63d78bf5e9b5f255860bcce4b1808acdd13b2e08f19617d584"
   end

--- a/Formula/ignition-tools.rb
+++ b/Formula/ignition-tools.rb
@@ -5,6 +5,7 @@ class IgnitionTools < Formula
   sha256 "00cf5d2eb6222784d6db4de6baffc068013b1fd71d733f496c9f99addc12117d"
   license "Apache-2.0"
   revision 1
+
   head "https://github.com/gazebosim/gz-tools.git", branch: "ign-tools1"
 
   bottle do

--- a/Formula/ignition-tools.rb
+++ b/Formula/ignition-tools.rb
@@ -10,6 +10,7 @@ class IgnitionTools < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, monterey: "b71312917e1bf3be636dd7b328529cee00246681a13088a26a1da94f3cc9bd79"
     sha256 cellar: :any, big_sur:  "9402482d4365a56f82a98e2ba77bd8dfbccbf13a046b7e8fed764914120509d4"
     sha256 cellar: :any, catalina: "41f0d2252bf63b397066d8b82b1e48186deac5aabc57cc9a7dbb4b332fa7131f"
   end

--- a/Formula/ignition-utils1.rb
+++ b/Formula/ignition-utils1.rb
@@ -5,6 +5,8 @@ class IgnitionUtils1 < Formula
   sha256 "2b895878a1e80e8df560c80366aeaa846588dd2670ffa0432b4472e81c65ce58"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/gz-utils.git", branch: "ign-utils1"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any, big_sur:  "837853e0c7387464c7ac15c8f5a2a5f7aa21debc7f2e5d87dbbe790c21e722f7"

--- a/Formula/ignition-utils1.rb
+++ b/Formula/ignition-utils1.rb
@@ -9,6 +9,7 @@ class IgnitionUtils1 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, monterey: "ef7e847022760f728b5e83e8d321eabcf894c7d43aa291e20c76eb1941ee6ab1"
     sha256 cellar: :any, big_sur:  "837853e0c7387464c7ac15c8f5a2a5f7aa21debc7f2e5d87dbbe790c21e722f7"
     sha256 cellar: :any, catalina: "dd74cfaee528c3878c9aaa0865488e742bf1716bf7c15d6c2f701c6a531573b2"
   end


### PR DESCRIPTION
Add small change to several formulae (head)
so bottle builds for macOS Monterey can be
triggered.

* ign-cmake2, ign-utils1, ign-tools, ign-math6, ign-plugin1

Signed-off-by: Steve Peters <scpeters@openrobotics.org>