### PR TITLE
Fix linting problems with github tarball refs

### DIFF
--- a/Formula/bullet@2.87.rb
+++ b/Formula/bullet@2.87.rb
@@ -1,7 +1,7 @@
 class BulletAT287 < Formula
   desc "Physics SDK"
   homepage "https://bulletphysics.org/"
-  url "https://github.com/bulletphysics/bullet3/archive/2.87.tar.gz"
+  url "https://github.com/bulletphysics/bullet3/archive/refs/tags/2.87.tar.gz"
   sha256 "438c151c48840fe3f902ec260d9496f8beb26dba4b17769a4a53212903935f95"
   license "Zlib"
   head "https://github.com/bulletphysics/bullet3.git"

--- a/Formula/chrono-engine.rb
+++ b/Formula/chrono-engine.rb
@@ -1,7 +1,7 @@
 class ChronoEngine < Formula
   desc "Chrono physics engine"
   homepage "http://www.projectchrono.org"
-  url "https://github.com/projectchrono/chrono/archive/7.0.3.tar.gz"
+  url "https://github.com/projectchrono/chrono/archive/refs/tags/7.0.3.tar.gz"
   sha256 "335923458fc75024baf2458c94d9d227da6ee91f989f5603b2d13498e2db0a81"
   license "BSD-3-Clause"
 

--- a/Formula/simbody.rb
+++ b/Formula/simbody.rb
@@ -1,7 +1,7 @@
 class Simbody < Formula
   desc "Multibody physics API"
   homepage "https://simtk.org/home/simbody"
-  url "https://github.com/simbody/simbody/archive/Simbody-3.7.tar.gz"
+  url "https://github.com/simbody/simbody/archive/refs/tags/Simbody-3.7.tar.gz"
   sha256 "d371a92d440991400cb8e8e2473277a75307abb916e5aabc14194bea841b804a"
   license "Apache-2.0"
 

--- a/Formula/sofa.rb
+++ b/Formula/sofa.rb
@@ -1,7 +1,7 @@
 class Sofa < Formula
   desc "Physics framework sofa"
   homepage "https://www.sofa-framework.org"
-  url "https://github.com/sofa-framework/sofa/archive/v19.12.00.tar.gz"
+  url "https://github.com/sofa-framework/sofa/archive/refs/tags/v19.12.00.tar.gz"
   sha256 "830f6cfe237feea545f2afb85d8797330db6712ce4581886d83e9c47372285ba"
   license "LGPL-2.1"
 

--- a/Formula/tbb@2020_u3.rb
+++ b/Formula/tbb@2020_u3.rb
@@ -1,7 +1,7 @@
 class TbbAT2020U3 < Formula
   desc "Rich and complete approach to parallelism in C++"
   homepage "https://github.com/oneapi-src/oneTBB"
-  url "https://github.com/intel/tbb/archive/v2020.3.tar.gz"
+  url "https://github.com/intel/tbb/archive/refs/tags/v2020.3.tar.gz"
   version "2020_U3"
   sha256 "ebc4f6aa47972daed1f7bf71d100ae5bf6931c2e3144cf299c8cc7d041dca2f3"
   license "Apache-2.0"

--- a/Formula/tinyxml2@6.2.0.rb
+++ b/Formula/tinyxml2@6.2.0.rb
@@ -1,7 +1,7 @@
 class Tinyxml2AT620 < Formula
   desc "Improved tinyxml (in memory efficiency and size)"
   homepage "http://grinninglizard.com/tinyxml2"
-  url "https://github.com/leethomason/tinyxml2/archive/6.2.0.tar.gz"
+  url "https://github.com/leethomason/tinyxml2/archive/refs/tags/6.2.0.tar.gz"
   sha256 "cdf0c2179ae7a7931dba52463741cf59024198bbf9673bf08415bcb46344110f"
   license "Zlib"
   head "https://github.com/leethomason/tinyxml2.git"


### PR DESCRIPTION
Seems like brew has changed the linting to avoid github archive paths not using refs/tags, see https://github.com/osrf/homebrew-simulation/actions/runs/6655393821/job/18085564469?pr=2480.

Let's try to make it happy.

