### PR TITLE
Add missing protobuf dependency to gui, sensors, sim

### DIFF
--- a/Formula/gz-gui7.rb
+++ b/Formula/gz-gui7.rb
@@ -17,6 +17,7 @@ class GzGui7 < Formula
   depends_on "gz-rendering7"
   depends_on "gz-transport12"
   depends_on macos: :mojave # c++17
+  depends_on "protobuf"
   depends_on "qt@5"
   depends_on "tinyxml2"
 

--- a/Formula/gz-gui8.rb
+++ b/Formula/gz-gui8.rb
@@ -16,6 +16,7 @@ class GzGui8 < Formula
   depends_on "gz-rendering8"
   depends_on "gz-transport13"
   depends_on macos: :mojave # c++17
+  depends_on "protobuf"
   depends_on "qt@5"
   depends_on "tinyxml2"
 

--- a/Formula/gz-sensors7.rb
+++ b/Formula/gz-sensors7.rb
@@ -17,6 +17,7 @@ class GzSensors7 < Formula
   depends_on "gz-msgs9"
   depends_on "gz-rendering7"
   depends_on "gz-transport12"
+  depends_on "protobuf"
   depends_on "sdformat13"
 
   patch do

--- a/Formula/gz-sensors8.rb
+++ b/Formula/gz-sensors8.rb
@@ -16,6 +16,7 @@ class GzSensors8 < Formula
   depends_on "gz-msgs10"
   depends_on "gz-rendering8"
   depends_on "gz-transport13"
+  depends_on "protobuf"
   depends_on "sdformat13"
 
   def install

--- a/Formula/gz-sim7.rb
+++ b/Formula/gz-sim7.rb
@@ -28,6 +28,7 @@ class GzSim7 < Formula
   depends_on "gz-utils2"
   depends_on macos: :mojave # c++17
   depends_on "pkg-config"
+  depends_on "protobuf"
   depends_on "ruby"
   depends_on "sdformat13"
 

--- a/Formula/gz-sim8.rb
+++ b/Formula/gz-sim8.rb
@@ -27,6 +27,7 @@ class GzSim8 < Formula
   depends_on "gz-utils2"
   depends_on macos: :mojave # c++17
   depends_on "pkg-config"
+  depends_on "protobuf"
   depends_on "ruby"
   depends_on "sdformat13"
 

--- a/Formula/ignition-gazebo3.rb
+++ b/Formula/ignition-gazebo3.rb
@@ -35,6 +35,7 @@ class IgnitionGazebo3 < Formula
   depends_on "ignition-transport8"
   depends_on macos: :mojave # c++17
   depends_on "pkg-config"
+  depends_on "protobuf"
   depends_on "ruby"
   depends_on "sdformat9"
 

--- a/Formula/ignition-gazebo3.rb
+++ b/Formula/ignition-gazebo3.rb
@@ -4,15 +4,9 @@ class IgnitionGazebo3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gazebo/releases/ignition-gazebo3-3.15.0.tar.bz2"
   sha256 "009a107afc4517caea609ab0b24eae65282faab808bda9aa0a22e600bc2b0088"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo3"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 monterey: "41646378772691ae18b2f006c62949a85537c66a7e8cd5512cf192fab22bd35c"
-    sha256 big_sur:  "ada37281abe031b939ed8fea3515257be7e0b8418deddf2e113e2023dad07716"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -34,6 +34,7 @@ class IgnitionGazebo6 < Formula
   depends_on "ignition-utils1"
   depends_on macos: :mojave # c++17
   depends_on "pkg-config"
+  depends_on "protobuf"
   depends_on "python@3.11"
   depends_on "ruby"
   depends_on "sdformat12"

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -4,15 +4,9 @@ class IgnitionGazebo6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gazebo/releases/ignition-gazebo6-6.14.0.tar.bz2"
   sha256 "7c516f826c1214dd5079a96975004910ad91a09c53afc14e1f308cdaa4b8e918"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 monterey: "e873027a6827e6bd293e55636643cff0734ae81e57608fb55126bca930c3c223"
-    sha256 big_sur:  "2c30918e5c194399694770a28a55e0bfb705594c9ca7621881c2fa86528d0589"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build

--- a/Formula/ignition-gui3.rb
+++ b/Formula/ignition-gui3.rb
@@ -20,6 +20,7 @@ class IgnitionGui3 < Formula
   depends_on "ignition-rendering3"
   depends_on "ignition-transport8"
   depends_on macos: :mojave # c++17
+  depends_on "protobuf"
   depends_on "qt@5"
   depends_on "tinyxml2"
 

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -17,6 +17,7 @@ class IgnitionGui6 < Formula
   depends_on "ignition-rendering6"
   depends_on "ignition-transport11"
   depends_on macos: :mojave # c++17
+  depends_on "protobuf"
   depends_on "qt@5"
   depends_on "tinyxml2"
 

--- a/Formula/ignition-sensors3.rb
+++ b/Formula/ignition-sensors3.rb
@@ -19,6 +19,7 @@ class IgnitionSensors3 < Formula
   depends_on "ignition-msgs5"
   depends_on "ignition-rendering3"
   depends_on "ignition-transport8"
+  depends_on "protobuf"
   depends_on "sdformat9"
 
   patch do

--- a/Formula/ignition-sensors6.rb
+++ b/Formula/ignition-sensors6.rb
@@ -17,6 +17,7 @@ class IgnitionSensors6 < Formula
   depends_on "ignition-msgs8"
   depends_on "ignition-rendering6"
   depends_on "ignition-transport11"
+  depends_on "protobuf"
   depends_on "sdformat12"
 
   patch do


### PR DESCRIPTION
These packages explicitly find protobuf, so add it as a dependency. Also remove some broken bottles missed in #2300.