### PR TITLE
gz-sim*: remove unneeded references to ffmpeg@4

### DIFF
--- a/Formula/gz-sim7.rb
+++ b/Formula/gz-sim7.rb
@@ -130,7 +130,6 @@ class GzSim7 < Formula
     #                "-o", "test"
     # system "./test"
     # test building with cmake
-    ENV.append_path "CMAKE_PREFIX_PATH", Formula["ffmpeg@4"].opt_prefix
     ENV.append_path "CMAKE_PREFIX_PATH", Formula["qt@5"].opt_prefix
     mkdir "build" do
       system "cmake", ".."

--- a/Formula/gz-sim8.rb
+++ b/Formula/gz-sim8.rb
@@ -130,7 +130,6 @@ class GzSim8 < Formula
     #                "-o", "test"
     # system "./test"
     # test building with cmake
-    ENV.append_path "CMAKE_PREFIX_PATH", Formula["ffmpeg@4"].opt_prefix
     ENV.append_path "CMAKE_PREFIX_PATH", Formula["qt@5"].opt_prefix
     mkdir "build" do
       system "cmake", ".."

--- a/Formula/gz-sim9.rb
+++ b/Formula/gz-sim9.rb
@@ -123,7 +123,6 @@ class GzSim9 < Formula
     #                "-o", "test"
     # system "./test"
     # test building with cmake
-    ENV.append_path "CMAKE_PREFIX_PATH", Formula["ffmpeg@4"].opt_prefix
     ENV.append_path "CMAKE_PREFIX_PATH", Formula["qt@5"].opt_prefix
     mkdir "build" do
       system "cmake", ".."

--- a/Formula/ignition-gazebo3.rb
+++ b/Formula/ignition-gazebo3.rb
@@ -113,7 +113,6 @@ class IgnitionGazebo3 < Formula
     #                "-o", "test"
     # system "./test"
     # test building with cmake
-    ENV.append_path "CMAKE_PREFIX_PATH", Formula["ffmpeg@4"].opt_prefix
     ENV.append_path "CMAKE_PREFIX_PATH", Formula["qt@5"].opt_prefix
     mkdir "build" do
       system "cmake", ".."

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -131,7 +131,6 @@ class IgnitionGazebo6 < Formula
     #                "-o", "test"
     # system "./test"
     # test building with cmake
-    ENV.append_path "CMAKE_PREFIX_PATH", Formula["ffmpeg@4"].opt_prefix
     ENV.append_path "CMAKE_PREFIX_PATH", Formula["qt@5"].opt_prefix
     mkdir "build" do
       system "cmake", ".."


### PR DESCRIPTION
These lines could have been removed in https://github.com/osrf/homebrew-simulation/pull/1833 and https://github.com/osrf/homebrew-simulation/pull/1840 when the dependencies on `ffmpeg@4` were reverted.