### PR TITLE
Remove broken bottles for urdfdom 4.0.0

### DIFF
--- a/Formula/dartsim@6.10.0.rb
+++ b/Formula/dartsim@6.10.0.rb
@@ -6,14 +6,7 @@ class DartsimAT6100 < Formula
   version "6.10.0~20211005~d2b6ee08a60d0dbf71b0f008cd8fed1f611f6e24"
   sha256 "372af181024452418eec95f8a9cd723ceb1ada979208add66c9a4330b9c0fa32"
   license "BSD-2-Clause"
-  revision 8
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "c3f503bc10e6dd087b28f214d03fd4c891057e72ea63075a46ded2e2ded4c979"
-    sha256 monterey: "f34d5dd73ebd398d29fee127aefffa5393967a87b487e538ba6222d83e9f20b6"
-    sha256 big_sur:  "7639a0c81e5b02e4b2a12563c56503ed8a3b0f0482f45d5c02887a9e1a3282d3"
-  end
+  revision 9
 
   keg_only "open robotics fork of dart HEAD + custom changes"
 

--- a/Formula/gz-physics6.rb
+++ b/Formula/gz-physics6.rb
@@ -26,6 +26,7 @@ class GzPhysics6 < Formula
   depends_on macos: :mojave # c++17
   depends_on "pkg-config"
   depends_on "sdformat13"
+  depends_on "urdfdom"
 
   def install
     rpaths = [

--- a/Formula/gz-physics6.rb
+++ b/Formula/gz-physics6.rb
@@ -4,14 +4,9 @@ class GzPhysics6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-6.5.1.tar.bz2"
   sha256 "6556a066f88e48eb3a5d9219245b988e02778ce8c1f90cceb9359e87cbced828"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "d1fc0671acdbd7336199290f2c5c0f39b020b0bc976ffad3c513f708674d1e46"
-    sha256 monterey: "b306397e44824117c1d0f1323cf1324a67ffacad20f03c9ad1c844a178a2c4ed"
-  end
 
   depends_on "cmake" => [:build, :test]
 

--- a/Formula/gz-physics7.rb
+++ b/Formula/gz-physics7.rb
@@ -26,6 +26,7 @@ class GzPhysics7 < Formula
   depends_on macos: :mojave # c++17
   depends_on "pkg-config"
   depends_on "sdformat14"
+  depends_on "urdfdom"
 
   def install
     rpaths = [

--- a/Formula/gz-physics7.rb
+++ b/Formula/gz-physics7.rb
@@ -4,14 +4,9 @@ class GzPhysics7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-7.0.0.tar.bz2"
   sha256 "3bfd59d7d49e3ae9f0ef5737ba6b23919700ce93e15f20d1eff3281914e58f78"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "ab0c780dd2d76ca589b9b11ed14c09469ccdcec39d63da36b7a711d0f5a5c4f0"
-    sha256 monterey: "a9e73543ce9e9d5dc1f4bb1cff6df5823a14ecbd443c9eb3e06929adf636ff6c"
-  end
 
   depends_on "cmake" => [:build, :test]
 

--- a/Formula/gz-physics8.rb
+++ b/Formula/gz-physics8.rb
@@ -20,6 +20,7 @@ class GzPhysics8 < Formula
   depends_on macos: :mojave # c++17
   depends_on "pkg-config"
   depends_on "sdformat15"
+  depends_on "urdfdom"
 
   def install
     rpaths = [

--- a/Formula/ignition-physics2.rb
+++ b/Formula/ignition-physics2.rb
@@ -4,16 +4,9 @@ class IgnitionPhysics2 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics2-2.6.1.tar.bz2"
   sha256 "036c2b4effec9eefcdc94ac4ae0c6caec15d802db2e20665d76fcf69b7934643"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics2"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "8d73864060afb088d94d734ab9962b98dbdc8b9d2a625bc140150e89adec6eea"
-    sha256 cellar: :any, monterey: "12564bdb4d62912093a42e81aec8e4c0172e4bab0d1cd9baa701dc43c12fa5f4"
-    sha256 cellar: :any, big_sur:  "9a868329c347e206992e28a3a590f83c17da673605199727746a515a189c11e5"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-physics2.rb
+++ b/Formula/ignition-physics2.rb
@@ -29,6 +29,7 @@ class IgnitionPhysics2 < Formula
   depends_on macos: :mojave # c++17
   depends_on "pkg-config"
   depends_on "sdformat9"
+  depends_on "urdfdom"
 
   def install
     cmake_args = std_cmake_args

--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -4,16 +4,9 @@ class IgnitionPhysics5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics5-5.3.2.tar.bz2"
   sha256 "4262512fbb6952712234c5cbeed69cdabca338931bb6c587a1ef7d487a5f262b"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "ign-physics5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "ac9d10fedc61d2b9db49969c19e07c0687b4607d1916bab49be57a7a347e7a57"
-    sha256 cellar: :any, monterey: "2365a03533b6c0d30394f55b9d3686adb8b04df50de2186688b2fc41b57f18da"
-    sha256 cellar: :any, big_sur:  "4bb15f5e986a956abf3a9cc4a667eea5c01070a505c8a02028a62afb2a01d007"
-  end
 
   depends_on "cmake" => :build
 

--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -30,6 +30,7 @@ class IgnitionPhysics5 < Formula
   depends_on macos: :mojave # c++17
   depends_on "pkg-config"
   depends_on "sdformat12"
+  depends_on "urdfdom"
 
   patch do
     # Fix for unregistering dartsim collision detector

--- a/Formula/sdformat12.rb
+++ b/Formula/sdformat12.rb
@@ -4,15 +4,9 @@ class Sdformat12 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-12.7.2.tar.bz2"
   sha256 "f199f5ad8e4390024c0a2a7c619bee12c662b81f6758b2b50877397ad4f743c0"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/sdformat.git", branch: "sdf12"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "2922c994e95c278dcb6416bf42a111a6e427e337115a7dd940acc1bfab1ab167"
-    sha256 monterey: "fc1a07c0f89cdc6b16da7c0667e8c123d9dbb40cae4a8b3c949ad9dd1fdeb233"
-    sha256 big_sur:  "9cb3663bd4fb928cfb827813e68ba9d7a82c90da8cdc9b0edb2615a73c6b54a4"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/sdformat13.rb
+++ b/Formula/sdformat13.rb
@@ -4,15 +4,9 @@ class Sdformat13 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-13.6.0.tar.bz2"
   sha256 "5845c9c0da66bb30b209ed8421f5b4805bf6e8863fd58a790a59f856902e67f3"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/sdformat.git", branch: "sdf13"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "1ccf65cf3a90b31bfe26eef6c08acae3037fde038e8da2f7d7a6a962416c5f40"
-    sha256 monterey: "79f5088682b11bb1266ab6eef2f9818862c94875ce76f28c89602722ac661054"
-    sha256 big_sur:  "20245a996496b38662582fd68d65927897c0afb0d32ab2079cce81d7dc1bdf3c"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/sdformat14.rb
+++ b/Formula/sdformat14.rb
@@ -4,14 +4,9 @@ class Sdformat14 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-14.0.0.tar.bz2"
   sha256 "88c0858a23ef4a4f36a9b3162e4b438878ae8670608af73d1797d67a3aaa4246"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/sdformat.git", branch: "main"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "6397f0b43e3315cab30f25d3d7450f7b5d1520019800ec7188a9c33ee8ab14df"
-    sha256 monterey: "139e69798eb6711d3ad6596fc2568844e71b6dc8f5299d56a348093b969a8df8"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/sdformat4.rb
+++ b/Formula/sdformat4.rb
@@ -4,16 +4,9 @@ class Sdformat4 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-4.4.0.tar.bz2"
   sha256 "4424a984f69d3333f087e7aae1d8fa5aec61ad52e09be39e2f5e2cb69ade1527"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   head "https://github.com/osrf/sdformat.git", branch: "sdf4", using: :git
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 mojave:      "f4926ac28179ed217c034f7b69a42176b7a8290be7dd91bb87fcd5fe96f64daf"
-    sha256 high_sierra: "b727234177c477d3de90413ac7880ecca91e0c73acf69fcf6c2a2d3b099806b1"
-    sha256 sierra:      "d0b28be274c293fd1c5395fcae0be37f43f6c16ef129a171d39a020564e6b7f9"
-  end
 
   disable! date: "2023-02-28", because: "is past end-of-life date"
   deprecate! date: "2019-09-01", because: "is past end-of-life date"

--- a/Formula/sdformat9.rb
+++ b/Formula/sdformat9.rb
@@ -4,15 +4,9 @@ class Sdformat9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-9.10.0.tar.bz2"
   sha256 "5660d4d1547f4e4039e3ad64830b29d2ebfc6aab2aa86ed86d8d8305ee4eb3c2"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/sdformat.git", branch: "sdf9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "c41c3b209374a08b22943b547f747b73cca91832b2af27b5a470886873624b0c"
-    sha256 monterey: "d756a1a7e0f5b838ce2fc50f494dda5e149d95878378caec1d7ccb5f845451ee"
-    sha256 big_sur:  "ee28c636471a819a3c8896a25ac0e8b8b45b80aa798fe68876ac96363aa65c7a"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]


### PR DESCRIPTION
Part of #2505.

I added a missing dependency on `urdfdom` to the `gz-physics*` formulae in https://github.com/osrf/homebrew-simulation/commit/607c935005986e447f08e41709b08adeb054bb39 and then used the script from https://github.com/osrf/homebrew-simulation#to-disable-broken-bottles to remove the broken bottles.

This should be merged when https://github.com/Homebrew/homebrew-core/pull/158963 is merged.