### PR TITLE
gz-transport13: depend on gz-msgs10

### DIFF
--- a/Aliases/gz-transport13
+++ b/Aliases/gz-transport13
@@ -1,1 +1,0 @@
-../Formula/gz-transport12.rb

--- a/Formula/gz-transport13.rb
+++ b/Formula/gz-transport13.rb
@@ -1,4 +1,4 @@
-class Gztransport13 < Formula
+class GzTransport13 < Formula
   desc "Transport middleware for robotics"
   homepage "https://gazebosim.org"
   url "https://github.com/gazebosim/gz-transport.git", branch: "main"

--- a/Formula/gz-transport13.rb
+++ b/Formula/gz-transport13.rb
@@ -1,0 +1,77 @@
+class GzTransport12 < Formula
+  desc "Transport middleware for robotics"
+  homepage "https://gazebosim.org"
+  url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/gz-transport-12.1.0.tar.bz2"
+  sha256 "0d9ddaae23eb78fa28a8ce1a70048243e0d180de13e51a29b1a85317602bb4f9"
+  license "Apache-2.0"
+
+  head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport12"
+
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 monterey: "c28ab9f8afb2dd92907092d27e1b23cb65a0942ce39552866bb211631734521f"
+    sha256 big_sur:  "272d40cb3f32cbb8ce7fcc2426e8d27a3ac4a6976702ceb276ea53210f7a34aa"
+  end
+
+  depends_on "doxygen" => [:build, :optional]
+  depends_on "protobuf-c" => :build
+
+  depends_on "cmake"
+  depends_on "cppzmq"
+  depends_on "gz-cmake3"
+  depends_on "gz-msgs10"
+  depends_on "gz-tools2"
+  depends_on "gz-utils2"
+  depends_on macos: :mojave # c++17
+  depends_on "ossp-uuid"
+  depends_on "pkg-config"
+  depends_on "protobuf"
+  depends_on "zeromq"
+
+  def install
+    cmake_args = std_cmake_args
+    cmake_args << "-DBUILD_TESTING=Off"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+
+    # Use build folder
+    mkdir "build" do
+      system "cmake", "..", *cmake_args
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS
+      #include <iostream>
+      #include <gz/transport.hh>
+      int main() {
+        gz::transport::NodeOptions options;
+        return 0;
+      }
+    EOS
+    (testpath/"CMakeLists.txt").write <<-EOS
+      cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+      find_package(gz-transport12 QUIET REQUIRED)
+      add_executable(test_cmake test.cpp)
+      target_link_libraries(test_cmake gz-transport12::gz-transport12)
+    EOS
+    system "pkg-config", "gz-transport12"
+    cflags = `pkg-config --cflags gz-transport12`.split
+    system ENV.cc, "test.cpp",
+                   *cflags,
+                   "-L#{lib}",
+                   "-lgz-transport12",
+                   "-lc++",
+                   "-o", "test"
+    ENV["GZ_PARTITION"] = rand((1 << 32) - 1).to_s
+    system "./test"
+    mkdir "build" do
+      system "cmake", ".."
+      system "make"
+      system "./test_cmake"
+    end
+    # check for Xcode frameworks in bottle
+    cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
+    system cmd_not_grep_xcode
+  end
+end

--- a/Formula/gz-transport13.rb
+++ b/Formula/gz-transport13.rb
@@ -1,17 +1,11 @@
 class Gztransport13 < Formula
   desc "Transport middleware for robotics"
   homepage "https://gazebosim.org"
-  url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/gz-transport-12.1.0.tar.bz2"
-  sha256 "0d9ddaae23eb78fa28a8ce1a70048243e0d180de13e51a29b1a85317602bb4f9"
+  url "https://github.com/gazebosim/gz-transport.git", branch: "main"
+  version "12.999.999~0~20230203"
   license "Apache-2.0"
 
-  head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport13"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 monterey: "c28ab9f8afb2dd92907092d27e1b23cb65a0942ce39552866bb211631734521f"
-    sha256 big_sur:  "272d40cb3f32cbb8ce7fcc2426e8d27a3ac4a6976702ceb276ea53210f7a34aa"
-  end
+  head "https://github.com/gazebosim/gz-transport.git", branch: "main"
 
   depends_on "doxygen" => [:build, :optional]
   depends_on "protobuf-c" => :build

--- a/Formula/gz-transport13.rb
+++ b/Formula/gz-transport13.rb
@@ -1,11 +1,11 @@
-class GzTransport12 < Formula
+class Gztransport13 < Formula
   desc "Transport middleware for robotics"
   homepage "https://gazebosim.org"
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/gz-transport-12.1.0.tar.bz2"
   sha256 "0d9ddaae23eb78fa28a8ce1a70048243e0d180de13e51a29b1a85317602bb4f9"
   license "Apache-2.0"
 
-  head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport12"
+  head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport13"
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
@@ -51,16 +51,16 @@ class GzTransport12 < Formula
     EOS
     (testpath/"CMakeLists.txt").write <<-EOS
       cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
-      find_package(gz-transport12 QUIET REQUIRED)
+      find_package(gz-transport13 QUIET REQUIRED)
       add_executable(test_cmake test.cpp)
-      target_link_libraries(test_cmake gz-transport12::gz-transport12)
+      target_link_libraries(test_cmake gz-transport13::gz-transport13)
     EOS
-    system "pkg-config", "gz-transport12"
-    cflags = `pkg-config --cflags gz-transport12`.split
+    system "pkg-config", "gz-transport13"
+    cflags = `pkg-config --cflags gz-transport13`.split
     system ENV.cc, "test.cpp",
                    *cflags,
                    "-L#{lib}",
-                   "-lgz-transport12",
+                   "-lgz-transport13",
                    "-lc++",
                    "-o", "test"
     ENV["GZ_PARTITION"] = rand((1 << 32) - 1).to_s


### PR DESCRIPTION
Remove the alias, copy the transport12 formula and bump dependency on msgs to version 10. Update all references to 12 to 13.
