### PR TITLE
Deprecate old formulae

### DIFF
--- a/Formula/gazebo10.rb
+++ b/Formula/gazebo10.rb
@@ -8,6 +8,8 @@ class Gazebo10 < Formula
 
   head "https://github.com/osrf/gazebo.git", branch: "gazebo10"
 
+  deprecate! date: "2021-01-24", because: "is past end-of-life date"
+
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
 

--- a/Formula/gazebo7.rb
+++ b/Formula/gazebo7.rb
@@ -8,6 +8,8 @@ class Gazebo7 < Formula
 
   head "https://github.com/osrf/gazebo.git", branch: "gazebo7"
 
+  deprecate! date: "2021-01-25", because: "is past end-of-life date"
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
 

--- a/Formula/ignition-cmake1.rb
+++ b/Formula/ignition-cmake1.rb
@@ -7,12 +7,12 @@ class IgnitionCmake1 < Formula
 
   head "https://github.com/gazebosim/gz-cmake.git", branch: "ign-cmake1"
 
-  deprecate! date: "2019-09-01", because: "is past end-of-life date"
-
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any_skip_relocation, sierra: "10cdf432ef40bbcdaee901763a457467710d3007bca99250fda5ac49cbd0bfae"
   end
+
+  deprecate! date: "2019-09-01", because: "is past end-of-life date"
 
   depends_on "cmake"
   depends_on "pkg-config"

--- a/Formula/ignition-cmake1.rb
+++ b/Formula/ignition-cmake1.rb
@@ -7,6 +7,8 @@ class IgnitionCmake1 < Formula
 
   head "https://github.com/gazebosim/gz-cmake.git", branch: "ign-cmake1"
 
+  deprecate! date: "2019-09-01", because: "is past end-of-life date"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any_skip_relocation, sierra: "10cdf432ef40bbcdaee901763a457467710d3007bca99250fda5ac49cbd0bfae"

--- a/Formula/ignition-common0.rb
+++ b/Formula/ignition-common0.rb
@@ -8,6 +8,8 @@ class IgnitionCommon0 < Formula
 
   head "https://github.com/gazebosim/gz-common.git", branch: "ign-common0"
 
+  deprecate! date: "2019-09-01", because: "is past end-of-life date"
+
   depends_on "cmake"
   depends_on "ffmpeg"
   depends_on "freeimage"

--- a/Formula/ignition-common2.rb
+++ b/Formula/ignition-common2.rb
@@ -8,13 +8,13 @@ class IgnitionCommon2 < Formula
 
   head "https://github.com/gazebosim/gz-common.git", branch: "ign-common2"
 
-  deprecate! date: "2019-09-01", because: "is past end-of-life date"
-
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any, catalina: "7b56734b816d905ac6bbf1428bf0cbe7b034bbc550b6e2ffb6cf5da7e0c05137"
     sha256 cellar: :any, mojave:   "ba20967b0c64bc1eef5475d427bf252a348903fe7ea7dec92153cf70b89459b2"
   end
+
+  deprecate! date: "2019-09-01", because: "is past end-of-life date"
 
   depends_on "cmake"
   depends_on "ffmpeg"

--- a/Formula/ignition-common2.rb
+++ b/Formula/ignition-common2.rb
@@ -8,6 +8,8 @@ class IgnitionCommon2 < Formula
 
   head "https://github.com/gazebosim/gz-common.git", branch: "ign-common2"
 
+  deprecate! date: "2019-09-01", because: "is past end-of-life date"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any, catalina: "7b56734b816d905ac6bbf1428bf0cbe7b034bbc550b6e2ffb6cf5da7e0c05137"

--- a/Formula/ignition-fuel-tools0.rb
+++ b/Formula/ignition-fuel-tools0.rb
@@ -6,6 +6,8 @@ class IgnitionFuelTools0 < Formula
   sha256 "dce9a2816c797392a3a0c94f0c09bbb8dedd37969d1a9990dc37c61f767bb3e2"
   license "Apache-2.0"
 
+  deprecate! date: "2019-09-01", because: "is past end-of-life date"
+
   depends_on "cmake"
   depends_on "ignition-cmake0"
   depends_on "ignition-common1"

--- a/Formula/ignition-fuel-tools2.rb
+++ b/Formula/ignition-fuel-tools2.rb
@@ -6,6 +6,8 @@ class IgnitionFuelTools2 < Formula
   license "Apache-2.0"
   revision 2
 
+  deprecate! date: "2019-09-01", because: "is past end-of-life date"
+
   depends_on "cmake"
   depends_on "ignition-cmake0"
   depends_on "ignition-common1"

--- a/Formula/ignition-math2.rb
+++ b/Formula/ignition-math2.rb
@@ -16,6 +16,8 @@ class IgnitionMath2 < Formula
     sha256 cellar: :any, yosemite:    "401ecbcc6c53af2ba8161790115a0df3cefbe393cafa72358fd92441bccdb633"
   end
 
+  deprecate! date: "2021-01-25", because: "is past end-of-life date"
+
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
 

--- a/Formula/ignition-math3.rb
+++ b/Formula/ignition-math3.rb
@@ -16,6 +16,8 @@ class IgnitionMath3 < Formula
     sha256 cellar: :any, yosemite:    "360b5673f882a817cb0e576b2778c8665d27f0671d34eaa188f30873221da058"
   end
 
+  deprecate! date: "2019-09-01", because: "is past end-of-life date"
+
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
 

--- a/Formula/ignition-math5.rb
+++ b/Formula/ignition-math5.rb
@@ -8,6 +8,8 @@ class IgnitionMath5 < Formula
 
   head "https://github.com/gazebosim/gz-math.git", branch: "ign-math5"
 
+  deprecate! date: "2019-09-01", because: "is past end-of-life date"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any, mojave:      "08a8d27d961fba37b980e3ecdd87d7416429807402ddaf38d3d616808d578371"

--- a/Formula/ignition-math5.rb
+++ b/Formula/ignition-math5.rb
@@ -8,14 +8,14 @@ class IgnitionMath5 < Formula
 
   head "https://github.com/gazebosim/gz-math.git", branch: "ign-math5"
 
-  deprecate! date: "2019-09-01", because: "is past end-of-life date"
-
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any, mojave:      "08a8d27d961fba37b980e3ecdd87d7416429807402ddaf38d3d616808d578371"
     sha256 cellar: :any, high_sierra: "43dc2a329a12fed49066bc08d0fd788ffa346b936c7d683f8b936e86b3404b88"
     sha256 cellar: :any, sierra:      "606c4dfb580402e4cfb7ac1a5d7ccd99a7eeded41c974df618e067c1e51fd423"
   end
+
+  deprecate! date: "2019-09-01", because: "is past end-of-life date"
 
   depends_on "cmake" => :build
   depends_on "doxygen" => :build

--- a/Formula/ignition-math@1.rb
+++ b/Formula/ignition-math@1.rb
@@ -6,6 +6,8 @@ class IgnitionMathAT1 < Formula
   license "Apache-2.0"
   head "https://github.com/gazebosim/gz-math.git", branch: "master"
 
+  deprecate! date: "2019-09-01", because: "is past end-of-life date"
+
   depends_on "cmake" => :build
   depends_on "doxygen" => [:build, :optional]
 

--- a/Formula/ignition-msgs0.rb
+++ b/Formula/ignition-msgs0.rb
@@ -8,6 +8,8 @@ class IgnitionMsgs0 < Formula
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs0"
 
+  deprecate! date: "2019-09-01", because: "is past end-of-life date"
+
   depends_on "protobuf-c" => :build
   depends_on "cmake"
   depends_on "ignition-math3"

--- a/Formula/ignition-msgs2.rb
+++ b/Formula/ignition-msgs2.rb
@@ -8,6 +8,8 @@ class IgnitionMsgs2 < Formula
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs2"
 
+  deprecate! date: "2019-09-01", because: "is past end-of-life date"
+
   depends_on "protobuf-c" => :build
 
   depends_on "cmake"

--- a/Formula/ignition-plugin0.rb
+++ b/Formula/ignition-plugin0.rb
@@ -14,6 +14,8 @@ class IgnitionPlugin0 < Formula
     sha256 cellar: :any, el_capitan:  "813f6a21a9f722cb1ca605e4d1703e77ea753ae2c9e43ed0c3393b69ec902719"
   end
 
+  deprecate! date: "2019-09-01", because: "is past end-of-life date"
+
   depends_on "cmake"
   depends_on "ignition-cmake1"
   depends_on "pkg-config"

--- a/Formula/ignition-rendering0.rb
+++ b/Formula/ignition-rendering0.rb
@@ -8,6 +8,8 @@ class IgnitionRendering0 < Formula
 
   head "https://github.com/gazebosim/gz-rendering.git", branch: "ign-rendering0"
 
+  deprecate! date: "2019-09-01", because: "is past end-of-life date"
+
   depends_on "cmake" => :build
   depends_on "pkg-config" => [:build, :test]
 

--- a/Formula/ignition-transport5.rb
+++ b/Formula/ignition-transport5.rb
@@ -7,6 +7,8 @@ class IgnitionTransport5 < Formula
   license "Apache-2.0"
   revision 2
 
+  deprecate! date: "2019-09-01", because: "is past end-of-life date"
+
   depends_on "doxygen" => [:build, :optional]
   depends_on "protobuf-c" => :build
 

--- a/Formula/sdformat.rb
+++ b/Formula/sdformat.rb
@@ -8,6 +8,8 @@ class Sdformat < Formula
 
   head "https://github.com/osrf/sdformat.git", branch: "sdf_2.3", using: :git
 
+  deprecate! date: "2019-09-01", because: "is past end-of-life date"
+
   depends_on "cmake" => :build
 
   depends_on "boost"

--- a/Formula/sdformat3.rb
+++ b/Formula/sdformat3.rb
@@ -8,6 +8,8 @@ class Sdformat3 < Formula
 
   head "https://github.com/osrf/sdformat.git", branch: "sdf3", using: :git
 
+  deprecate! date: "2019-09-01", because: "is past end-of-life date"
+
   depends_on "cmake" => :build
 
   depends_on "boost"

--- a/Formula/sdformat4.rb
+++ b/Formula/sdformat4.rb
@@ -15,6 +15,8 @@ class Sdformat4 < Formula
     sha256 sierra:      "d0b28be274c293fd1c5395fcae0be37f43f6c16ef129a171d39a020564e6b7f9"
   end
 
+  deprecate! date: "2019-09-01", because: "is past end-of-life date"
+
   depends_on "cmake" => :build
 
   depends_on "boost"

--- a/Formula/sdformat7.rb
+++ b/Formula/sdformat7.rb
@@ -8,6 +8,8 @@ class Sdformat7 < Formula
 
   head "https://github.com/osrf/sdformat.git", branch: "sdf7", using: :git
 
+  deprecate! date: "2019-09-01", because: "is past end-of-life date"
+
   depends_on "cmake" => :build
 
   depends_on "boost"


### PR DESCRIPTION
There's a lot of old formulae in this tap that should be cleaned up. I'm adding `deprecate!` fields now and will add `disable!` tags in about a month and then remove them about a month after that.