### PR TITLE
Remove broken protobuf bottles again

### DIFF
--- a/Formula/gazebo11.rb
+++ b/Formula/gazebo11.rb
@@ -4,15 +4,9 @@ class Gazebo11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/gazebo-11.13.0.tar.bz2"
   sha256 "2f65b98fe652a574e01b7cae6cf12e14a9dd29343fde99e066ac5193a8d03e71"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/osrf/gazebo.git", branch: "gazebo11"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 monterey: "f417bb5d97e878829501feed523e47807b9ac1a017871ffe5744100b8cbda077"
-    sha256 big_sur:  "f7be1ff859608a7de2e5c3ffcee9530629a8194d62b7221243b6d578eb57f53b"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/gz-msgs9.rb
+++ b/Formula/gz-msgs9.rb
@@ -4,15 +4,9 @@ class GzMsgs9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/gz-msgs-9.4.0.tar.bz2"
   sha256 "6690ea3ab938afa4980373008dcc4119da43e4c51763a46948f6fd549144e993"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, monterey: "53b777f4ccc5563d3ba521bb6ac511443870e39dd6197bfebc342518278644d1"
-    sha256 cellar: :any, big_sur:  "05533c0329fe13fa315e44c9799bd20978aa9a86e57f8af0b0c8b92a42ccbc89"
-  end
 
   depends_on "cmake"
   depends_on "gz-cmake3"

--- a/Formula/gz-transport12.rb
+++ b/Formula/gz-transport12.rb
@@ -4,15 +4,9 @@ class GzTransport12 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/gz-transport-12.2.0.tar.bz2"
   sha256 "731ec9f87fd815c62486ed4e2c3ecbeff5b8b4a8f09cc5e7abf4d8758cebe048"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport12"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 monterey: "71dba9d4f2b95dbf7ecb7f7bbd25b68d21bf9a3ae625f43dd17f172a63144155"
-    sha256 big_sur:  "4a3449df6d2ed925d8fb952d6e3379b837065c680cae4326ca44a6945aac802d"
-  end
 
   depends_on "doxygen" => [:build, :optional]
 

--- a/Formula/ignition-gui3.rb
+++ b/Formula/ignition-gui3.rb
@@ -4,15 +4,9 @@ class IgnitionGui3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gui/releases/ignition-gui3-3.12.0.tar.bz2"
   sha256 "f53ee05d844449b900ecb30d5e1f812fd3f7e9e28630d309b7d8d11add3c3b1c"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui3"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 monterey: "ffd863d2901c61e77ff39dd995f35c390a7d2a1d46e513c5f62ef0d705b6080d"
-    sha256 big_sur:  "b028205de5920d7f08f1c60ba7fc2a274f96b896bb04d405652bc25a425b4f8b"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -4,15 +4,9 @@ class IgnitionGui6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gui/releases/ignition-gui6-6.8.0.tar.bz2"
   sha256 "dd4f26100f4d1343f068ba36f2b8394a0cddb337efde7b4a21c1b0f66ce496c9"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 monterey: "aa6a3f6d9b84175b101f0f000d50f150dbf253a8c136a6ba35cac3b38f53b88b"
-    sha256 big_sur:  "f096e635f3e0c198af0d290896d83d45c5f7659a7bb2e7a90e07cf37e412bde3"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/ignition-msgs5.rb
+++ b/Formula/ignition-msgs5.rb
@@ -4,15 +4,9 @@ class IgnitionMsgs5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs5-5.11.0.tar.bz2"
   sha256 "59a03770c27b4cdb6d0b0f3de9f10f1c748a47b45376a297e1f30900edb893fd"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, monterey: "fe77e5f7f3af9013f05eca2f5151a551e031fdf25ec047c080f8df6e1e9c6fe0"
-    sha256 cellar: :any, big_sur:  "5f637c098b7b6689279819152c1485b58f2b8e8e05e947d2d2722d052b1f3276"
-  end
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-msgs8.rb
+++ b/Formula/ignition-msgs8.rb
@@ -4,15 +4,9 @@ class IgnitionMsgs8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs8-8.7.0.tar.bz2"
   sha256 "b17a8e16fe56a84891bd0654a2ac09427e9a567b9cd2255bb2cfa830f8e1af45"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, monterey: "24430140d192e15b75b441a54b8ff96e949df3630213fa35084bb5d996582111"
-    sha256 cellar: :any, big_sur:  "b4aff238a68f78a55d82affa405df2a03d63e7ec995a45e581bd885cccc88879"
-  end
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-sensors3.rb
+++ b/Formula/ignition-sensors3.rb
@@ -4,15 +4,9 @@ class IgnitionSensors3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-sensors/releases/ignition-sensors3-3.5.0.tar.bz2"
   sha256 "904297a8deea7f3bff79a4a1fa24aee9c208a72013e29147c3087ca07fc41788"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors3"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 monterey: "05643e11ba1c4688a9dde16926edf8fda9a5291a4ceddcb89767c4d39872c0e9"
-    sha256 big_sur:  "20da66854a5c3025970382aaa94f08445a2f7829d3e7cc220273b711427cd0a6"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-sensors6.rb
+++ b/Formula/ignition-sensors6.rb
@@ -4,15 +4,9 @@ class IgnitionSensors6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-sensors/releases/ignition-sensors6-6.7.0.tar.bz2"
   sha256 "c53a5f077dbf59b1ecc1d0527f54f2a5690ab1cc7f23fdc690aaa6bdd6c67c4c"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, monterey: "ca594bf755bfe23cb4a2f3d43ec1177edd33a16a83407c798e562ace6f3403bc"
-    sha256 cellar: :any, big_sur:  "91c86d8d02ac268b6428c4f72b32b3642641f94562ea76ebad102797564bfb73"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -4,16 +4,10 @@ class IgnitionTransport11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases/ignition-transport11-11.4.0.tar.bz2"
   sha256 "504310cec3c097abb8d9a45e694924a70fadbf785c9e679545f85cb72cfdc434"
   license "Apache-2.0"
-  revision 2
+  revision 3
   version_scheme 1
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport11"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 monterey: "7a049e16e757c81d4e581f848120f6e7a75cd70d35652275e9db660126b230cb"
-    sha256 big_sur:  "b58576e307457ebcb03a1fca89c18382289325f857d0cdb0be59176fc00f0435"
-  end
 
   depends_on "doxygen" => [:build, :optional]
 

--- a/Formula/ignition-transport8.rb
+++ b/Formula/ignition-transport8.rb
@@ -4,15 +4,9 @@ class IgnitionTransport8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases/ignition-transport8-8.4.0.tar.bz2"
   sha256 "deac1e04f08e3bebd70d587de54054beacf205a05aaac2db0dc1926fa35bf2a2"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 monterey: "a572e57952ddb4bddb99eb71c042df5f3baaa334d7e8c99687034bfbe6041974"
-    sha256 big_sur:  "73994a5e8a47e7647886db1686e10050142b93d18d3b0114dba9b9150f3b491f"
-  end
 
   depends_on "doxygen" => [:build, :optional]
 


### PR DESCRIPTION
I think there was an ABI change in https://github.com/Homebrew/homebrew-core/pull/133818 because the bottles are broken again. This should remove all the relevant bottles that are currently built.

See also #2274.