### PR TITLE
gz-sensors8: depend on msgs10 and transport13

### DIFF
--- a/Formula/gz-sensors8.rb
+++ b/Formula/gz-sensors8.rb
@@ -13,9 +13,9 @@ class GzSensors8 < Formula
   depends_on "gz-cmake3"
   depends_on "gz-common5"
   depends_on "gz-math7"
-  depends_on "gz-msgs9"
+  depends_on "gz-msgs10"
   depends_on "gz-rendering8"
-  depends_on "gz-transport12"
+  depends_on "gz-transport13"
   depends_on "sdformat13"
 
   def install


### PR DESCRIPTION
Bump to use msgs 10 and transport 13 

related PR: https://github.com/gazebosim/gz-sensors/pull/316