### PR TITLE
Fortress: patch physics and rebuild bottles

### DIFF
--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -8,6 +8,13 @@ class IgnitionFuelTools7 < Formula
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools7"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, ventura:  "6dc71ce7889abe2687571c8c052bad075f1475daee509615980703722f868c57"
+    sha256 cellar: :any, monterey: "396ca1c1965695afa6eff10e6c200f2a869d2c642abee09e18046172102ad6a4"
+    sha256 cellar: :any, big_sur:  "5a06ac35eb8ff173459765c0af68399a2858b4e874ca5ffa173937954aba0b49"
+  end
+
   depends_on "cmake"
   depends_on "ignition-cmake2"
   depends_on "ignition-common4"

--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -4,7 +4,7 @@ class IgnitionFuelTools7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-fuel-tools/releases/ignition-fuel-tools7-7.3.0.tar.bz2"
   sha256 "59d06f23a054742e1f97c1f0f709e2a38c341ce96f560d6e09b3dba011dd79a5"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools7"
 

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -4,7 +4,7 @@ class IgnitionGazebo6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gazebo/releases/ignition-gazebo6-6.15.0.tar.bz2"
   sha256 "897c8823054d504272dd8312509fb09baa6f042a131d348de2020ebd80bbf780"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo6"
 

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -45,13 +45,10 @@ class IgnitionGazebo6 < Formula
   end
 
   test do
-    # Disable failing test on Monterey
-    if MacOS.version != :monterey
-      ENV["IGN_CONFIG_PATH"] = "#{opt_share}/ignition"
-      system Formula["ruby"].opt_bin/"ruby",
-             Formula["ignition-tools"].opt_bin/"ign",
-             "gazebo", "-s", "--iterations", "5", "-r", "-v", "4"
-    end
+    ENV["IGN_CONFIG_PATH"] = "#{opt_share}/ignition"
+    system Formula["ruby"].opt_bin/"ruby",
+           Formula["ignition-tools"].opt_bin/"ign",
+           "gazebo", "-s", "--iterations", "5", "-r", "-v", "4"
     (testpath/"test.cpp").write <<-EOS
     #include <cstdint>
     #include <ignition/gazebo/Entity.hh>

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -8,6 +8,13 @@ class IgnitionGazebo6 < Formula
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo6"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 ventura:  "002c11ac8c1f52766fa803f25a0feb7a37a6ae9789a87015e6ce9617b6cfa81d"
+    sha256 monterey: "f474d4ef4f3881b114f78084f36e78352246212febfce504060ce1b950bd8363"
+    sha256 big_sur:  "609a698024fc6ef4533f04b3ecec1d3bf873adf6d3a1202b51ab866eb885c38d"
+  end
+
   depends_on "cmake" => :build
   depends_on "pybind11" => :build
   depends_on "ffmpeg"

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -8,6 +8,13 @@ class IgnitionGui6 < Formula
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui6"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 ventura:  "12ad1a1ea711a87226d9ff85a8c93a8331e7168cbf638fdd05eca528bf3ac49a"
+    sha256 monterey: "20443a073acc7141680e277f1e0ace5fbcb507be782f53161c6aa5f1415d0e67"
+    sha256 big_sur:  "9b36c3972a32ef7eaca19ef7106283f8cc39ca33f67a59b9d649e3ad4ef7a8d2"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
   depends_on "ignition-cmake2"

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -4,7 +4,7 @@ class IgnitionGui6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gui/releases/ignition-gui6-6.8.0.tar.bz2"
   sha256 "dd4f26100f4d1343f068ba36f2b8394a0cddb337efde7b4a21c1b0f66ce496c9"
   license "Apache-2.0"
-  revision 10
+  revision 11
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui6"
 

--- a/Formula/ignition-launch5.rb
+++ b/Formula/ignition-launch5.rb
@@ -8,6 +8,13 @@ class IgnitionLaunch5 < Formula
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "ign-launch5"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 ventura:  "03009f4bbecb8ca07df777c329fa4f1fad915ec27f28df82698941641d4a81ad"
+    sha256 monterey: "3579468be3c929957bd0b250a490e5eaebb9780ada8d20e90943c29759d1caa7"
+    sha256 big_sur:  "6b72248e6f4e0d8a7400a7455d16a09bf9eb3a8b9d38f0a2a32f0a4f40df9313"
+  end
+
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
 

--- a/Formula/ignition-launch5.rb
+++ b/Formula/ignition-launch5.rb
@@ -4,7 +4,7 @@ class IgnitionLaunch5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-launch/releases/ignition-launch5-5.3.0.tar.bz2"
   sha256 "84d356b9c85609da1bb7feda2f90ae6d1a1fd2d6713b284799d5605de42e2613"
   license "Apache-2.0"
-  revision 7
+  revision 8
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "ign-launch5"
 

--- a/Formula/ignition-msgs8.rb
+++ b/Formula/ignition-msgs8.rb
@@ -8,6 +8,13 @@ class IgnitionMsgs8 < Formula
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs8"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, ventura:  "68e6f6521410d727f6008619115833b9aee487aa2eb013afd523cc82271cdf68"
+    sha256 cellar: :any, monterey: "28e220efab0b050c38e974a404c76947ba0b9f772f45adaa1cdee9df443f0c53"
+    sha256 cellar: :any, big_sur:  "85fb663e902773b0375c2ab58cdbc7c90485aad186f456bae2e0b9d2bf99885c"
+  end
+
   depends_on "cmake"
   depends_on "ignition-cmake2"
   depends_on "ignition-math6"

--- a/Formula/ignition-msgs8.rb
+++ b/Formula/ignition-msgs8.rb
@@ -4,7 +4,7 @@ class IgnitionMsgs8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs8-8.7.0.tar.bz2"
   sha256 "b17a8e16fe56a84891bd0654a2ac09427e9a567b9cd2255bb2cfa830f8e1af45"
   license "Apache-2.0"
-  revision 10
+  revision 11
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs8"
 

--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -10,9 +10,9 @@ class IgnitionPhysics5 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "3a7d33dfa15c5efeababcb7624020b2b81d41ddac2605e18bede38259cbf0720"
-    sha256 cellar: :any, monterey: "c851366911cecb5e466c8c4db15a0b9b927b84aff5824b8a8094222573bf861c"
-    sha256 cellar: :any, big_sur:  "21c3de8c60cb2ca1bdefbfb7306f26cffa1acf91583d0053fcf42c6ed7e30e19"
+    sha256 cellar: :any, ventura:  "3493a87d1120ffbf9214263f3bf2db615f932b72a75984d2d95011860e81cb8d"
+    sha256 cellar: :any, monterey: "58beb1a2a04067bd51db1f412ca0e02360ad7f1ed737aab980d5441f2c0b9db1"
+    sha256 cellar: :any, big_sur:  "c9b119681bdf174676192cfdc86a7bc628f3a1b55e97546ed4c58d6a1c2048b3"
   end
 
   depends_on "cmake" => :build

--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -4,6 +4,7 @@ class IgnitionPhysics5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics5-5.3.2.tar.bz2"
   sha256 "4262512fbb6952712234c5cbeed69cdabca338931bb6c587a1ef7d487a5f262b"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "ign-physics5"
 
@@ -27,6 +28,12 @@ class IgnitionPhysics5 < Formula
   depends_on macos: :mojave # c++17
   depends_on "pkg-config"
   depends_on "sdformat12"
+
+  patch do
+    # Fix for unregistering dartsim collision detector
+    url "https://github.com/gazebosim/gz-physics/commit/2c238fe87b7c5ebd3d1ba37784db39ce93a6f143.patch?full_index=1"
+    sha256 "396557d48ae665c9a99ea0d9f60308a9ebb08198098df88a7f8497619ffb15d2"
+  end
 
   def install
     cmake_args = std_cmake_args

--- a/Formula/ignition-sensors6.rb
+++ b/Formula/ignition-sensors6.rb
@@ -8,6 +8,13 @@ class IgnitionSensors6 < Formula
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors6"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, ventura:  "3cb3f517a81f7d940acfe9cce5c5ed9b15a62910b2d6dcaad3d3dafcde75050e"
+    sha256 cellar: :any, monterey: "a87069731b930e5367eab005b26d4c3159487e91ffe588fb58c2c0c3efadd604"
+    sha256 cellar: :any, big_sur:  "fe5bd6851d365c28b1f9dbcb6859995082483758cdb995339ae7b5ab3254aaa5"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
 

--- a/Formula/ignition-sensors6.rb
+++ b/Formula/ignition-sensors6.rb
@@ -4,7 +4,7 @@ class IgnitionSensors6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-sensors/releases/ignition-sensors6-6.7.1.tar.bz2"
   sha256 "5b01cb99ff8b1effc0bdaa0309f4378894ace2640644ee3f2b96d44ff3aa10f0"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors6"
 

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -9,6 +9,13 @@ class IgnitionTransport11 < Formula
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport11"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 ventura:  "b53196b78408ba553eeb7daa2474e9607d57417cbb8cb842b13f42d4a97c2c4a"
+    sha256 monterey: "0cb5f2a96834eb7eb40c718038864e29ea70618aaac56af82f79e9f8c2ee490c"
+    sha256 big_sur:  "cd33798169761ad6a6750bb6f5003c12b361c25ddba3a91412671e1f802f6f3c"
+  end
+
   depends_on "doxygen" => [:build, :optional]
 
   depends_on "cmake"

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -4,7 +4,7 @@ class IgnitionTransport11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases/ignition-transport11-11.4.1.tar.bz2"
   sha256 "f18501cbd5c78b584b3db1960a3049d6ae416bab7f0289af64eadda13d1c5da5"
   license "Apache-2.0"
-  revision 2
+  revision 3
   version_scheme 1
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport11"


### PR DESCRIPTION
This adds a patch for gz-physics5 from https://github.com/gazebosim/gz-physics/pull/537 so that the gz-sim6 test on monterey can be enabled.

This also rebuilds the fortress bottles that depend on protobuf as part of #2394.