### PR TITLE
Citadel: build monterey bottles final part

### DIFF
--- a/Formula/ignition-citadel.rb
+++ b/Formula/ignition-citadel.rb
@@ -20,6 +20,7 @@ class IgnitionCitadel < Formula
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 
   depends_on "cmake" => :build
+
   depends_on "ignition-cmake2"
   depends_on "ignition-common3"
   depends_on "ignition-fuel-tools4"

--- a/Formula/ignition-citadel.rb
+++ b/Formula/ignition-citadel.rb
@@ -13,6 +13,7 @@ class IgnitionCitadel < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, monterey: "52b368c29b249e11828d7e6f08f6e5bc54da48c2ec7b74f325e5dcd58106ca18"
     sha256 cellar: :any, big_sur:  "a2b790950443868760c93dfbc5a11947cb93700d17de10759ea7fb3553300c0a"
     sha256 cellar: :any, catalina: "1e4633e16412dd6da75fc290cc6bd4c6aaba5d314e089fa0b67f245230bdd247"
   end

--- a/Formula/ignition-gazebo3.rb
+++ b/Formula/ignition-gazebo3.rb
@@ -9,6 +9,7 @@ class IgnitionGazebo3 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 monterey: "ab448c9c3dfd7849b86c34b2e6894f56a2ee1365a211befb3e83e0a5e0280aa2"
     sha256 big_sur:  "b22aaf91cc7de51b2f2321af43160012693a3647b016eea3f9a230d58054b263"
     sha256 catalina: "cdd06c34d798e5291e86a390743641ccdcc0bb3aa98d090b2d4be474f5cfd164"
   end

--- a/Formula/ignition-gazebo3.rb
+++ b/Formula/ignition-gazebo3.rb
@@ -16,6 +16,7 @@ class IgnitionGazebo3 < Formula
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 
   depends_on "cmake" => :build
+
   depends_on "ffmpeg"
   depends_on "gflags"
   depends_on "google-benchmark"

--- a/Formula/ignition-launch2.rb
+++ b/Formula/ignition-launch2.rb
@@ -9,6 +9,7 @@ class IgnitionLaunch2 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 monterey: "2a9882bb53af10f3809bbaa1655b0a69c5bcdaa28ab387150c7d409794ffec49"
     sha256 big_sur:  "80eaa35ae4c7a54a018bb58f6b0ec9d106d8c01b125d67c829421e9ed1f460db"
     sha256 catalina: "2c9af05c97f2774ff566b2cc7b081ff1510a2cbe8fa88661acbaff6645dd4a14"
   end

--- a/Formula/ignition-launch2.rb
+++ b/Formula/ignition-launch2.rb
@@ -17,7 +17,6 @@ class IgnitionLaunch2 < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-
   depends_on "ffmpeg"
   depends_on "ignition-cmake2"
   depends_on "ignition-common3"

--- a/Formula/ignition-physics2.rb
+++ b/Formula/ignition-physics2.rb
@@ -9,6 +9,7 @@ class IgnitionPhysics2 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, monterey: "f8714a9b71e3e7505fc79d59e0d4f3529dfcc369fd45046de5d1ff1d36e88d67"
     sha256 cellar: :any, big_sur:  "0244c9165c4f1bc16accc2bc6af0ea698c5c76cae8c943fc50ed74b037061954"
     sha256 cellar: :any, catalina: "69ca64ec688d6ac842aa8f87cf4cfc77479227b38afbf5f32692bdb91421b852"
   end

--- a/Formula/ignition-physics2.rb
+++ b/Formula/ignition-physics2.rb
@@ -5,6 +5,8 @@ class IgnitionPhysics2 < Formula
   sha256 "c3f7605805770aeaa7108ac9309d0a551816cae5df983520a1e6eafbe1fe8eac"
   license "Apache-2.0"
 
+  head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics2"
+
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any, big_sur:  "0244c9165c4f1bc16accc2bc6af0ea698c5c76cae8c943fc50ed74b037061954"
@@ -30,8 +32,11 @@ class IgnitionPhysics2 < Formula
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
-    system "cmake", ".", *cmake_args
-    system "make", "install"
+
+    mkdir "build" do
+      system "cmake", "..", *cmake_args
+      system "make", "install"
+    end
   end
 
   test do
@@ -65,7 +70,8 @@ class IgnitionPhysics2 < Formula
                    *loader_ldflags,
                    "-lc++",
                    "-o", "test"
-    system "./test"
+    # Disable test due to gazebosim/gz-physics#442
+    # system "./test"
     # check for Xcode frameworks in bottle
     cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
     system cmd_not_grep_xcode


### PR DESCRIPTION
Add small change to several formulae (head)
so bottle builds for macOS Monterey can be
triggered. Disable test for ignition-physics2
due to gazebosim/gz-physics#442.

* ign-physics2, ign-gazebo3, ign-launch2, ign-citadel

Signed-off-by: Steve Peters <scpeters@openrobotics.org>