### PR TITLE
gz-physics6: rebuild bottle

### DIFF
--- a/Formula/gz-physics6.rb
+++ b/Formula/gz-physics6.rb
@@ -6,7 +6,6 @@ class GzPhysics6 < Formula
   license "Apache-2.0"
   revision 1
 
-
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     sha256 cellar: :any, monterey: "acb86b3e7ea9832b139d0a6ca0fcbab9fd816a231ca70f63b7e4fcb7a6b315a3"

--- a/Formula/gz-physics6.rb
+++ b/Formula/gz-physics6.rb
@@ -8,8 +8,8 @@ class GzPhysics6 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, monterey: "acb86b3e7ea9832b139d0a6ca0fcbab9fd816a231ca70f63b7e4fcb7a6b315a3"
-    sha256 cellar: :any, big_sur:  "1d0586293d24f0200bcae7253dc466dd1e219fdf6cb6d7297d552b2b29babe7c"
+    sha256 cellar: :any, monterey: "64fa5335f0d0e52c48837173f1ed2b1964f1ff332ad62bcb3be5ca7f37511e14"
+    sha256 cellar: :any, big_sur:  "0c9525f3636ad7c451d191f886264e046bcc0a088e8a90bb584fc414991c6cd9"
   end
 
   depends_on "cmake" => :build

--- a/Formula/gz-physics6.rb
+++ b/Formula/gz-physics6.rb
@@ -4,6 +4,8 @@ class GzPhysics6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-6.4.0.tar.bz2"
   sha256 "20c47b96d430eee05c3f3ef24606e798a922077b099e9796713d2e7d8a893cf3"
   license "Apache-2.0"
+  revision 1
+
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"


### PR DESCRIPTION
CI is failing with the following error, so attempting to fix it by rebuilding the bottle

```
==> Fetching osrf/simulation/gz-physics6
==> Downloading https://osrf-distributions.s3.amazonaws.com/bottles-simulation/gz-physics6-6.4.0.big_sur.bottle.tar.gz
Already downloaded: /Users/jenkins/Library/Caches/Homebrew/downloads/727045607bbb4925e393058b187598c10da17ee7db84414821a3bcd617df6164--gz-physics6-6.4.0.big_sur.bottle.tar.gz
Error: gz-sim7: SHA256 mismatch
Expected: 1d0586293d24f0200bcae7253dc466dd1e219fdf6cb6d7297d552b2b29babe7c
  Actual: f7f7041e6bc4ab6da97aa418697c7914196fac471cef89e27f1b77287ec8ba4c
    File: /Users/jenkins/Library/Caches/Homebrew/downloads/727045607bbb4925e393058b187598c10da17ee7db84414821a3bcd617df6164--gz-physics6-6.4.0.big_sur.bottle.tar.gz

```

I'll wait for @scpeters  to okay this before building the bottle.