### PR TITLE
gazebo9: build monterey bottle

### DIFF
--- a/Formula/gazebo9.rb
+++ b/Formula/gazebo9.rb
@@ -14,7 +14,7 @@ class Gazebo9 < Formula
     sha256 catalina: "2aa5271dbb33b284612efae859e3b37983f19d357af2485b346b62c165d5a520"
   end
 
-  depends_on "cmake" => :build
+  depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => :build
 
   depends_on "boost"


### PR DESCRIPTION
Add small change to the formula so bottle
build for macOS Monterey can be triggered.

Signed-off-by: Steve Peters <scpeters@openrobotics.org>