### PR TITLE
gz-plugin: fix rpath for libexec/gz/plugin2

### DIFF
--- a/Formula/gz-plugin2.rb
+++ b/Formula/gz-plugin2.rb
@@ -4,6 +4,7 @@ class GzPlugin2 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-plugin/releases/gz-plugin-2.0.1.tar.bz2"
   sha256 "92b5c9a99b611887b40c271bf47300b4e8a5d006aa80902bd705d36f1d8508f5"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-math.git", branch: "gz-math7"
 

--- a/Formula/gz-plugin2.rb
+++ b/Formula/gz-plugin2.rb
@@ -23,9 +23,13 @@ class GzPlugin2 < Formula
   depends_on "pkg-config"
 
   def install
+    rpaths = [
+      rpath,
+      rpath(source: libexec/"gz/plugin2", target: lib),
+    ]
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
-    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpaths.join(";")}"
 
     # Use build folder
     mkdir "build" do

--- a/Formula/gz-plugin2.rb
+++ b/Formula/gz-plugin2.rb
@@ -10,10 +10,9 @@ class GzPlugin2 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "0cccfc4e784821706358e8e91655d231c5378fa950ee02775d2917522f9da41f"
-    sha256 cellar: :any, monterey: "f5a33572b7400a2948ae1c988be41ee08f9c3f0a4217e7361fcca263b8290ed0"
-    sha256 cellar: :any, big_sur:  "696b7c7ed4768f14eb5ba56fa393f087571f238873c4681caac6ac6c711169d5"
-    sha256 cellar: :any, catalina: "c7faa3c09ae61b955b32e2c959a586fd61fb73a03f90282f5d3f29a2e8af71b1"
+    sha256 cellar: :any, ventura:  "657a4ddc17e9b96a49b3abfc74a12e2d1cc32cb9157d1db3698f74abe3c013aa"
+    sha256 cellar: :any, monterey: "80a2063bba46c16fb1a7137176c97709503402d82bbcac6de4f2937a71bdba43"
+    sha256 cellar: :any, big_sur:  "46ef3900833388ac27a78cacf6e063807429b7600933bf8ed5f2e7c5ae4c6cec"
   end
 
   depends_on "cmake"


### PR DESCRIPTION
Add an rpath entry with a relative path from the libexec subfolder containing the CLI executable to lib.

Fixes https://github.com/osrf/homebrew-simulation/issues/2403#issuecomment-1716888880.

This could alternatively be fixed in gz-plugin with something like https://github.com/gazebosim/gz-plugin/commit/c5d69a40ae73d1de0f5f9ab1ea5f734fe0d4bba6.

For reference, I copied the implementation for this from the [arrayfire](https://github.com/Homebrew/homebrew-core/blob/master/Formula/a/arrayfire.rb#L36-L51) formula in homebrew-core.