### PR TITLE
Fortress: fix rpath part 1

### DIFF
--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -4,7 +4,7 @@ class IgnitionPhysics5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics5-5.3.2.tar.bz2"
   sha256 "4262512fbb6952712234c5cbeed69cdabca338931bb6c587a1ef7d487a5f262b"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "ign-physics5"
 

--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -10,9 +10,9 @@ class IgnitionPhysics5 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "3493a87d1120ffbf9214263f3bf2db615f932b72a75984d2d95011860e81cb8d"
-    sha256 cellar: :any, monterey: "58beb1a2a04067bd51db1f412ca0e02360ad7f1ed737aab980d5441f2c0b9db1"
-    sha256 cellar: :any, big_sur:  "c9b119681bdf174676192cfdc86a7bc628f3a1b55e97546ed4c58d6a1c2048b3"
+    sha256 cellar: :any, ventura:  "ac9d10fedc61d2b9db49969c19e07c0687b4607d1916bab49be57a7a347e7a57"
+    sha256 cellar: :any, monterey: "2365a03533b6c0d30394f55b9d3686adb8b04df50de2186688b2fc41b57f18da"
+    sha256 cellar: :any, big_sur:  "4bb15f5e986a956abf3a9cc4a667eea5c01070a505c8a02028a62afb2a01d007"
   end
 
   depends_on "cmake" => :build

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -11,9 +11,9 @@ class IgnitionTransport11 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "b53196b78408ba553eeb7daa2474e9607d57417cbb8cb842b13f42d4a97c2c4a"
-    sha256 monterey: "0cb5f2a96834eb7eb40c718038864e29ea70618aaac56af82f79e9f8c2ee490c"
-    sha256 big_sur:  "cd33798169761ad6a6750bb6f5003c12b361c25ddba3a91412671e1f802f6f3c"
+    sha256 ventura:  "adbac4b7cf0afc45d52fae7a6c3aef9c39764ace064d1a96687dc487bbd9ed30"
+    sha256 monterey: "084ee9a5ef1af37ae0640064294fdad9a87849f8254570de7bdfac0d8a377fa2"
+    sha256 big_sur:  "0edb3f21e239c71024a0b61dd92f16d0f20cdaab2b3f3723451bbf7bd1f5b0e6"
   end
 
   depends_on "doxygen" => [:build, :optional]

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -4,7 +4,7 @@ class IgnitionTransport11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases/ignition-transport11-11.4.1.tar.bz2"
   sha256 "f18501cbd5c78b584b3db1960a3049d6ae416bab7f0289af64eadda13d1c5da5"
   license "Apache-2.0"
-  revision 3
+  revision 4
   version_scheme 1
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport11"

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -31,9 +31,13 @@ class IgnitionTransport11 < Formula
   depends_on "zeromq"
 
   def install
+    rpaths = [
+      rpath,
+      rpath(source: libexec/"gz/transport11", target: lib),
+    ]
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
-    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpaths.join(";")}"
 
     mkdir "build" do
       system "cmake", "..", *cmake_args
@@ -42,6 +46,10 @@ class IgnitionTransport11 < Formula
   end
 
   test do
+    # test CLI executables
+    system libexec/"gz/transport11/ign-transport-service"
+    system libexec/"gz/transport11/ign-transport-topic"
+    # build against API
     (testpath/"test.cpp").write <<-EOS
       #include <iostream>
       #include <ignition/transport.hh>


### PR DESCRIPTION
Fix rpath for `gz-physics5` and `gz-transport11`.