### PR TITLE
gz-msgs10, gz-transport13: don't use protobuf@21

### DIFF
--- a/Formula/gz-msgs10.rb
+++ b/Formula/gz-msgs10.rb
@@ -5,14 +5,13 @@ class GzMsgs10 < Formula
   version "9.999.999~0~20230125"
   license "Apache-2.0"
 
-  depends_on "protobuf-c" => :build
   depends_on "cmake"
   depends_on "gz-cmake3"
   depends_on "gz-math7"
   depends_on "gz-tools2"
   depends_on macos: :high_sierra # c++17
   depends_on "pkg-config"
-  depends_on "protobuf@21"
+  depends_on "protobuf"
   depends_on "tinyxml2"
 
   def install

--- a/Formula/gz-transport13.rb
+++ b/Formula/gz-transport13.rb
@@ -8,7 +8,6 @@ class GzTransport13 < Formula
   head "https://github.com/gazebosim/gz-transport.git", branch: "main"
 
   depends_on "doxygen" => [:build, :optional]
-  depends_on "protobuf-c" => :build
 
   depends_on "cmake"
   depends_on "cppzmq"
@@ -19,7 +18,7 @@ class GzTransport13 < Formula
   depends_on macos: :mojave # c++17
   depends_on "ossp-uuid"
   depends_on "pkg-config"
-  depends_on "protobuf@21"
+  depends_on "protobuf"
   depends_on "zeromq"
 
   def install

--- a/Formula/ignition-transport4.rb
+++ b/Formula/ignition-transport4.rb
@@ -10,7 +10,6 @@ class IgnitionTransport4 < Formula
 
   depends_on "doxygen" => [:build, :optional]
 
-  depends_on "protobuf-c" => :build
   depends_on "cmake"
   depends_on "cppzmq"
   depends_on "ignition-cmake0"
@@ -18,7 +17,7 @@ class IgnitionTransport4 < Formula
   depends_on "ignition-tools"
   depends_on "ossp-uuid"
   depends_on "pkg-config"
-  depends_on "protobuf@21"
+  depends_on "protobuf"
   depends_on "zeromq"
 
   def install


### PR DESCRIPTION
This reverts from https://github.com/osrf/homebrew-simulation/pull/2275 the dependency from `protobuf@21` back to `protobuf` for several formulae and also removes the unused dependency on `protobuf-c`.

Part of #2274.