### PR TITLE
gz-math6: use python@3.12, fix bindings install

### DIFF
--- a/Formula/ignition-math6.rb
+++ b/Formula/ignition-math6.rb
@@ -18,7 +18,7 @@ class IgnitionMath6 < Formula
   depends_on "pybind11" => :build
   depends_on "eigen"
   depends_on "ignition-cmake2"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "ruby"
 
   def install
@@ -31,6 +31,9 @@ class IgnitionMath6 < Formula
       system "cmake", "..", *cmake_args
       system "make", "install"
     end
+
+    (lib/"python3.12/site-packages").install Dir[lib/"python/*"]
+    rmdir prefix/"lib/python"
   end
 
   test do
@@ -67,5 +70,7 @@ class IgnitionMath6 < Formula
     # check for Xcode frameworks in bottle
     cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
     system cmd_not_grep_xcode
+    # check python import
+    system Formula["python@3.12"].opt_bin/"python3.12", "-c", "import ignition.math"
   end
 end

--- a/Formula/ignition-math6.rb
+++ b/Formula/ignition-math6.rb
@@ -4,6 +4,7 @@ class IgnitionMath6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-math/releases/ignition-math6-6.15.1.tar.bz2"
   sha256 "a9e96a4e28d7d92d4d054cdae7cef28f1d8397b72433398bfc68855956531170"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-math.git", branch: "ign-math6"
 


### PR DESCRIPTION
Part of https://github.com/gazebosim/gz-sim/issues/2249. Switch to python@3.12 since that version is used by `gdal` and is preferred by cmake `find_package` calls over 3.11.