### PR TITLE
gz-gui8: depend on msgs10 and transport13

### DIFF
--- a/Formula/gz-gui8.rb
+++ b/Formula/gz-gui8.rb
@@ -11,10 +11,10 @@ class GzGui8 < Formula
   depends_on "pkg-config" => [:build, :test]
   depends_on "gz-cmake3"
   depends_on "gz-common5"
-  depends_on "gz-msgs9"
+  depends_on "gz-msgs10"
   depends_on "gz-plugin2"
   depends_on "gz-rendering8"
-  depends_on "gz-transport12"
+  depends_on "gz-transport13"
   depends_on macos: :mojave # c++17
   depends_on "qt@5"
   depends_on "tinyxml2"


### PR DESCRIPTION
Related PR: https://github.com/gazebosim/gz-gui/pull/517

Part of https://github.com/gazebo-tooling/release-tools/issues/878