### PR TITLE
Disable broken bottles due to bullet 3.25

### DIFF
--- a/Formula/dartsim@6.10.0.rb
+++ b/Formula/dartsim@6.10.0.rb
@@ -6,14 +6,7 @@ class DartsimAT6100 < Formula
   version "6.10.0~20211005~d2b6ee08a60d0dbf71b0f008cd8fed1f611f6e24"
   sha256 "372af181024452418eec95f8a9cd723ceb1ada979208add66c9a4330b9c0fa32"
   license "BSD-2-Clause"
-  revision 6
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 monterey: "3ef1a5626d845f7393496c1a370be54da4bdb47c35777b37df2c00f6e19ea450"
-    sha256 big_sur:  "2d6fa500451ddde92be8e7ae4ac3e7261612eca95584748f894d161d93798f76"
-    sha256 catalina: "baa069907b662f2986120cdf59984fa7307574050dd7866531a634c045f38394"
-  end
+  revision 7
 
   keg_only "open robotics fork of dart HEAD + custom changes"
 

--- a/Formula/gazebo11.rb
+++ b/Formula/gazebo11.rb
@@ -4,15 +4,9 @@ class Gazebo11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/gazebo-11.12.0.tar.bz2"
   sha256 "c40ca1ec71b6ab427e7feb83c922bfb262e84e11ebf6bb91f99bc3cca75bcd97"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   head "https://github.com/osrf/gazebo.git", branch: "gazebo11"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 monterey: "b0e0742b37f3d2bebbcb75d4cb15953cb5163fd783778bec0f093b2777301d85"
-    sha256 big_sur:  "774c35193f61dc3b9a1b11b2067484a05b39eb8287d07bec8b56ef6ed0697fa7"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/gz-physics6.rb
+++ b/Formula/gz-physics6.rb
@@ -4,13 +4,7 @@ class GzPhysics6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-6.2.0.tar.bz2"
   sha256 "5a9a126039ddd357c3f61da6e9e1553310ff139aada5e838dd485bfcb73439ad"
   license "Apache-2.0"
-  revision 2
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, monterey: "58df5f22193fe22a938fec5825d7a58495887b4b6a3cd21b72d0ad8be4006c77"
-    sha256 cellar: :any, big_sur:  "64c37b8356c291b773aa1aae8c67eca74c7d0f3cdab63eb21f7de34d6e0c2dce"
-  end
+  revision 3
 
   depends_on "cmake" => :build
 

--- a/Formula/ignition-physics2.rb
+++ b/Formula/ignition-physics2.rb
@@ -4,14 +4,9 @@ class IgnitionPhysics2 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics2-2.6.1.tar.bz2"
   sha256 "036c2b4effec9eefcdc94ac4ae0c6caec15d802db2e20665d76fcf69b7934643"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics2"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, monterey: "037bc7c71a4d03c537a185110594cdec370918e62f115008f1f9124dededdd9c"
-    sha256 cellar: :any, big_sur:  "8b68316f0ef92a97f030d8b0e2e1e59fa069f0f53f8fbb99d2be3248afc373dd"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -4,14 +4,9 @@ class IgnitionPhysics5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics5-5.3.0.tar.bz2"
   sha256 "0d1cd96b3dbede4880ba4c2fe7ad0dc59a56b04cb106a705c848dae60efda410"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "ign-physics5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, monterey: "14adc17acc90eaa7ea7afb2a274b95bfaa1d0f526af7f751c33538448ecc4ec1"
-    sha256 cellar: :any, big_sur:  "4f957c803bf57f2902065d50ac8985a96f25d6e397637b14993e995f314c7ecf"
-  end
 
   depends_on "cmake" => :build
 


### PR DESCRIPTION
Several of our bottles were broken by https://github.com/Homebrew/homebrew-core/pull/121687, so disable them for now.