### PR TITLE
Fortress: fix rpath part 2

### DIFF
--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -10,9 +10,9 @@ class IgnitionGazebo6 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "002c11ac8c1f52766fa803f25a0feb7a37a6ae9789a87015e6ce9617b6cfa81d"
-    sha256 monterey: "f474d4ef4f3881b114f78084f36e78352246212febfce504060ce1b950bd8363"
-    sha256 big_sur:  "609a698024fc6ef4533f04b3ecec1d3bf873adf6d3a1202b51ab866eb885c38d"
+    sha256 ventura:  "aefc939b2c4ddf44afaf12a50fd6919f5183afadba5ff7bddda1092fbacc7ff0"
+    sha256 monterey: "13b4c04462fed433a8801bc43c450dbb54e2ee1791ac166711e6b5a677facdd2"
+    sha256 big_sur:  "d05e40ef1e23e5903fc7be9f6587fb5aae9be91ad4f63803743bd3779cb21d11"
   end
 
   depends_on "cmake" => :build

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -17,6 +17,7 @@ class IgnitionGazebo6 < Formula
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build
+  depends_on "gz-plugin2" => :test
   depends_on "ffmpeg"
   depends_on "gflags"
   depends_on "google-benchmark"
@@ -41,9 +42,15 @@ class IgnitionGazebo6 < Formula
   depends_on "sdformat12"
 
   def install
+    rpaths = [
+      rpath,
+      rpath(source: lib/"ign-gazebo-6/plugins", target: lib),
+      rpath(source: lib/"ign-gazebo-6/plugins/gui", target: lib),
+      rpath(source: lib/"ign-gazebo-6/plugins/gui/GzSim", target: lib),
+    ]
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
-    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpaths.join(";")}"
 
     mkdir "build" do
       system "cmake", "..", *cmake_args
@@ -52,10 +59,28 @@ class IgnitionGazebo6 < Formula
   end
 
   test do
+    # test some plugins in subfolders
+    plugin_info = lambda { |p|
+      # Use gz-plugin --info command to check plugin linking
+      cmd = Formula["gz-plugin2"].opt_libexec/"gz/plugin2/gz-plugin"
+      args = ["--info", "--plugin"] << p
+      # print command and check return code
+      system cmd, *args
+      # check that library was loaded properly
+      _, stderr = system_command(cmd, args: args)
+      error_string = "Error while loading the library"
+      assert stderr.exclude?(error_string), error_string
+    }
+    %w[altimeter log physics sensors].each do |system|
+      plugin_info.call lib/"ign-gazebo-6/plugins/libignition-gazebo-#{system}-system.dylib"
+    end
+    ["libAlignTool", "libEntityContextMenuPlugin", "libGzSceneManager", "IgnGazebo/libEntityContextMenu"].each do |p|
+      plugin_info.call lib/"ign-gazebo-6/plugins/gui/#{p}.dylib"
+    end
     ENV["IGN_CONFIG_PATH"] = "#{opt_share}/ignition"
-    system Formula["ruby"].opt_bin/"ruby",
-           Formula["ignition-tools"].opt_bin/"ign",
+    system Formula["ignition-tools"].opt_bin/"ign",
            "gazebo", "-s", "--iterations", "5", "-r", "-v", "4"
+    # build against API
     (testpath/"test.cpp").write <<-EOS
     #include <cstdint>
     #include <ignition/gazebo/Entity.hh>

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -4,7 +4,7 @@ class IgnitionGazebo6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gazebo/releases/ignition-gazebo6-6.15.0.tar.bz2"
   sha256 "897c8823054d504272dd8312509fb09baa6f042a131d348de2020ebd80bbf780"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo6"
 

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -4,7 +4,7 @@ class IgnitionGui6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gui/releases/ignition-gui6-6.8.0.tar.bz2"
   sha256 "dd4f26100f4d1343f068ba36f2b8394a0cddb337efde7b4a21c1b0f66ce496c9"
   license "Apache-2.0"
-  revision 11
+  revision 12
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui6"
 

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -10,9 +10,9 @@ class IgnitionGui6 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "12ad1a1ea711a87226d9ff85a8c93a8331e7168cbf638fdd05eca528bf3ac49a"
-    sha256 monterey: "20443a073acc7141680e277f1e0ace5fbcb507be782f53161c6aa5f1415d0e67"
-    sha256 big_sur:  "9b36c3972a32ef7eaca19ef7106283f8cc39ca33f67a59b9d649e3ad4ef7a8d2"
+    sha256 ventura:  "4577cc5c96570b80db04beefe8484c4a446fe653162a3c48bb3c8c0331d9bc67"
+    sha256 monterey: "ee75c69ff8022215f596b03ec29927e7d53f4f9b954fff5592c3a55733c51e5e"
+    sha256 big_sur:  "afa9ddf3774cece1b00c3777d2728d3ca2e50182012107dc08a1910118813508"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/ignition-launch5.rb
+++ b/Formula/ignition-launch5.rb
@@ -10,9 +10,9 @@ class IgnitionLaunch5 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "03009f4bbecb8ca07df777c329fa4f1fad915ec27f28df82698941641d4a81ad"
-    sha256 monterey: "3579468be3c929957bd0b250a490e5eaebb9780ada8d20e90943c29759d1caa7"
-    sha256 big_sur:  "6b72248e6f4e0d8a7400a7455d16a09bf9eb3a8b9d38f0a2a32f0a4f40df9313"
+    sha256 ventura:  "35834d227840da92b6c84ebb125a5b8c73743c6ad629db99e32e45e1d147451e"
+    sha256 monterey: "b7996798a122b9431d6689ed3e4c6ecf8d56d11f136ab007598625e304725d3b"
+    sha256 big_sur:  "6e918d27795a6b33ba9b5035bf1c5393b722c7606820774ed4f0e8b7f6de1069"
   end
 
   depends_on "cmake" => :build

--- a/Formula/ignition-launch5.rb
+++ b/Formula/ignition-launch5.rb
@@ -4,7 +4,7 @@ class IgnitionLaunch5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-launch/releases/ignition-launch5-5.3.0.tar.bz2"
   sha256 "84d356b9c85609da1bb7feda2f90ae6d1a1fd2d6713b284799d5605de42e2613"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "ign-launch5"
 


### PR DESCRIPTION
Fix rpath for binaries in remaining Fortress packages and add a patch for gz-launch5. Note this fixes rpath issues but that `gz sim -g` does not work as the patch from https://github.com/gazebosim/gz-sim/pull/1225 would need to be backported.