### PR TITLE
Update CMAKE_INSTALL_RPATH for gz-garden dependencies

### DIFF
--- a/Formula/gz-common5.rb
+++ b/Formula/gz-common5.rb
@@ -30,7 +30,7 @@ class GzCommon5 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
-    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath};/opt/homebrew/lib"
 
     # Use build folder
     mkdir "build" do

--- a/Formula/gz-fuel-tools8.rb
+++ b/Formula/gz-fuel-tools8.rb
@@ -26,7 +26,7 @@ class GzFuelTools8 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
-    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath};/opt/homebrew/lib"
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/gz-fuel-tools9.rb
+++ b/Formula/gz-fuel-tools9.rb
@@ -20,7 +20,7 @@ class GzFuelTools9 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
-    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath};/opt/homebrew/lib"
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/gz-gui7.rb
+++ b/Formula/gz-gui7.rb
@@ -28,7 +28,7 @@ class GzGui7 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
-    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath};/opt/homebrew/lib"
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/gz-gui8.rb
+++ b/Formula/gz-gui8.rb
@@ -22,7 +22,7 @@ class GzGui8 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
-    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath};/opt/homebrew/lib"
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/gz-launch6.rb
+++ b/Formula/gz-launch6.rb
@@ -33,7 +33,7 @@ class GzLaunch6 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
-    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath};/opt/homebrew/lib"
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/gz-launch7.rb
+++ b/Formula/gz-launch7.rb
@@ -25,7 +25,7 @@ class GzLaunch7 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
-    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath};/opt/homebrew/lib"
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/gz-math7.rb
+++ b/Formula/gz-math7.rb
@@ -26,7 +26,7 @@ class GzMath7 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
-    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath};/opt/homebrew/lib"
 
     # Use build folder
     mkdir "build" do

--- a/Formula/gz-msgs10.rb
+++ b/Formula/gz-msgs10.rb
@@ -18,7 +18,7 @@ class GzMsgs10 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
-    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath};/opt/homebrew/lib"
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/gz-msgs9.rb
+++ b/Formula/gz-msgs9.rb
@@ -26,7 +26,7 @@ class GzMsgs9 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
-    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath};/opt/homebrew/lib"
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/gz-physics6.rb
+++ b/Formula/gz-physics6.rb
@@ -29,7 +29,7 @@ class GzPhysics6 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
-    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath};/opt/homebrew/lib"
     system "cmake", ".", *cmake_args
     system "make", "install"
   end

--- a/Formula/gz-plugin2.rb
+++ b/Formula/gz-plugin2.rb
@@ -24,7 +24,7 @@ class GzPlugin2 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
-    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath};/opt/homebrew/lib"
 
     # Use build folder
     mkdir "build" do

--- a/Formula/gz-rendering7.rb
+++ b/Formula/gz-rendering7.rb
@@ -29,7 +29,7 @@ class GzRendering7 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
-    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath};/opt/homebrew/lib"
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/gz-rendering8.rb
+++ b/Formula/gz-rendering8.rb
@@ -23,7 +23,7 @@ class GzRendering8 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
-    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath};/opt/homebrew/lib"
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/gz-sensors7.rb
+++ b/Formula/gz-sensors7.rb
@@ -27,7 +27,7 @@ class GzSensors7 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
-    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath};/opt/homebrew/lib"
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/gz-sensors8.rb
+++ b/Formula/gz-sensors8.rb
@@ -21,7 +21,7 @@ class GzSensors8 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
-    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath};/opt/homebrew/lib"
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/gz-sim7.rb
+++ b/Formula/gz-sim7.rb
@@ -39,7 +39,7 @@ class GzSim7 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
-    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath};/opt/homebrew/lib"
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/gz-sim8.rb
+++ b/Formula/gz-sim8.rb
@@ -33,7 +33,7 @@ class GzSim8 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
-    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath};/opt/homebrew/lib"
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/gz-transport12.rb
+++ b/Formula/gz-transport12.rb
@@ -31,7 +31,7 @@ class GzTransport12 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
-    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath};/opt/homebrew/lib"
 
     # Use build folder
     mkdir "build" do

--- a/Formula/gz-transport13.rb
+++ b/Formula/gz-transport13.rb
@@ -25,7 +25,7 @@ class GzTransport13 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
-    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath};/opt/homebrew/lib"
 
     # Use build folder
     mkdir "build" do

--- a/Formula/gz-utils2.rb
+++ b/Formula/gz-utils2.rb
@@ -21,7 +21,7 @@ class GzUtils2 < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
-    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath};/opt/homebrew/lib"
 
     # Use build folder
     mkdir "build" do


### PR DESCRIPTION
Update the `CMAKE_INSTALL_RPATH` to include `/opt/homebrew/lib` which is the brew library location for Apple M1 machines.

Fixes: https://github.com/gazebosim/gz-sim/issues/1990

Tested on macOS Ventura, Xcode and CommandLineTools 14.3.1. MacBookPro M1.