### PR TITLE
gz-gui9: improve test error message

### DIFF
--- a/Formula/gz-gui9.rb
+++ b/Formula/gz-gui9.rb
@@ -97,7 +97,8 @@ class GzGui9 < Formula
       target_link_libraries(test_cmake gz-gui9::gz-gui9)
     EOS
     ENV.append_path "PKG_CONFIG_PATH", Formula["qt@5"].opt_lib/"pkgconfig"
-    system "pkg-config", "gz-gui9"
+    system "pkg-config", "gz-gui9", "--cflags"
+    system "pkg-config", "gz-gui9", "--libs"
     cflags   = `pkg-config --cflags gz-gui9`.split
     ldflags  = `pkg-config --libs gz-gui9`.split
     system ENV.cc, "test.cpp",


### PR DESCRIPTION
The gz-gui9 pkg-config test fails without a useful error message. Running with --cflags and --libs will improve the error message.