### PR TITLE
Remove broken abseil bottles

### DIFF
--- a/Formula/gz-fuel-tools8.rb
+++ b/Formula/gz-fuel-tools8.rb
@@ -4,16 +4,9 @@ class GzFuelTools8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-8.1.0.tar.bz2"
   sha256 "18a25e2bc31e61539c890bdd377068b5192646a6647267e76d9b0bb0d0349545"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "a682dc7d74c6a60dfdec4e8f870323dbea6fed134d38951b61a7b8768ba9f27b"
-    sha256 cellar: :any, monterey: "89a23292d017d48939b9132d1ba8d0bf1e35cd47eac933940594e3c6dc27441b"
-    sha256 cellar: :any, big_sur:  "f4ee0bfcd89b5622d139a078ec75792590dd1d2dc827257d1ca48a5ed122ddf7"
-  end
 
   depends_on "cmake"
   depends_on "gz-cmake3"

--- a/Formula/gz-fuel-tools9.rb
+++ b/Formula/gz-fuel-tools9.rb
@@ -5,15 +5,9 @@ class GzFuelTools9 < Formula
   version "9.0.0~pre1"
   sha256 "30324b1b89944c827595be858a3b827de4ee71eedac3a8ca6e75f49c54648ed7"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "main"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "908f8d47af3b2b705e5bbd0fdc4ade4901f035aaa3f1aab49fcc39813bbf8286"
-    sha256 cellar: :any, monterey: "b2f130ff1443b8c817159c792f9417ee591cf15e8a4e949942c66a73c364c519"
-    sha256 cellar: :any, big_sur:  "774d1b0180107ac6b1714733b52b80d7c5626a1fb1c658a60f4974981de9d87f"
-  end
 
   depends_on "cmake"
   depends_on "gz-cmake3"

--- a/Formula/gz-gui7.rb
+++ b/Formula/gz-gui7.rb
@@ -4,16 +4,9 @@ class GzGui7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-7.2.0.tar.bz2"
   sha256 "d44ca605165d296205995a6d5fe3c5bcc58436699fdeae455839b703430b2023"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "a499d01ab0f1643ebcae941b01ca5401561247ac6867b3c23972417174d516ad"
-    sha256 monterey: "c1e5039400acc9ff88ee1a803609817779bcc7ba8a834c2ad9477548fc69cb8f"
-    sha256 big_sur:  "6808318e93e78ad566a8c52a68b6842026cca196d8104a09b6d2b445046e232b"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/gz-msgs10.rb
+++ b/Formula/gz-msgs10.rb
@@ -5,13 +5,7 @@ class GzMsgs10 < Formula
   version "10.0.0~pre2"
   sha256 "4dd05d1c0cd9f91e60ecd79b128a1343e7a8632754d8524bf21c4418adec857e"
   license "Apache-2.0"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "e2e44b6d0962b88922d77339d6b00a19ba098c1c55860734fc25299c2e007cf7"
-    sha256 monterey: "e8cd8a210b304880324be5979713d6c1b7b12e889714e093c7314f599ef614ac"
-    sha256 big_sur:  "39bcc22808acf014941b953580a96b4f6d37099fdcee95a9e50e45c28d2a5bd1"
-  end
+  revision 1
 
   depends_on "cmake"
   depends_on "gz-cmake3"

--- a/Formula/gz-msgs9.rb
+++ b/Formula/gz-msgs9.rb
@@ -4,16 +4,9 @@ class GzMsgs9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/gz-msgs-9.5.0.tar.bz2"
   sha256 "693f403fca86e9956b393a86fd46505d94e27b7b2c1d39bc631ba9c3029b91f9"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "add487eef7f5f37c27c0e58a76942a01b6a36b054e2b8700bc4ca910180d89e1"
-    sha256 cellar: :any, monterey: "b5cfe7ed5c48e38ce52615e0d746630d3f0759ca3206bff0ad540b96a3797924"
-    sha256 cellar: :any, big_sur:  "8b30c0ff782130a500a5a5dcc030be6c76597c4c4edaff1d8b87fa88ee81a324"
-  end
 
   depends_on "cmake"
   depends_on "gz-cmake3"

--- a/Formula/gz-sensors7.rb
+++ b/Formula/gz-sensors7.rb
@@ -4,16 +4,9 @@ class GzSensors7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-7.2.0.tar.bz2"
   sha256 "bf158cb7bde71866a3bf70e649888fe8f6f8eb0b7b77d87e991385c3b8a565af"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "64222c378258faacf8b7c2054655c33f8de2bc10627df92e24661260e4225967"
-    sha256 cellar: :any, monterey: "3a36f1d01b23820dcadd04bde3e1bb8843f242860afa255bad6e2dff6efa8f48"
-    sha256 cellar: :any, big_sur:  "bdd6448f6d3519e5b0dbd983f5b62e5bf3e13f2245090bfbf9f7215b72460cbb"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/gz-transport12.rb
+++ b/Formula/gz-transport12.rb
@@ -4,16 +4,9 @@ class GzTransport12 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/gz-transport-12.2.0.tar.bz2"
   sha256 "731ec9f87fd815c62486ed4e2c3ecbeff5b8b4a8f09cc5e7abf4d8758cebe048"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport12"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "64219d94f0604efc5fee5335c08ebce1891a3ca221d96b4a04659bc0f844f8d7"
-    sha256 monterey: "714b98e4a98bc8663957f64016453b66649dac0af80a254024f8ff6d83b233a8"
-    sha256 big_sur:  "8c0f05fd18044c49498b7d4440a765d7a479363cd874eca4c30e95d8b11f827e"
-  end
 
   depends_on "doxygen" => [:build, :optional]
 

--- a/Formula/gz-transport13.rb
+++ b/Formula/gz-transport13.rb
@@ -5,15 +5,9 @@ class GzTransport13 < Formula
   version "13.0.0~pre1"
   sha256 "1f5785c70d4e0740490c372436fe06a724544e1b323525e39edf981168c89101"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "main"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "b39b32278228372fd3ea7fa5a48c3d717f8a34704f9ea7580d9a70d2c8195d55"
-    sha256 monterey: "84e01fce8d7a113894557fe3e7c298f3188238eb0614dbfb13bccdfe61c2bc7d"
-    sha256 big_sur:  "792234982745497698d8ba5abd58edff0ec7a038eb383ae5f883e428a5459d11"
-  end
 
   depends_on "doxygen" => [:build, :optional]
   depends_on "pybind11" => :build


### PR DESCRIPTION
The recent release of abseil in https://github.com/Homebrew/homebrew-core/pull/139025 has broken our bottles that use protobuf yet again. This removes the broken bottles.

Lumping with https://github.com/osrf/homebrew-simulation/issues/2339.