### PR TITLE
gz-harmonic: alias to gz-garden

### DIFF
--- a/Aliases/gz-harmonic
+++ b/Aliases/gz-harmonic
@@ -1,0 +1,1 @@
+../Formula/gz-garden.rb

--- a/Aliases/ignition-harmonic
+++ b/Aliases/ignition-harmonic
@@ -1,0 +1,1 @@
+../Formula/gz-garden.rb


### PR DESCRIPTION
There is a harmonic bottle CI job since https://github.com/gazebo-tooling/release-tools/pull/857/ was merged, but it fails because there is no `gz-harmonic` formula:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_harmonic-install_bottle-homebrew-amd64&build=4)](https://build.osrfoundation.org/job/ignition_harmonic-install_bottle-homebrew-amd64/4/) https://build.osrfoundation.org/job/ignition_harmonic-install_bottle-homebrew-amd64/4/

~~~
+ brew install --include-test ignition-harmonic
Warning: No available formula with the name "ignition-harmonic".
~~~

So let's just make an alias for now.