### PR TITLE
gz-sim7: enable test on monterey

### DIFF
--- a/Formula/gz-sim7.rb
+++ b/Formula/gz-sim7.rb
@@ -57,13 +57,10 @@ class GzSim7 < Formula
   end
 
   test do
-    # Disable failing test on Monterey
-    if MacOS.version != :monterey
-      ENV["IGN_CONFIG_PATH"] = "#{opt_share}/gz"
-      system Formula["ruby"].opt_bin/"ruby",
-             Formula["gz-tools2"].opt_bin/"gz",
-             "sim", "-s", "--iterations", "5", "-r", "-v", "4"
-    end
+    ENV["IGN_CONFIG_PATH"] = "#{opt_share}/gz"
+    system Formula["ruby"].opt_bin/"ruby",
+           Formula["gz-tools2"].opt_bin/"gz",
+           "sim", "-s", "--iterations", "5", "-r", "-v", "4"
     (testpath/"test.cpp").write <<-EOS
     #include <cstdint>
     #include <gz/sim/Entity.hh>


### PR DESCRIPTION
It should be fixed now that https://github.com/gazebosim/gz-physics/pull/529 has been merged and released. Tested successfully on [mac-five.monterey](https://build.osrfoundation.org/computer/mac-five.monterey/) in the following build (using https://github.com/gazebo-tooling/release-tools/pull/1005):

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_sim7-install_bottle-homebrew-amd64&build=185)](https://build.osrfoundation.org/job/ignition_sim7-install_bottle-homebrew-amd64/185/) https://build.osrfoundation.org/job/ignition_sim7-install_bottle-homebrew-amd64/185/
