### PR TITLE
Specify python3 include and library paths

### DIFF
--- a/Formula/gz-math7.rb
+++ b/Formula/gz-math7.rb
@@ -23,15 +23,22 @@ class GzMath7 < Formula
   depends_on "python@3.11"
   depends_on "ruby"
 
-  def python_cmake_arg
-    "-DPython3_EXECUTABLE=#{which("python3")}"
+  def python_cmake_args
+    python_prefix = Formula["python@3.11"].opt_prefix
+    return [
+      "-DPython3_EXECUTABLE=#{python_prefix}/bin/python3",
+      "-DPython3_INCLUDE_DIR=#{python_prefix}/Frameworks/Python.framework/" \
+          "Versions/3.11/include/python3.11",
+      "-DPython3_LIBRARY=#{python_prefix}/Frameworks/Python.framework/" \
+          "Versions/3.11/lib/libpython3.11.dylib",
+    ]
   end
 
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
-    cmake_args << python_cmake_arg
+    cmake_args += python_cmake_args
 
     # Use build folder
     mkdir "build" do

--- a/Formula/gz-math8.rb
+++ b/Formula/gz-math8.rb
@@ -16,15 +16,22 @@ class GzMath8 < Formula
   depends_on "python@3.11"
   depends_on "ruby"
 
-  def python_cmake_arg
-    "-DPython3_EXECUTABLE=#{which("python3")}"
+  def python_cmake_args
+    python_prefix = Formula["python@3.11"].opt_prefix
+    return [
+      "-DPython3_EXECUTABLE=#{python_prefix}/bin/python3",
+      "-DPython3_INCLUDE_DIR=#{python_prefix}/Frameworks/Python.framework/" \
+          "Versions/3.11/include/python3.11",
+      "-DPython3_LIBRARY=#{python_prefix}/Frameworks/Python.framework/" \
+          "Versions/3.11/lib/libpython3.11.dylib",
+    ]
   end
 
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
-    cmake_args << python_cmake_arg
+    cmake_args += python_cmake_args
 
     # Use build folder
     mkdir "build" do

--- a/Formula/gz-msgs10.rb
+++ b/Formula/gz-msgs10.rb
@@ -24,15 +24,22 @@ class GzMsgs10 < Formula
   depends_on "python@3.11"
   depends_on "tinyxml2"
 
-  def python_cmake_arg
-    "-DPython3_EXECUTABLE=#{which("python3")}"
+  def python_cmake_args
+    python_prefix = Formula["python@3.11"].opt_prefix
+    return [
+      "-DPython3_EXECUTABLE=#{python_prefix}/bin/python3",
+      "-DPython3_INCLUDE_DIR=#{python_prefix}/Frameworks/Python.framework/" \
+          "Versions/3.11/include/python3.11",
+      "-DPython3_LIBRARY=#{python_prefix}/Frameworks/Python.framework/" \
+          "Versions/3.11/lib/libpython3.11.dylib",
+    ]
   end
 
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
-    cmake_args << python_cmake_arg
+    cmake_args += python_cmake_args
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/gz-msgs11.rb
+++ b/Formula/gz-msgs11.rb
@@ -17,15 +17,22 @@ class GzMsgs11 < Formula
   depends_on "python@3.11"
   depends_on "tinyxml2"
 
-  def python_cmake_arg
-    "-DPython3_EXECUTABLE=#{which("python3")}"
+  def python_cmake_args
+    python_prefix = Formula["python@3.11"].opt_prefix
+    return [
+      "-DPython3_EXECUTABLE=#{python_prefix}/bin/python3",
+      "-DPython3_INCLUDE_DIR=#{python_prefix}/Frameworks/Python.framework/" \
+          "Versions/3.11/include/python3.11",
+      "-DPython3_LIBRARY=#{python_prefix}/Frameworks/Python.framework/" \
+          "Versions/3.11/lib/libpython3.11.dylib",
+    ]
   end
 
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
-    cmake_args << python_cmake_arg
+    cmake_args += python_cmake_args
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/gz-sim7.rb
+++ b/Formula/gz-sim7.rb
@@ -39,8 +39,15 @@ class GzSim7 < Formula
   depends_on "ruby"
   depends_on "sdformat13"
 
-  def python_cmake_arg
-    "-DPython3_EXECUTABLE=#{which("python3")}"
+  def python_cmake_args
+    python_prefix = Formula["python@3.11"].opt_prefix
+    return [
+      "-DPython3_EXECUTABLE=#{python_prefix}/bin/python3",
+      "-DPython3_INCLUDE_DIR=#{python_prefix}/Frameworks/Python.framework/" \
+          "Versions/3.11/include/python3.11",
+      "-DPython3_LIBRARY=#{python_prefix}/Frameworks/Python.framework/" \
+          "Versions/3.11/lib/libpython3.11.dylib",
+    ]
   end
 
   def install
@@ -53,7 +60,7 @@ class GzSim7 < Formula
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpaths.join(";")}"
-    cmake_args << python_cmake_arg
+    cmake_args += python_cmake_args
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/gz-sim8.rb
+++ b/Formula/gz-sim8.rb
@@ -39,8 +39,15 @@ class GzSim8 < Formula
   depends_on "ruby"
   depends_on "sdformat14"
 
-  def python_cmake_arg
-    "-DPython3_EXECUTABLE=#{which("python3")}"
+  def python_cmake_args
+    python_prefix = Formula["python@3.11"].opt_prefix
+    return [
+      "-DPython3_EXECUTABLE=#{python_prefix}/bin/python3",
+      "-DPython3_INCLUDE_DIR=#{python_prefix}/Frameworks/Python.framework/" \
+          "Versions/3.11/include/python3.11",
+      "-DPython3_LIBRARY=#{python_prefix}/Frameworks/Python.framework/" \
+          "Versions/3.11/lib/libpython3.11.dylib",
+    ]
   end
 
   def install
@@ -53,7 +60,7 @@ class GzSim8 < Formula
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpaths.join(";")}"
-    cmake_args << python_cmake_arg
+    cmake_args += python_cmake_args
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/gz-sim9.rb
+++ b/Formula/gz-sim9.rb
@@ -32,8 +32,15 @@ class GzSim9 < Formula
   depends_on "ruby"
   depends_on "sdformat15"
 
-  def python_cmake_arg
-    "-DPython3_EXECUTABLE=#{which("python3")}"
+  def python_cmake_args
+    python_prefix = Formula["python@3.11"].opt_prefix
+    return [
+      "-DPython3_EXECUTABLE=#{python_prefix}/bin/python3",
+      "-DPython3_INCLUDE_DIR=#{python_prefix}/Frameworks/Python.framework/" \
+          "Versions/3.11/include/python3.11",
+      "-DPython3_LIBRARY=#{python_prefix}/Frameworks/Python.framework/" \
+          "Versions/3.11/lib/libpython3.11.dylib",
+    ]
   end
 
   def install
@@ -46,7 +53,7 @@ class GzSim9 < Formula
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpaths.join(";")}"
-    cmake_args << python_cmake_arg
+    cmake_args += python_cmake_args
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/gz-transport13.rb
+++ b/Formula/gz-transport13.rb
@@ -30,8 +30,15 @@ class GzTransport13 < Formula
   depends_on "python@3.11"
   depends_on "zeromq"
 
-  def python_cmake_arg
-    "-DPython3_EXECUTABLE=#{which("python3")}"
+  def python_cmake_args
+    python_prefix = Formula["python@3.11"].opt_prefix
+    return [
+      "-DPython3_EXECUTABLE=#{python_prefix}/bin/python3",
+      "-DPython3_INCLUDE_DIR=#{python_prefix}/Frameworks/Python.framework/" \
+          "Versions/3.11/include/python3.11",
+      "-DPython3_LIBRARY=#{python_prefix}/Frameworks/Python.framework/" \
+          "Versions/3.11/lib/libpython3.11.dylib",
+    ]
   end
 
   def install
@@ -42,7 +49,7 @@ class GzTransport13 < Formula
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpaths.join(";")}"
-    cmake_args << python_cmake_arg
+    cmake_args += python_cmake_args
 
     # Use build folder
     mkdir "build" do

--- a/Formula/gz-transport14.rb
+++ b/Formula/gz-transport14.rb
@@ -23,8 +23,15 @@ class GzTransport14 < Formula
   depends_on "python@3.11"
   depends_on "zeromq"
 
-  def python_cmake_arg
-    "-DPython3_EXECUTABLE=#{which("python3")}"
+  def python_cmake_args
+    python_prefix = Formula["python@3.11"].opt_prefix
+    return [
+      "-DPython3_EXECUTABLE=#{python_prefix}/bin/python3",
+      "-DPython3_INCLUDE_DIR=#{python_prefix}/Frameworks/Python.framework/" \
+          "Versions/3.11/include/python3.11",
+      "-DPython3_LIBRARY=#{python_prefix}/Frameworks/Python.framework/" \
+          "Versions/3.11/lib/libpython3.11.dylib",
+    ]
   end
 
   def install
@@ -35,7 +42,7 @@ class GzTransport14 < Formula
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpaths.join(";")}"
-    cmake_args << python_cmake_arg
+    cmake_args += python_cmake_args
 
     # Use build folder
     mkdir "build" do

--- a/Formula/sdformat13.rb
+++ b/Formula/sdformat13.rb
@@ -28,15 +28,22 @@ class Sdformat13 < Formula
   depends_on "tinyxml2"
   depends_on "urdfdom"
 
-  def python_cmake_arg
-    "-DPython3_EXECUTABLE=#{which("python3")}"
+  def python_cmake_args
+    python_prefix = Formula["python@3.11"].opt_prefix
+    return [
+      "-DPython3_EXECUTABLE=#{python_prefix}/bin/python3",
+      "-DPython3_INCLUDE_DIR=#{python_prefix}/Frameworks/Python.framework/" \
+          "Versions/3.11/include/python3.11",
+      "-DPython3_LIBRARY=#{python_prefix}/Frameworks/Python.framework/" \
+          "Versions/3.11/lib/libpython3.11.dylib",
+    ]
   end
 
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
-    cmake_args << python_cmake_arg
+    cmake_args += python_cmake_args
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/sdformat14.rb
+++ b/Formula/sdformat14.rb
@@ -28,15 +28,22 @@ class Sdformat14 < Formula
   depends_on "tinyxml2"
   depends_on "urdfdom"
 
-  def python_cmake_arg
-    "-DPython3_EXECUTABLE=#{which("python3")}"
+  def python_cmake_args
+    python_prefix = Formula["python@3.11"].opt_prefix
+    return [
+      "-DPython3_EXECUTABLE=#{python_prefix}/bin/python3",
+      "-DPython3_INCLUDE_DIR=#{python_prefix}/Frameworks/Python.framework/" \
+          "Versions/3.11/include/python3.11",
+      "-DPython3_LIBRARY=#{python_prefix}/Frameworks/Python.framework/" \
+          "Versions/3.11/lib/libpython3.11.dylib",
+    ]
   end
 
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
-    cmake_args << python_cmake_arg
+    cmake_args += python_cmake_args
 
     mkdir "build" do
       system "cmake", "..", *cmake_args

--- a/Formula/sdformat15.rb
+++ b/Formula/sdformat15.rb
@@ -21,15 +21,22 @@ class Sdformat15 < Formula
   depends_on "tinyxml2"
   depends_on "urdfdom"
 
-  def python_cmake_arg
-    "-DPython3_EXECUTABLE=#{which("python3")}"
+  def python_cmake_args
+    python_prefix = Formula["python@3.11"].opt_prefix
+    return [
+      "-DPython3_EXECUTABLE=#{python_prefix}/bin/python3",
+      "-DPython3_INCLUDE_DIR=#{python_prefix}/Frameworks/Python.framework/" \
+          "Versions/3.11/include/python3.11",
+      "-DPython3_LIBRARY=#{python_prefix}/Frameworks/Python.framework/" \
+          "Versions/3.11/lib/libpython3.11.dylib",
+    ]
   end
 
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
-    cmake_args << python_cmake_arg
+    cmake_args += python_cmake_args
 
     mkdir "build" do
       system "cmake", "..", *cmake_args


### PR DESCRIPTION
Tell CMake not only the path of the Python3 executable but also the include directory and loadable library. Fixes #2549.

This also resolves the current CI failures for the Ionic bottles.