### PR TITLE
gz-common5: re-enable gdal dependency

### DIFF
--- a/Formula/gz-common5.rb
+++ b/Formula/gz-common5.rb
@@ -12,8 +12,7 @@ class GzCommon5 < Formula
   depends_on "cmake"
   depends_on "ffmpeg"
   depends_on "freeimage"
-  # Disable gdal dependency until apache-arrow uses unversioned protobuf
-  # depends on "gdal"
+  depends_on "gdal"
   depends_on "gts"
   depends_on "gz-cmake3"
   depends_on "gz-math7"

--- a/Formula/gz-physics6.rb
+++ b/Formula/gz-physics6.rb
@@ -20,12 +20,6 @@ class GzPhysics6 < Formula
   depends_on "pkg-config"
   depends_on "sdformat13"
 
-  patch do
-    # Fix for building without gdal
-    url "https://github.com/gazebosim/gz-physics/commit/67d008fb4c8860d1293ecb50c743b70107567c1b.patch?full_index=1"
-    sha256 "1746b1f3115f328b1b0ee6207aca7b531508326a0ccbd4d3f1335bf9f7af00a0"
-  end
-
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"


### PR DESCRIPTION
gz-physics5: remove unneeded patch

Part of #2274 