### PR TITLE
sdformat9, gazebo11: use tinyxml1

### DIFF
--- a/Formula/gazebo11.rb
+++ b/Formula/gazebo11.rb
@@ -4,7 +4,7 @@ class Gazebo11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/gazebo-11.14.0.tar.bz2"
   sha256 "7e9842c046c9e0755355b274c240a8abbf4e962be7ce7b7f59194e5f4b584f45"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   head "https://github.com/osrf/gazebo.git", branch: "gazebo11"
 
@@ -32,7 +32,7 @@ class Gazebo11 < Formula
   depends_on "sdformat9"
   depends_on "simbody"
   depends_on "tbb"
-  depends_on "tinyxml"
+  depends_on "tinyxml1"
   depends_on "tinyxml2"
   depends_on "urdfdom"
   depends_on "zeromq" => :linked

--- a/Formula/gazebo11.rb
+++ b/Formula/gazebo11.rb
@@ -8,6 +8,12 @@ class Gazebo11 < Formula
 
   head "https://github.com/osrf/gazebo.git", branch: "gazebo11"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 ventura:  "ae3563117019c4262f883612ed5d721609ff8803a6419abd1c21e41a142285ed"
+    sha256 monterey: "5ea07db618a5f324c07a524c6accd1cd3b79b2ee924647b9cdd8b2eb0b718bc0"
+  end
+
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
 

--- a/Formula/ignition-citadel.rb
+++ b/Formula/ignition-citadel.rb
@@ -6,7 +6,7 @@ class IgnitionCitadel < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-citadel/releases/ignition-citadel-1.0.2.tar.bz2"
   sha256 "2b99e7476093e78841c63d4ec348c6cf7c9d650a2e5787011723142c9f917659"
   license "Apache-2.0"
-  revision 7
+  revision 8
   version_scheme 1
 
   head "https://github.com/gazebosim/gz-citadel.git", branch: "main"

--- a/Formula/ignition-citadel.rb
+++ b/Formula/ignition-citadel.rb
@@ -13,9 +13,8 @@ class IgnitionCitadel < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "9d36689233cee3bb6016793002ab5fa0574a986d3787ef46c8c2d6c76d7b53a7"
-    sha256 cellar: :any, monterey: "39c496abc944d0ecf30f10489095d0beafa7cb794e4f88d2436c2c4fccd00deb"
-    sha256 cellar: :any, big_sur:  "dfc3b855fc80378130a975dc3a05783ed5efd4e1e8a89a14cbec9d970182e544"
+    sha256 cellar: :any, ventura:  "6825681c5f253c09f7ed54e17eb2fe67eb987bf64deec82886abad2df0dbec16"
+    sha256 cellar: :any, monterey: "7b39ced8c09bee8c7defa80c7265f8af300a79c83f838beac48f7adc0e8589d4"
   end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"

--- a/Formula/ignition-gazebo3.rb
+++ b/Formula/ignition-gazebo3.rb
@@ -4,7 +4,7 @@ class IgnitionGazebo3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gazebo/releases/ignition-gazebo3-3.15.0.tar.bz2"
   sha256 "009a107afc4517caea609ab0b24eae65282faab808bda9aa0a22e600bc2b0088"
   license "Apache-2.0"
-  revision 16
+  revision 17
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo3"
 

--- a/Formula/ignition-gazebo3.rb
+++ b/Formula/ignition-gazebo3.rb
@@ -10,8 +10,8 @@ class IgnitionGazebo3 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "f4147abc5bbdb7fef330d029f847c28997a69b41a494b4b7e1e4ba798a2b6221"
-    sha256 monterey: "00c41fbc8f2968b1dc6937c38e6fb25f5cb4b5ed098b023aa5172fa69bd30c3e"
+    sha256 ventura:  "d1d7e297e419c5de028f84c0a0e28277f8707b8ab569cd4406de72862fe292dd"
+    sha256 monterey: "843054223aa65ca4ffd93b26c28e5a4d6a1a0dc1396b1e8b0e8f8a5404c2b894"
   end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"

--- a/Formula/ignition-launch2.rb
+++ b/Formula/ignition-launch2.rb
@@ -4,7 +4,7 @@ class IgnitionLaunch2 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-launch/releases/ignition-launch2-2.3.0.tar.bz2"
   sha256 "6c341967a71d19a0a62fb5bf4ef0e2a40cd55096904b765738f981860055cd3d"
   license "Apache-2.0"
-  revision 17
+  revision 18
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "ign-launch2"
 

--- a/Formula/ignition-launch2.rb
+++ b/Formula/ignition-launch2.rb
@@ -10,8 +10,8 @@ class IgnitionLaunch2 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "e567139e1b4cd3d7106879c31b2a034afc4011269429e94d8a7b7be030032e33"
-    sha256 monterey: "85b700a0038b6a5b6ee6f27e2cdfb0d62b94e0f30aad754676f675830454906b"
+    sha256 ventura:  "a7b90c2bdbd4534bf4bdcdbd0fbac791f5ccc813fe6a9926cfa3e9337ff8c2bf"
+    sha256 monterey: "fb5493553c38d9074f6f6bbc2f082c5017035ac46b2d2576237a01f12eb66564"
   end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"

--- a/Formula/ignition-physics2.rb
+++ b/Formula/ignition-physics2.rb
@@ -10,8 +10,8 @@ class IgnitionPhysics2 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "6661b85039d0885b0eb41fbf6d4dbaddbb5f5c985018040aa0019ce19a72eb74"
-    sha256 cellar: :any, monterey: "5341b000c6ae41a7bfe281a6251127de06df0cbd1bf6c4642a764dc042815b7e"
+    sha256 cellar: :any, ventura:  "8a21efb2a45f1947e7ecf35f7e789452c5247d51843bafc6b5205cc7b1ca3cbf"
+    sha256 cellar: :any, monterey: "dbb879aa6e80c5111a905d0353344e005aa05764164a87581bd0af09e1451a78"
   end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"

--- a/Formula/ignition-physics2.rb
+++ b/Formula/ignition-physics2.rb
@@ -4,6 +4,7 @@ class IgnitionPhysics2 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics2-2.6.2.tar.bz2"
   sha256 "4aa0dcd1a254da63f55a93d2cc928a5ff517f19ac1603c0fb5f810dd29c70e1d"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics2"
 

--- a/Formula/ignition-sensors3.rb
+++ b/Formula/ignition-sensors3.rb
@@ -4,7 +4,7 @@ class IgnitionSensors3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-sensors/releases/ignition-sensors3-3.5.0.tar.bz2"
   sha256 "904297a8deea7f3bff79a4a1fa24aee9c208a72013e29147c3087ca07fc41788"
   license "Apache-2.0"
-  revision 16
+  revision 17
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors3"
 

--- a/Formula/ignition-sensors3.rb
+++ b/Formula/ignition-sensors3.rb
@@ -10,8 +10,8 @@ class IgnitionSensors3 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "2f9e1a20c3daa18126ade675da3da1a872f5f799c8c3f3b11fd267b8ae06b725"
-    sha256 monterey: "96edef5414f2fbe3e147a3e21fcc57d393f3ac7f20ef4fbdaa89a1c01d5cf906"
+    sha256 ventura:  "22ebbeb4a1bc7de885489033241b890e370094323c3f9f51dedf0e534635695b"
+    sha256 monterey: "c241177714c4b2b5dbf1458eef54cbd814cc8b2df6d1cfe24a9d0c8ec4a1831d"
   end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"

--- a/Formula/sdformat9.rb
+++ b/Formula/sdformat9.rb
@@ -4,6 +4,7 @@ class Sdformat9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-9.10.1.tar.bz2"
   sha256 "0b6af9955a94a22b077eb915f2b61b35f55963c12d0f1aecb5fbe5b51347a50d"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/sdformat.git", branch: "sdf9"
 
@@ -20,7 +21,7 @@ class Sdformat9 < Formula
   depends_on "ignition-math6"
   depends_on "ignition-tools"
   depends_on macos: :mojave # c++17
-  depends_on "tinyxml"
+  depends_on "tinyxml1"
   depends_on "urdfdom"
 
   def install

--- a/Formula/sdformat9.rb
+++ b/Formula/sdformat9.rb
@@ -10,8 +10,8 @@ class Sdformat9 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "b18bfdf2040a3a5f443d69f5700ba9cdbede7665e2dac4b69b27dbcef5cda3e5"
-    sha256 monterey: "5539ec2b47bb260af07920e22c0fd506e9f9f8527b8609b200bddfcac14c4ceb"
+    sha256 ventura:  "ac0f11dbdb6bfd75df7aa11b13d014bb2624febd625de524625f250198baa0b4"
+    sha256 monterey: "0d72b95fa548878ccb2272c1bf793e65a274af39ce0de5fb41c4b8a5a647b50d"
   end
 
   depends_on "cmake" => [:build, :test]


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/2503 and #2505. Depend on a `brew extract`ed formula instead of `homebrew/core/tinyxml` in preparation for the removal of `tinyxml` from homebrew-core.