### PR TITLE
gz-rendering7: re-enable pkg-config test

### DIFF
--- a/Formula/gz-gui7.rb
+++ b/Formula/gz-gui7.rb
@@ -81,20 +81,17 @@ class GzGui7 < Formula
       add_executable(test_cmake test.cpp)
       target_link_libraries(test_cmake gz-gui7::gz-gui7)
     EOS
-    # there is a problem with pkg-config in gz-rendering7
-    # disable this test for now
-    #
-    # ENV.append_path "PKG_CONFIG_PATH", Formula["qt@5"].opt_lib/"pkgconfig"
-    # system "pkg-config", "gz-gui7"
-    # cflags   = `pkg-config --cflags gz-gui7`.split
-    # ldflags  = `pkg-config --libs gz-gui7`.split
-    # system ENV.cc, "test.cpp",
-    #                *cflags,
-    #                *ldflags,
-    #                "-lc++",
-    #                "-o", "test"
-    # ENV["GZ_PARTITION"] = rand((1 << 32) - 1).to_s
-    # system "./test"
+    ENV.append_path "PKG_CONFIG_PATH", Formula["qt@5"].opt_lib/"pkgconfig"
+    system "pkg-config", "gz-gui7"
+    cflags   = `pkg-config --cflags gz-gui7`.split
+    ldflags  = `pkg-config --libs gz-gui7`.split
+    system ENV.cc, "test.cpp",
+                   *cflags,
+                   *ldflags,
+                   "-lc++",
+                   "-o", "test"
+    ENV["GZ_PARTITION"] = rand((1 << 32) - 1).to_s
+    system "./test"
     # test building with cmake
     ENV.append_path "CMAKE_PREFIX_PATH", Formula["qt@5"].opt_prefix
     mkdir "build" do

--- a/Formula/gz-rendering7.rb
+++ b/Formula/gz-rendering7.rb
@@ -26,6 +26,13 @@ class GzRendering7 < Formula
   depends_on "ogre1.9"
   depends_on "ogre2.3"
 
+  patch do
+    # Fix for pkg-config
+    # Remove with next release
+    url "https://github.com/gazebosim/gz-rendering/commit/7091c94772686fefb5e17d245b40585b5515bd0e.patch?full_index=1"
+    sha256 "065366eada1462d0a3fc504db198df6cb68aad9397a5753122913f6d9330c2c4"
+  end
+
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"

--- a/Formula/gz-rendering7.rb
+++ b/Formula/gz-rendering7.rb
@@ -56,18 +56,15 @@ class GzRendering7 < Formula
       target_link_libraries(test_cmake gz-rendering7::gz-rendering7)
     EOS
     # test building with pkg-config
-    # there is a problem finding gl.pc
-    # disable this test for now
-    #
-    # system "pkg-config", "gz-rendering7"
-    # cflags   = `pkg-config --cflags gz-rendering7`.split
-    # ldflags  = `pkg-config --libs gz-rendering7`.split
-    # system ENV.cc, "test.cpp",
-    #                *cflags,
-    #                *ldflags,
-    #                "-lc++",
-    #                "-o", "test"
-    # system "./test" unless github_actions
+    system "pkg-config", "gz-rendering7"
+    cflags   = `pkg-config --cflags gz-rendering7`.split
+    ldflags  = `pkg-config --libs gz-rendering7`.split
+    system ENV.cc, "test.cpp",
+                   *cflags,
+                   *ldflags,
+                   "-lc++",
+                   "-o", "test"
+    system "./test" unless github_actions
     # test building with cmake
     mkdir "build" do
       system "cmake", ".."

--- a/Formula/gz-sensors7.rb
+++ b/Formula/gz-sensors7.rb
@@ -53,18 +53,15 @@ class GzSensors7 < Formula
       target_link_libraries(test_cmake gz-sensors7::gz-sensors7)
     EOS
     # test building with pkg-config
-    # there is a problem with pkg-config in gz-rendering7
-    # disable this test for now
-    #
-    # system "pkg-config", "gz-sensors7"
-    # cflags   = `pkg-config --cflags gz-sensors7`.split
-    # ldflags  = `pkg-config --libs gz-sensors7`.split
-    # system ENV.cc, "test.cpp",
-    #                *cflags,
-    #                *ldflags,
-    #                "-lc++",
-    #                "-o", "test"
-    # system "./test"
+    system "pkg-config", "gz-sensors7"
+    cflags   = `pkg-config --cflags gz-sensors7`.split
+    ldflags  = `pkg-config --libs gz-sensors7`.split
+    system ENV.cc, "test.cpp",
+                   *cflags,
+                   *ldflags,
+                   "-lc++",
+                   "-o", "test"
+    system "./test"
     # test building with cmake
     mkdir "build" do
       system "cmake", ".."


### PR DESCRIPTION
This re-enables the pkg-config tests for gz-rendering7, gz-gui7, and gz-sensors7 by reverting #2251, and applies a patch from https://github.com/gazebosim/gz-rendering/pull/844 to fix the tests.

This change doesn't require building new bottles; this can be merged as is.