### PR TITLE
gz-rendering{3,7}: test both ogre components

### DIFF
--- a/Formula/gz-rendering7.rb
+++ b/Formula/gz-rendering7.rb
@@ -52,7 +52,7 @@ class GzRendering7 < Formula
     EOS
     (testpath/"CMakeLists.txt").write <<-EOS
       cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
-      find_package(gz-rendering7 QUIET REQUIRED)
+      find_package(gz-rendering7 REQUIRED COMPONENTS ogre ogre2)
       add_executable(test_cmake test.cpp)
       target_link_libraries(test_cmake gz-rendering7::gz-rendering7)
     EOS

--- a/Formula/ignition-rendering3.rb
+++ b/Formula/ignition-rendering3.rb
@@ -55,7 +55,7 @@ class IgnitionRendering3 < Formula
     EOS
     (testpath/"CMakeLists.txt").write <<-EOS
       cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
-      find_package(ignition-rendering3 QUIET REQUIRED)
+      find_package(ignition-rendering3 REQUIRED COMPONENTS ogre ogre2)
       add_executable(test_cmake test.cpp)
       target_link_libraries(test_cmake ignition-rendering3::ignition-rendering3)
     EOS


### PR DESCRIPTION
Test that both ogre and ogre2 components can be found by cmake.

I have confirmed locally that this works for both rendering3 and rendering7. There is a problem with rendering6 that I am sorting out separately.