### PR TITLE
Citadel: build monterey bottles part 2

### DIFF
--- a/Formula/ignition-common3.rb
+++ b/Formula/ignition-common3.rb
@@ -5,6 +5,8 @@ class IgnitionCommon3 < Formula
   sha256 "8c0ac36b97160ecfcb8eeae116fd0a6f07b62bf19004b0992ad2f3c7bc271294"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/gz-common.git", branch: "ign-common3"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any, big_sur:  "caabc4409cc085c30028d399b3be03078623fad7fda59f1b300f014636062697"
@@ -33,8 +35,10 @@ class IgnitionCommon3 < Formula
       cmake_args << "-DIGN_PROFILER_REMOTERY=Off"
     end
 
-    system "cmake", ".", *cmake_args
-    system "make", "install"
+    mkdir "build" do
+      system "cmake", "..", *cmake_args
+      system "make", "install"
+    end
 
     # Remove an accidentally installed CMakeLists.txt file
     # remove this at next release

--- a/Formula/ignition-common3.rb
+++ b/Formula/ignition-common3.rb
@@ -9,6 +9,7 @@ class IgnitionCommon3 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, monterey: "d40677aa261fd5acb29bdcb42fe4c36224892beb9c810befa82f8d3d3337562a"
     sha256 cellar: :any, big_sur:  "caabc4409cc085c30028d399b3be03078623fad7fda59f1b300f014636062697"
     sha256 cellar: :any, catalina: "9988cafca7832805d630d959348e308c7b6e6b9969c216fc2a7206292206e926"
   end

--- a/Formula/ignition-fuel-tools4.rb
+++ b/Formula/ignition-fuel-tools4.rb
@@ -9,6 +9,7 @@ class IgnitionFuelTools4 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, monterey: "897a3c873d79cffde81d55d863fc523d986e5dcb199371424bd80d6d12cced57"
     sha256 cellar: :any, big_sur:  "742db8c5778c335999d950b6e24dffff155391c26adc5c294a56e03e042cc67c"
     sha256 cellar: :any, catalina: "595387e8881ba5b8c927d8b1d5442fe89e5928f823daf345c1b07ee90bdd7322"
   end

--- a/Formula/ignition-fuel-tools4.rb
+++ b/Formula/ignition-fuel-tools4.rb
@@ -5,6 +5,8 @@ class IgnitionFuelTools4 < Formula
   sha256 "8451bdcb040a463f74863cc688e8164dcdd4646b42604a96774ce5d8adee7f9d"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools4"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any, big_sur:  "742db8c5778c335999d950b6e24dffff155391c26adc5c294a56e03e042cc67c"
@@ -22,10 +24,11 @@ class IgnitionFuelTools4 < Formula
   depends_on "pkg-config"
 
   def install
+    cmake_args = std_cmake_args
+    cmake_args << "-DBUILD_TESTING=Off"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+
     mkdir "build" do
-      cmake_args = std_cmake_args
-      cmake_args << "-DBUILD_TESTING=Off"
-      cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
       system "cmake", "..", *cmake_args
       system "make", "install"
     end

--- a/Formula/ignition-gui3.rb
+++ b/Formula/ignition-gui3.rb
@@ -9,6 +9,7 @@ class IgnitionGui3 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 monterey: "899a5304fd2f56a5c5585ef7f21a68491619fce3203c7ef13c93c0b053eddd3a"
     sha256 big_sur:  "6f8c09fde83038788691da475e948317c62ef56c2d410dcbebaa6c5b1ee5b7f1"
     sha256 catalina: "45c370441807a4d283bd3b94561b0536e707ad885d0ae0098b934ef209220e30"
   end

--- a/Formula/ignition-gui3.rb
+++ b/Formula/ignition-gui3.rb
@@ -17,6 +17,7 @@ class IgnitionGui3 < Formula
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
+
   depends_on "ignition-cmake2"
   depends_on "ignition-common3"
   depends_on "ignition-msgs5"

--- a/Formula/ignition-msgs5.rb
+++ b/Formula/ignition-msgs5.rb
@@ -5,6 +5,8 @@ class IgnitionMsgs5 < Formula
   sha256 "59a03770c27b4cdb6d0b0f3de9f10f1c748a47b45376a297e1f30900edb893fd"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs5"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any, big_sur:  "ff0f4b97f2a3cde8118ea90925a1ad6a48e652975d43c1beecce0f2ee3d9c8b2"
@@ -27,8 +29,10 @@ class IgnitionMsgs5 < Formula
     cmake_args << "-DBUILD_TESTING=Off"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
 
-    system "cmake", ".", *cmake_args
-    system "make", "install"
+    mkdir "build" do
+      system "cmake", "..", *cmake_args
+      system "make", "install"
+    end
   end
 
   test do

--- a/Formula/ignition-msgs5.rb
+++ b/Formula/ignition-msgs5.rb
@@ -9,6 +9,7 @@ class IgnitionMsgs5 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, monterey: "4dbb16e2d69fdc20720029c3b68fc7852b415e5c3df9cc2b120ca1464e58a12f"
     sha256 cellar: :any, big_sur:  "ff0f4b97f2a3cde8118ea90925a1ad6a48e652975d43c1beecce0f2ee3d9c8b2"
     sha256 cellar: :any, catalina: "a8a8434fa9d61420df198e4e646656d931ce6efa6b6af63ab9d06e91dbe1b8ed"
   end

--- a/Formula/ignition-rendering3.rb
+++ b/Formula/ignition-rendering3.rb
@@ -9,6 +9,7 @@ class IgnitionRendering3 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 monterey: "43bd98867840cf891ef547378eb546b56bab61a74b7221cbfdf33ae0389ce406"
     sha256 big_sur:  "6dc95605d68ee5c1472b62c220e3517ddc06771fec29a70c7070d5b25488e4e4"
     sha256 catalina: "a451162b2a081f5c3a53bf40ab69840bd564dbd62f7838eab68e3cf7edec2705"
   end

--- a/Formula/ignition-rendering3.rb
+++ b/Formula/ignition-rendering3.rb
@@ -5,6 +5,8 @@ class IgnitionRendering3 < Formula
   sha256 "535779f122710e8821785707cdec277e87497f16c002918b61396616d33ec6e2"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/gz-rendering.git", branch: "ign-rendering3"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 big_sur:  "6dc95605d68ee5c1472b62c220e3517ddc06771fec29a70c7070d5b25488e4e4"
@@ -29,8 +31,11 @@ class IgnitionRendering3 < Formula
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
-    system "cmake", ".", *cmake_args
-    system "make", "install"
+
+    mkdir "build" do
+      system "cmake", "..", *cmake_args
+      system "make", "install"
+    end
   end
 
   test do

--- a/Formula/ignition-sensors3.rb
+++ b/Formula/ignition-sensors3.rb
@@ -40,8 +40,10 @@ class IgnitionSensors3 < Formula
     cmake_args << "-DBUILD_TESTING=OFF"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
 
-    system "cmake", ".", *cmake_args
-    system "make", "install"
+    mkdir "build" do
+      system "cmake", "..", *cmake_args
+      system "make", "install"
+    end
   end
 
   test do

--- a/Formula/ignition-sensors3.rb
+++ b/Formula/ignition-sensors3.rb
@@ -10,6 +10,7 @@ class IgnitionSensors3 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 monterey: "b49287640d42399a17895b878399835bf4501edd9567d6923248b39bfcf77d18"
     sha256 big_sur:  "c7a64ee809dcb4a43af6b9f7b16384e2ddf64ccc7dfdf1b5b4005ee42c24f755"
     sha256 catalina: "7fe94be738d4dbf0681a83a1dd8064f33807c25fd163febe2c341ff0c1f80643"
   end

--- a/Formula/ignition-transport8.rb
+++ b/Formula/ignition-transport8.rb
@@ -9,6 +9,7 @@ class IgnitionTransport8 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 monterey: "74cf9455350f55a88eb394d492c9d10af10d407276e2f3d78be6872d21f9a35e"
     sha256 big_sur:  "de3fcfd97c18f5753df1644656afaab6f923178a4442d5e0868cc3ecd4d95ebb"
     sha256 catalina: "2f830ac3228681f634c06c62f392076b035cbe874602ba2dca4244e4e58149da"
   end

--- a/Formula/ignition-transport8.rb
+++ b/Formula/ignition-transport8.rb
@@ -5,6 +5,8 @@ class IgnitionTransport8 < Formula
   sha256 "bb12422a0563b9804e34074c6bfd3890505485c5e7d20a8f6f57fcd7beb57c9d"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport8"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 big_sur:  "de3fcfd97c18f5753df1644656afaab6f923178a4442d5e0868cc3ecd4d95ebb"
@@ -29,8 +31,11 @@ class IgnitionTransport8 < Formula
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
-    system "cmake", ".", *cmake_args
-    system "make", "install"
+
+    mkdir "build" do
+      system "cmake", "..", *cmake_args
+      system "make", "install"
+    end
   end
 
   test do

--- a/Formula/ogre2.1.rb
+++ b/Formula/ogre2.1.rb
@@ -19,6 +19,7 @@ class Ogre21 < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :test
+
   depends_on "doxygen"
   depends_on "freeimage"
   depends_on "freetype"

--- a/Formula/ogre2.1.rb
+++ b/Formula/ogre2.1.rb
@@ -12,6 +12,7 @@ class Ogre21 < Formula
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     rebuild 1
+    sha256 cellar: :any, monterey: "84b8e64c2a4b28afadb0ac267a84fcc341bdb34ead89c41a67e7a173e4c004fa"
     sha256 cellar: :any, big_sur:  "7049b87b9bbd4406dd9d37c97e0fa15aa8c8752c54e67ba620b485a38c69e262"
     sha256 cellar: :any, catalina: "d29874b82f0f942bd7d2453e145cd74382734a1d4161b25d7ac0e8efd4b41928"
     sha256 cellar: :any, mojave:   "f0b505985d282e7dd8b1aecc7daf51ff15c8fbb58b4b30c556fbc139ec878075"

--- a/Formula/sdformat9.rb
+++ b/Formula/sdformat9.rb
@@ -5,6 +5,8 @@ class Sdformat9 < Formula
   sha256 "fd57fbc6459f7a12732dc012e890d39391ee0b8b4bd29dc89867eaeff3aeb59c"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/sdformat.git", branch: "sdf9"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 big_sur:  "a19265f4a3565989e0d8843429aaa751abab6319c264c714b0bab601f66dadb4"

--- a/Formula/sdformat9.rb
+++ b/Formula/sdformat9.rb
@@ -9,6 +9,7 @@ class Sdformat9 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 monterey: "1215831a04c83239716c3c125fbc4aa0d0d935bfccff618a9d911d1504f3f778"
     sha256 big_sur:  "a19265f4a3565989e0d8843429aaa751abab6319c264c714b0bab601f66dadb4"
     sha256 catalina: "5721b846942561d8c348778dc3f378de75cb74ea90422c385902b0f03c3e7bab"
   end


### PR DESCRIPTION
Add small change to several formulae (head)
so bottle builds for macOS Monterey can be
triggered.

* ign-common3, ign-fuel-tools4, ign-gui3, ign-msgs5, ign-rendering3, ign-sensors3, ign-transport8, sdformat9

Signed-off-by: Steve Peters <scpeters@openrobotics.org>