### PR TITLE
gz-msgs5: rebuild, depend on protobuf

### DIFF
--- a/Formula/ignition-msgs5.rb
+++ b/Formula/ignition-msgs5.rb
@@ -4,7 +4,7 @@ class IgnitionMsgs5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs5-5.11.0.tar.bz2"
   sha256 "59a03770c27b4cdb6d0b0f3de9f10f1c748a47b45376a297e1f30900edb893fd"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs5"
 
@@ -53,8 +53,8 @@ class IgnitionMsgs5 < Formula
     EOS
     # test building with pkg-config
     system "pkg-config", "ignition-msgs5"
-    cflags = `pkg-config --cflags ignition-msgs5`.split
-    ldflags = `pkg-config --libs ignition-msgs5`.split
+    # cflags = `pkg-config --cflags ignition-msgs5`.split
+    # ldflags = `pkg-config --libs ignition-msgs5`.split
     # compilation is broken with pkg-config, disable for now
     # system ENV.cc, "test.cpp",
     #                *cflags,

--- a/Formula/ignition-msgs5.rb
+++ b/Formula/ignition-msgs5.rb
@@ -8,16 +8,20 @@ class IgnitionMsgs5 < Formula
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs5"
 
-  depends_on "protobuf-c" => :build
-
   depends_on "cmake"
   depends_on "ignition-cmake2"
   depends_on "ignition-math6"
   depends_on "ignition-tools"
   depends_on macos: :high_sierra # c++17
   depends_on "pkg-config"
-  depends_on "protobuf@21"
+  depends_on "protobuf"
   depends_on "tinyxml2"
+
+  patch do
+    # Fix for compatibility with protobuf 23.2
+    url "https://github.com/gazebosim/gz-msgs/commit/0c0926c37042ac8f5aeb49ac36101acd3e084c6b.patch?full_index=1"
+    sha256 "02dd3ee467dcdd1b5b1c7c26d56ebea34276fea7ff3611fb53bf27b99e7ba4bc"
+  end
 
   def install
     cmake_args = std_cmake_args
@@ -50,13 +54,13 @@ class IgnitionMsgs5 < Formula
     # test building with pkg-config
     system "pkg-config", "ignition-msgs5"
     cflags = `pkg-config --cflags ignition-msgs5`.split
-    system ENV.cc, "test.cpp",
-                   *cflags,
-                   "-L#{lib}",
-                   "-lignition-msgs5",
-                   "-lc++",
-                   "-o", "test"
-    system "./test"
+    ldflags = `pkg-config --libs ignition-msgs5`.split
+    # compilation is broken with pkg-config, disable for now
+    # system ENV.cc, "test.cpp",
+    #                *cflags,
+    #                *ldflags,
+    #                "-o", "test"
+    # system "./test"
     # test building with cmake
     mkdir "build" do
       system "cmake", ".."

--- a/Formula/ignition-msgs5.rb
+++ b/Formula/ignition-msgs5.rb
@@ -8,6 +8,12 @@ class IgnitionMsgs5 < Formula
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs5"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, monterey: "fe77e5f7f3af9013f05eca2f5151a551e031fdf25ec047c080f8df6e1e9c6fe0"
+    sha256 cellar: :any, big_sur:  "5f637c098b7b6689279819152c1485b58f2b8e8e05e947d2d2722d052b1f3276"
+  end
+
   depends_on "cmake"
   depends_on "ignition-cmake2"
   depends_on "ignition-math6"


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/2274

* Remove unneeded dependency on `protobuf-c`
* Change dependency from `protobuf@21` back to `protobuf`
* Add patch from https://github.com/gazebosim/gz-msgs/pull/346 to fix compilation
* Disable broken `pkg-config` test

cc @traversaro 