### PR TITLE
Fortress: build monterey bottles part 1

### DIFF
--- a/Formula/ignition-common4.rb
+++ b/Formula/ignition-common4.rb
@@ -5,6 +5,8 @@ class IgnitionCommon4 < Formula
   sha256 "a53cb85e4624ca2f3f171e7a78f582d21b089fe32d12219b9b38a9a196efe419"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/gz-common.git", branch: "ign-common4"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any, big_sur:  "96bef83125dc96830ffab8e2a0ec81a5cab54a928c9241a45024de1404558a96"
@@ -27,8 +29,12 @@ class IgnitionCommon4 < Formula
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
-    system "cmake", ".", *cmake_args
-    system "make", "install"
+
+    # Use build folder
+    mkdir "build" do
+      system "cmake", "..", *cmake_args
+      system "make", "install"
+    end
   end
 
   test do

--- a/Formula/ignition-common4.rb
+++ b/Formula/ignition-common4.rb
@@ -9,6 +9,7 @@ class IgnitionCommon4 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, monterey: "1548a7b92ac1c076c5b291a35ee28752d3e962ee1785439b325a09517e640c04"
     sha256 cellar: :any, big_sur:  "96bef83125dc96830ffab8e2a0ec81a5cab54a928c9241a45024de1404558a96"
     sha256 cellar: :any, catalina: "38c8750a0701508a7fa933c5794b367f9d5e5068081aad96e65c76d8baa47a04"
   end

--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -9,6 +9,7 @@ class IgnitionFuelTools7 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, monterey: "efa09218688d1acf00ce149dca4f89146ae3e97b9bb4ea399524cb9a49d92cf7"
     sha256 cellar: :any, big_sur:  "f2467ce8ed23d45ad47f94cb0599310be025d45e53fe4f8024f9189cdab68a98"
     sha256 cellar: :any, catalina: "aa07a5264760242dbd0463dbfd6bf8f72e26d3322048b20bdf1e48689e051883"
   end

--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -5,6 +5,8 @@ class IgnitionFuelTools7 < Formula
   sha256 "69e7a27d49187776eb9bc3fb646a2d73f598e808a70a03af5c41673da18b66a5"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools7"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any, big_sur:  "f2467ce8ed23d45ad47f94cb0599310be025d45e53fe4f8024f9189cdab68a98"

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -9,6 +9,7 @@ class IgnitionGui6 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 monterey: "22b7f97d84cfcddf4058785ab02068b67191397381dcaf7bc3b25342ffabe2ad"
     sha256 big_sur:  "2f2d63ed784260ddcf8f078e2eeeceeac0df43a7b912c3f087980e44299fc06c"
     sha256 catalina: "9ccea55db45a939c05e792a3578ab0572b57f2f25a617108528e69973d0647c1"
   end

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -5,6 +5,8 @@ class IgnitionGui6 < Formula
   sha256 "4b77e740d7e76a84b44751eb9c8744c9a4ecbfffee2a175f8fbaab2450e0b779"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui6"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 big_sur:  "2f2d63ed784260ddcf8f078e2eeeceeac0df43a7b912c3f087980e44299fc06c"

--- a/Formula/ignition-msgs8.rb
+++ b/Formula/ignition-msgs8.rb
@@ -9,6 +9,7 @@ class IgnitionMsgs8 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, monterey: "aac173533941affa54dc9538470572ce2858ff059d3eda3285c0d176212790ae"
     sha256 cellar: :any, big_sur:  "6a506d51c89f032b7f6c0d923c107d36d84d9bbce711ff6139686ef863ec3272"
     sha256 cellar: :any, catalina: "3c8ddaf2a56ebfb1ab322274bec231adbe745fd33fcb535bd4a42b4aa6e8b3f7"
   end

--- a/Formula/ignition-msgs8.rb
+++ b/Formula/ignition-msgs8.rb
@@ -5,6 +5,8 @@ class IgnitionMsgs8 < Formula
   sha256 "b17a8e16fe56a84891bd0654a2ac09427e9a567b9cd2255bb2cfa830f8e1af45"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs8"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any, big_sur:  "6a506d51c89f032b7f6c0d923c107d36d84d9bbce711ff6139686ef863ec3272"
@@ -26,8 +28,10 @@ class IgnitionMsgs8 < Formula
     cmake_args << "-DBUILD_TESTING=Off"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
 
-    system "cmake", ".", *cmake_args
-    system "make", "install"
+    mkdir "build" do
+      system "cmake", "..", *cmake_args
+      system "make", "install"
+    end
   end
 
   test do

--- a/Formula/ignition-rendering6.rb
+++ b/Formula/ignition-rendering6.rb
@@ -5,6 +5,8 @@ class IgnitionRendering6 < Formula
   sha256 "7f38992d15e6942cb548b625545d03589482e347328c87063ec80779f9a3a6ff"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/gz-rendering.git", branch: "ign-rendering6"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 big_sur:  "26e267f4dab2f92fe903964e29a27366686fae895d55732b95c2865082907d8b"
@@ -27,8 +29,11 @@ class IgnitionRendering6 < Formula
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
-    system "cmake", ".", *cmake_args
-    system "make", "install"
+
+    mkdir "build" do
+      system "cmake", "..", *cmake_args
+      system "make", "install"
+    end
   end
 
   test do

--- a/Formula/ignition-rendering6.rb
+++ b/Formula/ignition-rendering6.rb
@@ -9,6 +9,7 @@ class IgnitionRendering6 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 monterey: "55b266320b9b8c8c97e35d50384dc008cc1484997f998e5b017b9672a622c7ed"
     sha256 big_sur:  "26e267f4dab2f92fe903964e29a27366686fae895d55732b95c2865082907d8b"
     sha256 catalina: "ce0bbe299a38b856a7b185f827aa2ffb8c6dcf506dbf653a9d5ebb97295d73fd"
   end

--- a/Formula/ignition-sensors6.rb
+++ b/Formula/ignition-sensors6.rb
@@ -6,6 +6,8 @@ class IgnitionSensors6 < Formula
   license "Apache-2.0"
   revision 2
 
+  head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors6"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any, big_sur:  "021fcddc3bbb1bf4bba53d14e46d16503d32a26df459ea347a1e52e559661b3d"

--- a/Formula/ignition-sensors6.rb
+++ b/Formula/ignition-sensors6.rb
@@ -10,6 +10,7 @@ class IgnitionSensors6 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, monterey: "ec7396571f84d7c4b225ee56f9e1256761b2d944ab260f8b6ab52eba6b81139a"
     sha256 cellar: :any, big_sur:  "021fcddc3bbb1bf4bba53d14e46d16503d32a26df459ea347a1e52e559661b3d"
     sha256 cellar: :any, catalina: "e2fd696851e4a7d9f86c63b7ed76fe8b0513102fc52a943df508eef96399ceeb"
   end

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -10,6 +10,7 @@ class IgnitionTransport11 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 monterey: "7eaa21d7235ca35e2f77d3d30f9df4083aacaa987d4cbaa5926262e23425e52c"
     sha256 big_sur:  "4a9df6dac5980c48177b9ef7868e4fa28d0ef2c272cc784a0d5bc51c98f3b8d4"
     sha256 catalina: "1af702082d6793b2cca66b1ff728d8aa1e5b2b27cf9fe5c099d127506dc30877"
   end

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -6,6 +6,8 @@ class IgnitionTransport11 < Formula
   license "Apache-2.0"
   version_scheme 1
 
+  head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport11"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 big_sur:  "4a9df6dac5980c48177b9ef7868e4fa28d0ef2c272cc784a0d5bc51c98f3b8d4"
@@ -32,8 +34,10 @@ class IgnitionTransport11 < Formula
     cmake_args << "-DBUILD_TESTING=Off"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
 
-    system "cmake", ".", *cmake_args
-    system "make", "install"
+    mkdir "build" do
+      system "cmake", "..", *cmake_args
+      system "make", "install"
+    end
   end
 
   test do

--- a/Formula/sdformat12.rb
+++ b/Formula/sdformat12.rb
@@ -5,6 +5,8 @@ class Sdformat12 < Formula
   sha256 "7f5c5f75cd3377679a6c927197c19504f0d5a04610967a270a0f17a16ecfaac8"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/sdformat.git", branch: "sdf12"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 big_sur:  "84797a1c96b236818130cc67c8407ee094c748d6845eaaf9d57df1936e751328"

--- a/Formula/sdformat12.rb
+++ b/Formula/sdformat12.rb
@@ -9,6 +9,7 @@ class Sdformat12 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 monterey: "fa1753609cd99f945d8bc0c84a2af9aeb96a66631f27b36ca503ee90ffcbec5d"
     sha256 big_sur:  "84797a1c96b236818130cc67c8407ee094c748d6845eaaf9d57df1936e751328"
     sha256 catalina: "b10f02c1db4f81cc7833b85a8024f05b27b732a4555d97ee7c74f84540a05629"
   end


### PR DESCRIPTION
Add small change to several formulae (head)
so bottle builds for macOS Monterey can be
triggered.

* ign-common4, ign-fuel-tools7, ign-gui6, ign-msgs8, ign-rendering6, ign-sensors6, ign-transport11, sdformat12

Signed-off-by: Steve Peters <scpeters@openrobotics.org>