### PR TITLE
Ionic: add python_cmake_arg method

### DIFF
--- a/Formula/gz-math8.rb
+++ b/Formula/gz-math8.rb
@@ -16,10 +16,15 @@ class GzMath8 < Formula
   depends_on "python@3.11"
   depends_on "ruby"
 
+  def python_cmake_arg
+    "-DPython3_EXECUTABLE=#{which("python3")}"
+  end
+
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    cmake_args << python_cmake_arg
 
     # Use build folder
     mkdir "build" do

--- a/Formula/gz-msgs11.rb
+++ b/Formula/gz-msgs11.rb
@@ -17,10 +17,15 @@ class GzMsgs11 < Formula
   depends_on "python@3.11"
   depends_on "tinyxml2"
 
+  def python_cmake_arg
+    "-DPython3_EXECUTABLE=#{which("python3")}"
+  end
+
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    cmake_args << python_cmake_arg
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/gz-sim9.rb
+++ b/Formula/gz-sim9.rb
@@ -32,6 +32,10 @@ class GzSim9 < Formula
   depends_on "ruby"
   depends_on "sdformat15"
 
+  def python_cmake_arg
+    "-DPython3_EXECUTABLE=#{which("python3")}"
+  end
+
   def install
     rpaths = [
       rpath,
@@ -42,6 +46,7 @@ class GzSim9 < Formula
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpaths.join(";")}"
+    cmake_args << python_cmake_arg
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/gz-sim9.rb
+++ b/Formula/gz-sim9.rb
@@ -34,9 +34,9 @@ class GzSim9 < Formula
   def install
     rpaths = [
       rpath,
-      rpath(source: lib/"gz-sim-8/plugins", target: lib),
-      rpath(source: lib/"gz-sim-8/plugins/gui", target: lib),
-      rpath(source: lib/"gz-sim-8/plugins/gui/GzSim", target: lib),
+      rpath(source: lib/"gz-sim-9/plugins", target: lib),
+      rpath(source: lib/"gz-sim-9/plugins/gui", target: lib),
+      rpath(source: lib/"gz-sim-9/plugins/gui/GzSim", target: lib),
     ]
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
@@ -62,10 +62,10 @@ class GzSim9 < Formula
       assert stderr.exclude?(error_string), error_string
     }
     %w[altimeter log physics sensors].each do |system|
-      plugin_info.call lib/"gz-sim-8/plugins/libgz-sim-#{system}-system.dylib"
+      plugin_info.call lib/"gz-sim-9/plugins/libgz-sim-#{system}-system.dylib"
     end
     ["libAlignTool", "libEntityContextMenuPlugin", "libGzSceneManager", "GzSim/libEntityContextMenu"].each do |p|
-      plugin_info.call lib/"gz-sim-8/plugins/gui/#{p}.dylib"
+      plugin_info.call lib/"gz-sim-9/plugins/gui/#{p}.dylib"
     end
     # test gz sim CLI tool
     ENV["GZ_CONFIG_PATH"] = "#{opt_share}/gz"

--- a/Formula/gz-sim9.rb
+++ b/Formula/gz-sim9.rb
@@ -28,6 +28,7 @@ class GzSim9 < Formula
   depends_on macos: :mojave # c++17
   depends_on "pkg-config"
   depends_on "protobuf"
+  depends_on "python@3.11"
   depends_on "ruby"
   depends_on "sdformat15"
 
@@ -46,6 +47,9 @@ class GzSim9 < Formula
       system "cmake", "..", *cmake_args
       system "make", "install"
     end
+
+    (lib/"python3.11/site-packages").install Dir[lib/"python/*"]
+    rmdir prefix/"lib/python"
   end
 
   test do
@@ -132,5 +136,7 @@ class GzSim9 < Formula
     # check for Xcode frameworks in bottle
     cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
     system cmd_not_grep_xcode
+    # check python import
+    system Formula["python@3.11"].opt_bin/"python3.11", "-c", "import gz.sim9"
   end
 end

--- a/Formula/gz-transport14.rb
+++ b/Formula/gz-transport14.rb
@@ -23,6 +23,10 @@ class GzTransport14 < Formula
   depends_on "python@3.11"
   depends_on "zeromq"
 
+  def python_cmake_arg
+    "-DPython3_EXECUTABLE=#{which("python3")}"
+  end
+
   def install
     rpaths = [
       rpath,
@@ -31,6 +35,7 @@ class GzTransport14 < Formula
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpaths.join(";")}"
+    cmake_args << python_cmake_arg
 
     # Use build folder
     mkdir "build" do

--- a/Formula/sdformat15.rb
+++ b/Formula/sdformat15.rb
@@ -21,10 +21,15 @@ class Sdformat15 < Formula
   depends_on "tinyxml2"
   depends_on "urdfdom"
 
+  def python_cmake_arg
+    "-DPython3_EXECUTABLE=#{which("python3")}"
+  end
+
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    cmake_args << python_cmake_arg
 
     mkdir "build" do
       system "cmake", "..", *cmake_args


### PR DESCRIPTION
Used by macOS CI. Part of https://github.com/gazebosim/gz-sim/issues/2249.

This includes two improvements to the `gz-sim9` formula and the addition of a `python_cmake_arg` method to all Ionic packages that install python bindings.

This can be merged without rebuilding any bottles.