### PR TITLE
gz-sensors8: depend on gz-rendering8

### DIFF
--- a/Aliases/gz-sensors8
+++ b/Aliases/gz-sensors8
@@ -1,1 +1,0 @@
-../Formula/gz-sensors7.rb

--- a/Formula/gz-sensors8.rb
+++ b/Formula/gz-sensors8.rb
@@ -1,0 +1,69 @@
+class GzSensors8 < Formula
+  desc "Sensors library for robotics applications"
+  homepage "https://github.com/gazebosim/gz-sensors"
+  url "https://github.com/gazebosim/gz-sensors.git"
+  version "7.999.999~0~20221114"
+  license "Apache-2.0"
+
+  head "https://github.com/gazebosim/gz-sensors.git", branch: "main"
+
+  depends_on "cmake" => [:build, :test]
+  depends_on "pkg-config" => [:build, :test]
+
+  depends_on "gz-cmake3"
+  depends_on "gz-common5"
+  depends_on "gz-math7"
+  depends_on "gz-msgs9"
+  depends_on "gz-rendering8"
+  depends_on "gz-transport12"
+  depends_on "sdformat13"
+
+  def install
+    cmake_args = std_cmake_args
+    cmake_args << "-DBUILD_TESTING=OFF"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+
+    mkdir "build" do
+      system "cmake", "..", *cmake_args
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS
+      #include <gz/sensors/Noise.hh>
+
+      int main()
+      {
+        gz::sensors::Noise noise(gz::sensors::NoiseType::NONE);
+
+        return 0;
+      }
+    EOS
+    (testpath/"CMakeLists.txt").write <<-EOS
+      cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+      find_package(gz-sensors8 QUIET REQUIRED)
+      add_executable(test_cmake test.cpp)
+      target_link_libraries(test_cmake gz-sensors8::gz-sensors8)
+    EOS
+    # test building with pkg-config
+    system "pkg-config", "gz-sensors8"
+    cflags   = `pkg-config --cflags gz-sensors8`.split
+    ldflags  = `pkg-config --libs gz-sensors8`.split
+    system ENV.cc, "test.cpp",
+                   *cflags,
+                   *ldflags,
+                   "-lc++",
+                   "-o", "test"
+    system "./test"
+    # test building with cmake
+    mkdir "build" do
+      system "cmake", ".."
+      system "make"
+      system "./test_cmake"
+    end
+    # check for Xcode frameworks in bottle
+    cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
+    system cmd_not_grep_xcode
+  end
+end


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

https://github.com/gazebo-tooling/release-tools/issues/853

Bump rendering dep from 7 to 8

Removed gz-sensors8 alias and added a new gz-sensors8.rb formulat.

I removed the bottle section as I think it may not needed but I'm not sure that's correct.