### PR TITLE
ignition-rendering6: rebuild monterey bottle

### DIFF
--- a/Formula/ignition-rendering6.rb
+++ b/Formula/ignition-rendering6.rb
@@ -9,6 +9,7 @@ class IgnitionRendering6 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 monterey: "8545a7db2453a970a959b52c29a559f83237e0d801fb68d187de985d95fd7215"
     sha256 big_sur:  "26e267f4dab2f92fe903964e29a27366686fae895d55732b95c2865082907d8b"
     sha256 catalina: "ce0bbe299a38b856a7b185f827aa2ffb8c6dcf506dbf653a9d5ebb97295d73fd"
   end

--- a/Formula/ignition-rendering6.rb
+++ b/Formula/ignition-rendering6.rb
@@ -15,7 +15,6 @@ class IgnitionRendering6 < Formula
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
-
   depends_on "freeimage"
   depends_on "ignition-cmake2"
   depends_on "ignition-common4"


### PR DESCRIPTION
Adjust whitespace and rebuild monterey bottle
since it was missing the ogre2 component.

Signed-off-by: Steve Peters <scpeters@openrobotics.org>