### PR TITLE
Disable gz-ohysics bottles

### DIFF
--- a/Formula/gz-physics6.rb
+++ b/Formula/gz-physics6.rb
@@ -4,12 +4,7 @@ class GzPhysics6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-6.2.0.tar.bz2"
   sha256 "5a9a126039ddd357c3f61da6e9e1553310ff139aada5e838dd485bfcb73439ad"
   license "Apache-2.0"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, monterey: "8f53ea9099dd108f0451d7f2d75bc641fcb080443d598d40364d887f7288e62a"
-    sha256 cellar: :any, big_sur:  "2eab4a59f5d7922e36afc398a3d5541cefc1d44e4ff248e16483f8e34baa7e51"
-  end
+  revision 1
 
   depends_on "cmake" => :build
 

--- a/Formula/ignition-physics2.rb
+++ b/Formula/ignition-physics2.rb
@@ -4,14 +4,9 @@ class IgnitionPhysics2 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics2-2.6.0.tar.bz2"
   sha256 "89ae8d396b5f31179339b4fd1e01ef22bcca19073ab4422637917660862f7867"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics2"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, monterey: "4815cdf9a194d4eb9db90a1676a0a5e4ea3c53ebf8a43b89c409b0be1e256583"
-    sha256 cellar: :any, big_sur:  "5f4a48a6946d56f8cb565a47f9cdf4a0d1debf4fa15b2349edd8f012c5a0652d"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -4,15 +4,9 @@ class IgnitionPhysics5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics5-5.2.0.tar.bz2"
   sha256 "7343caec347c00794c0a6066b99728c77315da6750fa899e6ff06d3bd0a02cd3"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "ign-physics5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, monterey: "1f46e147b6c5bc981ee06e8af76a25e52769e1838930015f2bab5af676920c95"
-    sha256 cellar: :any, big_sur:  "8e32bff557518e1edd2367779559902e1e62908461a3504c23ee884f24756422"
-    sha256 cellar: :any, catalina: "2ff067ca255df12762264eea4c6eacaa8311ccc56a82c7fcb567e3113c824a84"
-  end
 
   depends_on "cmake" => :build
 


### PR DESCRIPTION
The gz-physics bottles have been broken since https://github.com/Homebrew/homebrew-core/pull/119513 was merged. This disables the bottles, which will be rebuilt in a subsequent pull request.