### PR TITLE
gz-gui3, gz-gui6: add protobuf patches

### DIFF
--- a/Formula/ignition-gui3.rb
+++ b/Formula/ignition-gui3.rb
@@ -29,6 +29,12 @@ class IgnitionGui3 < Formula
   depends_on "qt@5"
   depends_on "tinyxml2"
 
+  patch do
+    # Fix for compatibility with protobuf 23.2
+    url "https://github.com/gazebosim/gz-gui/commit/f65395f734df81b22dcd10d68d2802b61d6b72bc.patch?full_index=1"
+    sha256 "50c63503ca4dc48c677e254b3a50a9cffd3ffbee9b6d85a60b36c78a3eb3ba05"
+  end
+
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"

--- a/Formula/ignition-gui3.rb
+++ b/Formula/ignition-gui3.rb
@@ -4,15 +4,9 @@ class IgnitionGui3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gui/releases/ignition-gui3-3.12.0.tar.bz2"
   sha256 "f53ee05d844449b900ecb30d5e1f812fd3f7e9e28630d309b7d8d11add3c3b1c"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui3"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 monterey: "73969b7ee975de9e8dd06633a296ec6e3716f6370eb4383c63b821ca42387946"
-    sha256 big_sur:  "66a23575254348c3ef0c3cf3578d4e04581b4dc9970cc11736208130a53b3131"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -20,6 +20,12 @@ class IgnitionGui6 < Formula
   depends_on "qt@5"
   depends_on "tinyxml2"
 
+  patch do
+    # Fix for compatibility with protobuf 23.2
+    url "https://github.com/gazebosim/gz-gui/commit/f65395f734df81b22dcd10d68d2802b61d6b72bc.patch?full_index=1"
+    sha256 "50c63503ca4dc48c677e254b3a50a9cffd3ffbee9b6d85a60b36c78a3eb3ba05"
+  end
+
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"


### PR DESCRIPTION
Part of #2274. Add patch from https://github.com/gazebosim/gz-gui/pull/544 to `gz-gui3` and `gz-gui6`. Also remove bottle block from `gz-gui3` that was built without this patch. I'm not sure how it worked, but it's causing an issue with `gz-sim3`, so let's rebuild after merging these patches.