### PR TITLE
gz-fuel-tools*: explicitly depend on protobuf

### DIFF
--- a/Formula/gz-fuel-tools8.rb
+++ b/Formula/gz-fuel-tools8.rb
@@ -17,6 +17,7 @@ class GzFuelTools8 < Formula
   depends_on "libzip"
   depends_on macos: :high_sierra # c++17
   depends_on "pkg-config"
+  depends_on "protobuf"
 
   def install
     cmake_args = std_cmake_args

--- a/Formula/gz-fuel-tools9.rb
+++ b/Formula/gz-fuel-tools9.rb
@@ -16,6 +16,7 @@ class GzFuelTools9 < Formula
   depends_on "libzip"
   depends_on macos: :high_sierra # c++17
   depends_on "pkg-config"
+  depends_on "protobuf"
 
   def install
     cmake_args = std_cmake_args

--- a/Formula/ignition-fuel-tools4.rb
+++ b/Formula/ignition-fuel-tools4.rb
@@ -23,6 +23,7 @@ class IgnitionFuelTools4 < Formula
   depends_on "libzip"
   depends_on macos: :high_sierra # c++17
   depends_on "pkg-config"
+  depends_on "protobuf"
 
   def install
     cmake_args = std_cmake_args

--- a/Formula/ignition-fuel-tools4.rb
+++ b/Formula/ignition-fuel-tools4.rb
@@ -4,15 +4,9 @@ class IgnitionFuelTools4 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-fuel-tools/releases/ignition-fuel-tools4-4.9.0.tar.bz2"
   sha256 "6834b959cb7cc1d90ea86042bc29e41d12ad68b8f3029f5ebd8b6ae73649420e"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools4"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, monterey: "210e801a841245e245b7a7812ab179a6f0e5b9184828af980d03abd6ccf7a929"
-    sha256 cellar: :any, big_sur:  "a991f433e1c3135be16c380244a770867e15a22391b21b5d7b85960c9379ec0a"
-  end
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -4,14 +4,9 @@ class IgnitionFuelTools7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-fuel-tools/releases/ignition-fuel-tools7-7.3.0.tar.bz2"
   sha256 "59d06f23a054742e1f97c1f0f709e2a38c341ce96f560d6e09b3dba011dd79a5"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, monterey: "de58e0129e0d049d4a3fbe34c1718adbeac2d8170ec65ecf0332bd7b77419bfc"
-    sha256 cellar: :any, big_sur:  "006d75758d0824892c7d3aed40a0aa6bb900a6915f96c56c374f05af9419e332"
-  end
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -22,6 +22,7 @@ class IgnitionFuelTools7 < Formula
   depends_on "libzip"
   depends_on macos: :high_sierra # c++17
   depends_on "pkg-config"
+  depends_on "protobuf"
 
   def install
     cmake_args = std_cmake_args


### PR DESCRIPTION
Also remove broken bottles for gz-fuel-tools4 and gz-fuel-tools7.

Part of #2274.