### PR TITLE
gz-transport13: Add pybind11 dependency

### DIFF
--- a/Formula/gz-transport13.rb
+++ b/Formula/gz-transport13.rb
@@ -8,6 +8,7 @@ class GzTransport13 < Formula
   head "https://github.com/gazebosim/gz-transport.git", branch: "main"
 
   depends_on "doxygen" => [:build, :optional]
+  depends_on "pybind11" => :build
 
   depends_on "cmake"
   depends_on "cppzmq"


### PR DESCRIPTION
[Downstream](https://build.osrfoundation.org/view/ign-harmonic/job/ignition_sensors-ci-main-homebrew-amd64/87/consoleFull) builds are failing with
```
==> cmake .. -DBUILD_TESTING=Off -DCMAKE_INSTALL_RPATH=@loader_path/../lib
==> make install
Warning: Tried to install empty array to /usr/local/Cellar/gz-transport13/12.999.999~0~20230203/lib/python3.11/site-packages
Error: An exception occurred within a child process:
  Errno::ENOENT: No such file or directory @ dir_s_rmdir - /usr/local/Cellar/gz-transport13/12.999.999~0~20230203/lib/python
```
