### PR TITLE
gz-plugin2: test executable in libexec

### DIFF
--- a/Formula/gz-plugin2.rb
+++ b/Formula/gz-plugin2.rb
@@ -35,6 +35,7 @@ class GzPlugin2 < Formula
   end
 
   test do
+    system "#{libexec}/gz/plugin2/gz-plugin"
     (testpath/"test.cpp").write <<-EOS
       #include <gz/plugin/Loader.hh>
       int main() {


### PR DESCRIPTION
While reviewing https://github.com/osrf/homebrew-simulation/pull/2273, I noticed an issue on ARM Macs with the RPATH of the `gz-plugin` executable in the `libexec` folder. I've added a test for this executable to the `gz-plugin2` formula that I expect to pass on Intel CPUs and  fail on arm CPUs.