### PR TITLE
Remove bottles broken by tinyxml2 10.0

### DIFF
--- a/Formula/dartsim@6.10.0.rb
+++ b/Formula/dartsim@6.10.0.rb
@@ -6,13 +6,7 @@ class DartsimAT6100 < Formula
   version "6.10.0~20211005~d2b6ee08a60d0dbf71b0f008cd8fed1f611f6e24"
   sha256 "372af181024452418eec95f8a9cd723ceb1ada979208add66c9a4330b9c0fa32"
   license "BSD-2-Clause"
-  revision 10
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "4ea3d00ac47c820f3f1c70bd7d1b0a012da5c3cc274461ed908d168c2729889f"
-    sha256 monterey: "ba9733a6eb299e9e9c940dbe73e97e97081debdf0e0fead45f1362aa353ee109"
-  end
+  revision 11
 
   keg_only "open robotics fork of dart HEAD + custom changes"
 

--- a/Formula/gazebo11.rb
+++ b/Formula/gazebo11.rb
@@ -4,15 +4,9 @@ class Gazebo11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/gazebo-11.14.0.tar.bz2"
   sha256 "7e9842c046c9e0755355b274c240a8abbf4e962be7ce7b7f59194e5f4b584f45"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/osrf/gazebo.git", branch: "gazebo11"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "6e10492e03420b68899b37f4f237b988a1a9284b7dc89f06a2323ab2633bcb20"
-    sha256 monterey: "d13c3b23784b8ccbbb94304cca4af1c47d6cdf972003636595bfcb8c1e5161c8"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/gz-common5.rb
+++ b/Formula/gz-common5.rb
@@ -4,14 +4,9 @@ class GzCommon5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-common/releases/gz-common-5.5.0.tar.bz2"
   sha256 "77448902d3b24933c6b18b2b57f5f0b3e4f6ee05ec60874f9015a9801be7b834"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-common.git", branch: "gz-common5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "f8d39dae4691cdba003b0d2c3c9428469d1a112cbc1610f980bbce15eca9c92d"
-    sha256 cellar: :any, monterey: "f28184eb698527cc8429354ad742fb84dbaf1641a5a37c605c4ed0b0ff0775bc"
-  end
 
   depends_on "assimp"
   depends_on "cmake"

--- a/Formula/gz-fuel-tools10.rb
+++ b/Formula/gz-fuel-tools10.rb
@@ -17,6 +17,7 @@ class GzFuelTools10 < Formula
   depends_on macos: :high_sierra # c++17
   depends_on "pkg-config"
   depends_on "protobuf"
+  depends_on "tinyxml2"
 
   def install
     cmake_args = std_cmake_args

--- a/Formula/gz-fuel-tools8.rb
+++ b/Formula/gz-fuel-tools8.rb
@@ -4,15 +4,9 @@ class GzFuelTools8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-8.1.0.tar.bz2"
   sha256 "18a25e2bc31e61539c890bdd377068b5192646a6647267e76d9b0bb0d0349545"
   license "Apache-2.0"
-  revision 14
+  revision 15
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "dab2c2eddd94aa2f5fe74ea541ee456be27470931cdfab6770e31364b4559997"
-    sha256 cellar: :any, monterey: "497554bfcffa58cca71741d2a994a9f50a3af4bbd2479ec24960f8ee76be1456"
-  end
 
   depends_on "cmake"
   depends_on "gz-cmake3"

--- a/Formula/gz-fuel-tools8.rb
+++ b/Formula/gz-fuel-tools8.rb
@@ -24,6 +24,7 @@ class GzFuelTools8 < Formula
   depends_on macos: :high_sierra # c++17
   depends_on "pkg-config"
   depends_on "protobuf"
+  depends_on "tinyxml2"
 
   def install
     cmake_args = std_cmake_args

--- a/Formula/gz-fuel-tools9.rb
+++ b/Formula/gz-fuel-tools9.rb
@@ -4,15 +4,9 @@ class GzFuelTools9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-9.0.0.tar.bz2"
   sha256 "f6bff36311390bbdf169a767d94efd7657f6b44ee620dbe096ab122135f7c780"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "bb396d93885a4a0b433f8bb3682a86e38fa1fe57bfc108c48697ec47a1b4ddde"
-    sha256 cellar: :any, monterey: "a98f9a8e061a93b6e685ace78e11257b809b641143d75ad56dc7fb9dc0f6c45f"
-  end
 
   depends_on "cmake"
   depends_on "gz-cmake3"

--- a/Formula/gz-fuel-tools9.rb
+++ b/Formula/gz-fuel-tools9.rb
@@ -24,6 +24,7 @@ class GzFuelTools9 < Formula
   depends_on macos: :high_sierra # c++17
   depends_on "pkg-config"
   depends_on "protobuf"
+  depends_on "tinyxml2"
 
   def install
     cmake_args = std_cmake_args

--- a/Formula/gz-gui7.rb
+++ b/Formula/gz-gui7.rb
@@ -4,15 +4,9 @@ class GzGui7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-7.2.1.tar.bz2"
   sha256 "d6a9d0a14fc535773b23e06106a58238b03c04f7551aa642d28768119272042f"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "b852c40ffa7180b0c847a22c2f5d28e90deade1d1c7976fe8eb0ffc9205986b8"
-    sha256 monterey: "5cb237c9ebb585a5e240ef951a9d43c7370014c1362f18fc6e6c9800f3d8137e"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/gz-gui8.rb
+++ b/Formula/gz-gui8.rb
@@ -4,15 +4,9 @@ class GzGui8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-8.0.0.tar.bz2"
   sha256 "50815c1e81f985a616068e9c3d425ee035edfa2e7a13bd14ce3de41d9500fa40"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "7fe8bee59e43d536aeb7c40199a5c62b2d28fde756b86f7c5dcf40870838a04a"
-    sha256 monterey: "5a50d6b1e577680d2951d0c5db11499be3e51b22ca385b6f4d71ff05021d8c8d"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/gz-launch6.rb
+++ b/Formula/gz-launch6.rb
@@ -4,15 +4,9 @@ class GzLaunch6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-6.1.0.tar.bz2"
   sha256 "7c789c85ffb422ebbc4adb6f93c9b2aa7fdd7eccd521b7895297a6b8c525acc1"
   license "Apache-2.0"
-  revision 9
+  revision 10
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "27f7eee1b28782500e99a308d56c74df76bd1d2f4fb10372a0772d10fb137d7a"
-    sha256 monterey: "30717555b40c6def39a952e631987c50a6fa44445611d9b40beecf08d8aa99c9"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/gz-launch7.rb
+++ b/Formula/gz-launch7.rb
@@ -4,15 +4,9 @@ class GzLaunch7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-7.0.0.tar.bz2"
   sha256 "252cb170fd97d074e9d13536cda736cd481c8c2e6df30a4ee225cfb9dcd92e77"
   license "Apache-2.0"
-  revision 9
+  revision 10
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "09659f34ab8819cb477e911fefbdab63313544c57a45aa2f71c3b6b6d415cc68"
-    sha256 monterey: "af5f6b3fdad97d02ae5dd52ca1b20ddbff28b6360cf0e4f430cebe2a23b159ef"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/gz-msgs10.rb
+++ b/Formula/gz-msgs10.rb
@@ -4,15 +4,9 @@ class GzMsgs10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/gz-msgs-10.1.0.tar.bz2"
   sha256 "4f0463f5967314bcde63499a47ea88892d4b141c572910cc00fb415357f993d0"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs10"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "df0c55636315b37b66c305d48c29b93bd8b765e6105f8303af8b167ed4eb050d"
-    sha256 monterey: "dca75c9f1dc8244cebccb83f82d8d5e6aadb269e1dfea896dfa3b1f79cab9db6"
-  end
 
   depends_on "cmake"
   depends_on "gz-cmake3"

--- a/Formula/gz-msgs9.rb
+++ b/Formula/gz-msgs9.rb
@@ -4,15 +4,9 @@ class GzMsgs9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/gz-msgs-9.5.0.tar.bz2"
   sha256 "693f403fca86e9956b393a86fd46505d94e27b7b2c1d39bc631ba9c3029b91f9"
   license "Apache-2.0"
-  revision 14
+  revision 15
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "2bfa6f724fbb8832d720d5fa0778df805166ac1a09984cf26a47ca65296a6196"
-    sha256 cellar: :any, monterey: "1e96b584462b49526419f9bfdbb094a3984819131b4b08851070bfcd74c42d78"
-  end
 
   depends_on "cmake"
   depends_on "gz-cmake3"

--- a/Formula/gz-physics6.rb
+++ b/Formula/gz-physics6.rb
@@ -27,6 +27,7 @@ class GzPhysics6 < Formula
   depends_on macos: :mojave # c++17
   depends_on "pkg-config"
   depends_on "sdformat13"
+  depends_on "tinyxml2"
   depends_on "urdfdom"
 
   def install

--- a/Formula/gz-physics6.rb
+++ b/Formula/gz-physics6.rb
@@ -4,15 +4,9 @@ class GzPhysics6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-6.5.1.tar.bz2"
   sha256 "6556a066f88e48eb3a5d9219245b988e02778ce8c1f90cceb9359e87cbced828"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "e07bf4a800d6e7fb6d14fe3687288d9c2de07b81432ba59e46b9078f79a8fd05"
-    sha256 monterey: "ed200f14c43a0a586a3190f9df30ce9b9a6549fcc671a68f69c87dabd90773a9"
-  end
 
   depends_on "cmake" => [:build, :test]
 

--- a/Formula/gz-physics7.rb
+++ b/Formula/gz-physics7.rb
@@ -4,15 +4,9 @@ class GzPhysics7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-7.0.0.tar.bz2"
   sha256 "3bfd59d7d49e3ae9f0ef5737ba6b23919700ce93e15f20d1eff3281914e58f78"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "12e71d517a4b926cfed888456461d04009c0cc66a0153cb1ffa7c59c0a06d15b"
-    sha256 monterey: "8fef7da5958d8a17dcdb92f3fc6df91e1a8ccb0c038291337b152bdbff11f7d0"
-  end
 
   depends_on "cmake" => [:build, :test]
 

--- a/Formula/gz-physics7.rb
+++ b/Formula/gz-physics7.rb
@@ -27,6 +27,7 @@ class GzPhysics7 < Formula
   depends_on macos: :mojave # c++17
   depends_on "pkg-config"
   depends_on "sdformat14"
+  depends_on "tinyxml2"
   depends_on "urdfdom"
 
   def install

--- a/Formula/gz-physics8.rb
+++ b/Formula/gz-physics8.rb
@@ -20,6 +20,7 @@ class GzPhysics8 < Formula
   depends_on macos: :mojave # c++17
   depends_on "pkg-config"
   depends_on "sdformat15"
+  depends_on "tinyxml2"
   depends_on "urdfdom"
 
   def install

--- a/Formula/gz-sensors7.rb
+++ b/Formula/gz-sensors7.rb
@@ -25,6 +25,7 @@ class GzSensors7 < Formula
   depends_on "gz-transport12"
   depends_on "protobuf"
   depends_on "sdformat13"
+  depends_on "tinyxml2"
 
   def install
     cmake_args = std_cmake_args

--- a/Formula/gz-sensors7.rb
+++ b/Formula/gz-sensors7.rb
@@ -4,15 +4,9 @@ class GzSensors7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-7.3.0.tar.bz2"
   sha256 "92b9e0bf4707bdbf318142b0a17c1cd1ca8c94bfee9f8911bcd0b3a7c6cbd169"
   license "Apache-2.0"
-  revision 9
+  revision 10
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "839c718ed992d61d8bb38adaee18a1421196b4f419d313ca468dd726cb66e44a"
-    sha256 cellar: :any, monterey: "2c306d9b43817182699df15816e740ab7a3aac2f139d2962dd81b26a43c5e7bf"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/gz-sensors8.rb
+++ b/Formula/gz-sensors8.rb
@@ -25,6 +25,7 @@ class GzSensors8 < Formula
   depends_on "gz-transport13"
   depends_on "protobuf"
   depends_on "sdformat14"
+  depends_on "tinyxml2"
 
   def install
     cmake_args = std_cmake_args

--- a/Formula/gz-sensors8.rb
+++ b/Formula/gz-sensors8.rb
@@ -4,15 +4,9 @@ class GzSensors8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-8.0.0.tar.bz2"
   sha256 "17a3be4fbcc338a22928c7d5b96d4369f05be801470e37f580c0f83299609bf4"
   license "Apache-2.0"
-  revision 9
+  revision 10
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "4fc4eb070990610a7636143db5a795b26cadb644ecc90e7154fffe30ebebf806"
-    sha256 cellar: :any, monterey: "4b0269bca87c29b3c90936a5c0228ac19a9cbc66c006ea89376e22e1e0b237c4"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/gz-sensors9.rb
+++ b/Formula/gz-sensors9.rb
@@ -18,6 +18,7 @@ class GzSensors9 < Formula
   depends_on "gz-transport14"
   depends_on "protobuf"
   depends_on "sdformat15"
+  depends_on "tinyxml2"
 
   def install
     cmake_args = std_cmake_args

--- a/Formula/gz-sim7.rb
+++ b/Formula/gz-sim7.rb
@@ -38,6 +38,7 @@ class GzSim7 < Formula
   depends_on "python@3.11"
   depends_on "ruby"
   depends_on "sdformat13"
+  depends_on "tinyxml2"
 
   def python_cmake_arg
     "-DPython3_EXECUTABLE=#{which("python3")}"

--- a/Formula/gz-sim7.rb
+++ b/Formula/gz-sim7.rb
@@ -4,15 +4,9 @@ class GzSim7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-7.7.0.tar.bz2"
   sha256 "48d89b5e913eb8bb9925373eeb18616d512cd43f7e45be4413ce8c66bf1ca0d1"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "8bc334ad26812cf3c17d8abfe309c0ff081935475f512b94280bcc8abc3b3409"
-    sha256 monterey: "87b59515c867e3d0ba38e3c1029400e91a742d3bdf63887d7dbefc51f4cc2945"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build

--- a/Formula/gz-sim8.rb
+++ b/Formula/gz-sim8.rb
@@ -37,6 +37,7 @@ class GzSim8 < Formula
   depends_on "python@3.11"
   depends_on "ruby"
   depends_on "sdformat14"
+  depends_on "tinyxml2"
 
   def python_cmake_arg
     "-DPython3_EXECUTABLE=#{which("python3")}"

--- a/Formula/gz-sim8.rb
+++ b/Formula/gz-sim8.rb
@@ -4,14 +4,9 @@ class GzSim8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-8.1.0.tar.bz2"
   sha256 "7a2f3e13f7eb2a15f2fd012df03cd14e53b841d141f03b4841966252b3bf5263"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "2619de9ec01fd0c631df40176e85f3a65a46e2aa11912f5ef670b100c573e0c4"
-    sha256 monterey: "7bf0ec36f9f4fe83946926ec9f542c558b61fd3989e3b25fb54c0584c77e8aaf"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build

--- a/Formula/gz-sim9.rb
+++ b/Formula/gz-sim9.rb
@@ -31,6 +31,7 @@ class GzSim9 < Formula
   depends_on "python@3.11"
   depends_on "ruby"
   depends_on "sdformat15"
+  depends_on "tinyxml2"
 
   def python_cmake_arg
     "-DPython3_EXECUTABLE=#{which("python3")}"

--- a/Formula/gz-transport12.rb
+++ b/Formula/gz-transport12.rb
@@ -26,6 +26,7 @@ class GzTransport12 < Formula
   depends_on "ossp-uuid"
   depends_on "pkg-config"
   depends_on "protobuf"
+  depends_on "tinyxml2"
   depends_on "zeromq"
 
   def install

--- a/Formula/gz-transport12.rb
+++ b/Formula/gz-transport12.rb
@@ -4,15 +4,9 @@ class GzTransport12 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/gz-transport-12.2.1.tar.bz2"
   sha256 "62fb97a722dea804da262610061688f675222d4e33a7a1a59868fdefe6ae2d92"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport12"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "47ba79eb331b8d6738b23ab03ee82dc209d44a0c9153b06d96952fb4ccaa9999"
-    sha256 monterey: "3e3e224c42207188d44fb5fdf5a51ffd9fc89b0e1e9dd049553be9723f3eb794"
-  end
 
   depends_on "doxygen" => [:build, :optional]
 

--- a/Formula/gz-transport13.rb
+++ b/Formula/gz-transport13.rb
@@ -28,6 +28,7 @@ class GzTransport13 < Formula
   depends_on "pkg-config"
   depends_on "protobuf"
   depends_on "python@3.11"
+  depends_on "tinyxml2"
   depends_on "zeromq"
 
   def python_cmake_arg

--- a/Formula/gz-transport13.rb
+++ b/Formula/gz-transport13.rb
@@ -4,15 +4,9 @@ class GzTransport13 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/gz-transport-13.0.0.tar.bz2"
   sha256 "d44b4ed089110a1a7dfc3b59f782e33f27668a980ededdbf3c21171f72a82968"
   license "Apache-2.0"
-  revision 9
+  revision 10
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport13"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "8362b00e5b44bbd492b2acf85451fc7f178a9b5e8826f69577e4a9007a442096"
-    sha256 monterey: "b99f6f286519c3c3e5bd350f8219b35afeee99445beffa49b850d252e128cf92"
-  end
 
   depends_on "doxygen" => [:build, :optional]
   depends_on "pybind11" => :build

--- a/Formula/gz-transport14.rb
+++ b/Formula/gz-transport14.rb
@@ -21,6 +21,7 @@ class GzTransport14 < Formula
   depends_on "pkg-config"
   depends_on "protobuf"
   depends_on "python@3.11"
+  depends_on "tinyxml2"
   depends_on "zeromq"
 
   def python_cmake_arg

--- a/Formula/ignition-common1.rb
+++ b/Formula/ignition-common1.rb
@@ -4,15 +4,9 @@ class IgnitionCommon1 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-common/releases/ignition-common-1.1.1.tar.bz2"
   sha256 "2e8b65c9390bc78088865d95c0933c564b07b3b55b68c14e1c6d947ca8d9525a"
   license "Apache-2.0"
-  revision 6
+  revision 7
 
   head "https://github.com/gazebosim/gz-common.git", branch: "ign-common1"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, big_sur:  "79fdd71bed4003a3b3b374bed25a975f257f72f782d965edb3060f1b86ddfa85"
-    sha256 cellar: :any, catalina: "ffd94f0a4c2c7272f39a6f5e871cd72f67075c3cda408650496554ea0f99ea40"
-  end
 
   deprecate! date: "2023-01-25", because: "is past end-of-life date"
 

--- a/Formula/ignition-common3.rb
+++ b/Formula/ignition-common3.rb
@@ -4,14 +4,9 @@ class IgnitionCommon3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-common/releases/ignition-common3-3.17.0.tar.bz2"
   sha256 "243aa94babb37c7f0d58575b31127cc49181cd96f1a24d91cfdb66ffbc5976ef"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-common.git", branch: "ign-common3"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "1687a81e7436b41ef38c6bcf50237f61f51312e9ebc01466c8521457a8887bc9"
-    sha256 cellar: :any, monterey: "2423f08ee33c0c06cf41ac55134dd0d92144e15f03db1fb14b9ae81eb0e0f9ce"
-  end
 
   depends_on "cmake"
   depends_on "ffmpeg"

--- a/Formula/ignition-common4.rb
+++ b/Formula/ignition-common4.rb
@@ -4,15 +4,9 @@ class IgnitionCommon4 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-common/releases/ignition-common4-4.7.0.tar.bz2"
   sha256 "ec9bb68be9f6323f3a3a12b23259c567f9a2478951719573e1b7c906bd7e68cb"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-common.git", branch: "ign-common4"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "aa18a1f275373952271db06b9e16ef49fdd6f5c5dd2c327222e496dd75d342b6"
-    sha256 cellar: :any, monterey: "f83c51a0ace19ed6a45fbccccc2e94b2ed68198e16684033df565561f48ef500"
-    sha256 cellar: :any, big_sur:  "02fa82a28eb2855d965f5b185410b829bf6fb625fed27e578aaa6dc6a6bde6bd"
-  end
 
   depends_on "cmake"
   depends_on "ffmpeg"

--- a/Formula/ignition-fuel-tools4.rb
+++ b/Formula/ignition-fuel-tools4.rb
@@ -4,15 +4,9 @@ class IgnitionFuelTools4 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-fuel-tools/releases/ignition-fuel-tools4-4.9.1.tar.bz2"
   sha256 "35b8cdceae46f50360081eb1b310366ae085a8c64d88fee7175f2b0582e454a2"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools4"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "f1e070b50eb897a0b2b371c8faafe71958b1010929b75a1a2d6a9a5ca7c11bb4"
-    sha256 cellar: :any, monterey: "a90bcb82b5b56312a30dc14a1153214c9a83ae8d3dcac80743f00af6cc15f68c"
-  end
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-fuel-tools4.rb
+++ b/Formula/ignition-fuel-tools4.rb
@@ -24,6 +24,7 @@ class IgnitionFuelTools4 < Formula
   depends_on macos: :high_sierra # c++17
   depends_on "pkg-config"
   depends_on "protobuf"
+  depends_on "tinyxml2"
 
   def install
     cmake_args = std_cmake_args

--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -4,15 +4,9 @@ class IgnitionFuelTools7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-fuel-tools/releases/ignition-fuel-tools7-7.3.0.tar.bz2"
   sha256 "59d06f23a054742e1f97c1f0f709e2a38c341ce96f560d6e09b3dba011dd79a5"
   license "Apache-2.0"
-  revision 17
+  revision 18
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "b815edfffa7c9eb524b1bd524346a883f8e85c5030c37d03bf975e16f0a2e46a"
-    sha256 cellar: :any, monterey: "4f77a43711a79e2ab1b1d99d56259065a132e1ca9cec3aa96ded63a0325238f9"
-  end
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -24,6 +24,7 @@ class IgnitionFuelTools7 < Formula
   depends_on macos: :high_sierra # c++17
   depends_on "pkg-config"
   depends_on "protobuf"
+  depends_on "tinyxml2"
 
   def install
     cmake_args = std_cmake_args

--- a/Formula/ignition-gazebo3.rb
+++ b/Formula/ignition-gazebo3.rb
@@ -38,6 +38,7 @@ class IgnitionGazebo3 < Formula
   depends_on "protobuf"
   depends_on "ruby"
   depends_on "sdformat9"
+  depends_on "tinyxml2"
 
   def install
     cmake_args = std_cmake_args

--- a/Formula/ignition-gazebo3.rb
+++ b/Formula/ignition-gazebo3.rb
@@ -4,15 +4,9 @@ class IgnitionGazebo3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gazebo/releases/ignition-gazebo3-3.15.1.tar.bz2"
   sha256 "c801d4205f8f88fca813cbf699cf6a077536d430e6c312a85520d6f50a7052bd"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo3"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "2aaf656273339478d85e75af99e9aeb54dc0b241e49f7ddc5b48ab82139b3b59"
-    sha256 monterey: "006e206ebcb2ef86d437aa0830eefd0cebd8925b8e38753a8fbda0d125738068"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -4,15 +4,9 @@ class IgnitionGazebo6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gazebo/releases/ignition-gazebo6-6.16.0.tar.bz2"
   sha256 "1e61148e8b49a5a20f4cac1e116ce5c4d8de3718a1d26e41a1cec394ce5ea9e4"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "838cbda0266c783cd49a848474399d4b4aa2f078cbc3844055b92ec357bc2528"
-    sha256 monterey: "50b0f7f8f7ed3e005abf531c7c5f427392b9159ef4fc90a48050a8b5c493b619"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -39,6 +39,7 @@ class IgnitionGazebo6 < Formula
   depends_on "python@3.11"
   depends_on "ruby"
   depends_on "sdformat12"
+  depends_on "tinyxml2"
 
   def install
     rpaths = [

--- a/Formula/ignition-gui3.rb
+++ b/Formula/ignition-gui3.rb
@@ -4,15 +4,9 @@ class IgnitionGui3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gui/releases/ignition-gui3-3.12.0.tar.bz2"
   sha256 "f53ee05d844449b900ecb30d5e1f812fd3f7e9e28630d309b7d8d11add3c3b1c"
   license "Apache-2.0"
-  revision 20
+  revision 21
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui3"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "bf1100c3a5e6735ca87da9645ec5b0a5695053c9d4037dfbcf0e68238e7bbc0d"
-    sha256 monterey: "379ef407b3297a22914789edadb3000d2c70a81143a05d90c85783896efe64f2"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -4,15 +4,9 @@ class IgnitionGui6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gui/releases/ignition-gui6-6.8.0.tar.bz2"
   sha256 "dd4f26100f4d1343f068ba36f2b8394a0cddb337efde7b4a21c1b0f66ce496c9"
   license "Apache-2.0"
-  revision 20
+  revision 21
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "f1b2f04b8b1d39ff369e47ba048408553e4bb050c4fed107d868422be54fac2a"
-    sha256 monterey: "f5786d85c592f9b2ec0490669a725f0c9f08a2cb9ec92cb0f2bafe0a2ebefeab"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/ignition-launch2.rb
+++ b/Formula/ignition-launch2.rb
@@ -4,15 +4,9 @@ class IgnitionLaunch2 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-launch/releases/ignition-launch2-2.3.1.tar.bz2"
   sha256 "984e2a5df03ca220960470b6b59728edf3cd570314fbad6435b67cb26c9b7e4e"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "ign-launch2"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "af011bf5d2ee9dd37cf43c0462da7e95f9e105ad9c498ceb3c0693b7838fa69b"
-    sha256 monterey: "202acae4149191f8b9503cb78f8f0080f6f1d21d0ee0231c428acc61f8c144d1"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-launch5.rb
+++ b/Formula/ignition-launch5.rb
@@ -4,15 +4,9 @@ class IgnitionLaunch5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-launch/releases/ignition-launch5-5.3.0.tar.bz2"
   sha256 "84d356b9c85609da1bb7feda2f90ae6d1a1fd2d6713b284799d5605de42e2613"
   license "Apache-2.0"
-  revision 18
+  revision 19
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "ign-launch5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "bc19c91bfbcdb73f0106dd69b30251217457d9ba7a0fdaf3cf48fffbe469c060"
-    sha256 monterey: "47a916d068da8acbc7db18f9aa3dc2797a9d213d9eff506650b375044fc92a0c"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/ignition-msgs5.rb
+++ b/Formula/ignition-msgs5.rb
@@ -4,15 +4,9 @@ class IgnitionMsgs5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs5-5.11.0.tar.bz2"
   sha256 "59a03770c27b4cdb6d0b0f3de9f10f1c748a47b45376a297e1f30900edb893fd"
   license "Apache-2.0"
-  revision 18
+  revision 19
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "e7b8d65f4a133e57d564f34344a6cc5fec22ada7a7475364efe360337d5895ec"
-    sha256 cellar: :any, monterey: "799edd10641ae8d6fc293261f3c47ec50de3db861cb7ed1f4a54211cf47b7aad"
-  end
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-msgs8.rb
+++ b/Formula/ignition-msgs8.rb
@@ -4,15 +4,9 @@ class IgnitionMsgs8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs8-8.7.0.tar.bz2"
   sha256 "b17a8e16fe56a84891bd0654a2ac09427e9a567b9cd2255bb2cfa830f8e1af45"
   license "Apache-2.0"
-  revision 19
+  revision 20
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "2537052afe0c164ec5e2cde3053750cb9247034a2f28e41325c1ef66f2f440f2"
-    sha256 cellar: :any, monterey: "c283d8c297a31100da476a432dbbfdbfccdd5fb78ddcb34a8168c20ba46fe7d7"
-  end
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-physics2.rb
+++ b/Formula/ignition-physics2.rb
@@ -28,6 +28,7 @@ class IgnitionPhysics2 < Formula
   depends_on macos: :mojave # c++17
   depends_on "pkg-config"
   depends_on "sdformat9"
+  depends_on "tinyxml2"
   depends_on "urdfdom"
 
   def install

--- a/Formula/ignition-physics2.rb
+++ b/Formula/ignition-physics2.rb
@@ -4,15 +4,9 @@ class IgnitionPhysics2 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics2-2.6.2.tar.bz2"
   sha256 "4aa0dcd1a254da63f55a93d2cc928a5ff517f19ac1603c0fb5f810dd29c70e1d"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics2"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "8a21efb2a45f1947e7ecf35f7e789452c5247d51843bafc6b5205cc7b1ca3cbf"
-    sha256 cellar: :any, monterey: "dbb879aa6e80c5111a905d0353344e005aa05764164a87581bd0af09e1451a78"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -4,15 +4,9 @@ class IgnitionPhysics5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics5-5.3.2.tar.bz2"
   sha256 "4262512fbb6952712234c5cbeed69cdabca338931bb6c587a1ef7d487a5f262b"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "ign-physics5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "85ca12db8aba4c8eb881b7c95fd8de84a19e343fc524d3a8292c3f0a9acc769c"
-    sha256 cellar: :any, monterey: "c28772257d63c81d99ee5cc691e5d876b0984127cf47f0b303cc46624e8858f1"
-  end
 
   depends_on "cmake" => :build
 

--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -29,6 +29,7 @@ class IgnitionPhysics5 < Formula
   depends_on macos: :mojave # c++17
   depends_on "pkg-config"
   depends_on "sdformat12"
+  depends_on "tinyxml2"
   depends_on "urdfdom"
 
   patch do

--- a/Formula/ignition-sensors3.rb
+++ b/Formula/ignition-sensors3.rb
@@ -4,15 +4,9 @@ class IgnitionSensors3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-sensors/releases/ignition-sensors3-3.6.0.tar.bz2"
   sha256 "b64b187333907a9e866307ccc76649672e0df9b6bdfb4a390929ebbcaa83ce64"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors3"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "b5f60bb72905851e85b54a3c437807be3bcac96ee1d1602cefb9d5950280d058"
-    sha256 monterey: "19bca3f165b601bc176c7295cdf2d62eb16d7b4389b01321023e6344a222a68c"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-sensors3.rb
+++ b/Formula/ignition-sensors3.rb
@@ -27,6 +27,7 @@ class IgnitionSensors3 < Formula
   depends_on "ignition-transport8"
   depends_on "protobuf"
   depends_on "sdformat9"
+  depends_on "tinyxml2"
 
   def install
     cmake_args = std_cmake_args

--- a/Formula/ignition-sensors6.rb
+++ b/Formula/ignition-sensors6.rb
@@ -4,15 +4,9 @@ class IgnitionSensors6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-sensors/releases/ignition-sensors6-6.8.0.tar.bz2"
   sha256 "4bd5cd637dc624fe8d2a5244b3282ed74558c0fd50e040ba4770c312fcb8c1f5"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "0d899e0a1a9966a67b3a7fff841de6cb76b865afbbc8713806217f5de0d1ac4b"
-    sha256 cellar: :any, monterey: "b1e0cc6c5b8a628234551869668bf8bdc86098c59344aa747aa0e3aebff55e7a"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/ignition-sensors6.rb
+++ b/Formula/ignition-sensors6.rb
@@ -25,6 +25,7 @@ class IgnitionSensors6 < Formula
   depends_on "ignition-transport11"
   depends_on "protobuf"
   depends_on "sdformat12"
+  depends_on "tinyxml2"
 
   def install
     cmake_args = std_cmake_args

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -4,16 +4,10 @@ class IgnitionTransport11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases/ignition-transport11-11.4.1.tar.bz2"
   sha256 "f18501cbd5c78b584b3db1960a3049d6ae416bab7f0289af64eadda13d1c5da5"
   license "Apache-2.0"
-  revision 12
+  revision 13
   version_scheme 1
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport11"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "efb882e92a52a14a46713dd2da5a0b7bc7e37d1fd509055d69a9a6407740ec7f"
-    sha256 monterey: "c6bc1570c0148338f07c243c0e8bd9dfc9a1d5af08d26d8b885bda58d6839654"
-  end
 
   depends_on "doxygen" => [:build, :optional]
 

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -27,6 +27,7 @@ class IgnitionTransport11 < Formula
   depends_on "ossp-uuid"
   depends_on "pkg-config"
   depends_on "protobuf"
+  depends_on "tinyxml2"
   depends_on "zeromq"
 
   def install

--- a/Formula/ignition-transport8.rb
+++ b/Formula/ignition-transport8.rb
@@ -25,6 +25,7 @@ class IgnitionTransport8 < Formula
   depends_on "ossp-uuid"
   depends_on "pkg-config"
   depends_on "protobuf"
+  depends_on "tinyxml2"
   depends_on "zeromq"
 
   def install

--- a/Formula/ignition-transport8.rb
+++ b/Formula/ignition-transport8.rb
@@ -4,15 +4,9 @@ class IgnitionTransport8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases/ignition-transport8-8.5.0.tar.bz2"
   sha256 "5edd15699e35ade5ad2f814af1f5e96a866f7908e16b55333abb23978f44d4c6"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "f8fb9059ebadb6a33c7abb747fb5b3cf86ffcee5748aacef6f26b5cf3e454dea"
-    sha256 monterey: "8f9459b48d3624eb3cdca125bd12337f33ea0be09300e5a137efad6c4ecf3008"
-  end
 
   depends_on "doxygen" => [:build, :optional]
 

--- a/Formula/sdformat12.rb
+++ b/Formula/sdformat12.rb
@@ -4,15 +4,9 @@ class Sdformat12 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-12.7.2.tar.bz2"
   sha256 "f199f5ad8e4390024c0a2a7c619bee12c662b81f6758b2b50877397ad4f743c0"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/sdformat.git", branch: "sdf12"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "23b07e4ad7bce57baec796f52143efa2b6ae7fcc6580030c2dcc95571b056a3c"
-    sha256 monterey: "df6f97ca5c33077e400e156ef91349679148514fd03e0c9c706089dc944bbbcd"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/sdformat13.rb
+++ b/Formula/sdformat13.rb
@@ -4,15 +4,9 @@ class Sdformat13 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-13.6.0.tar.bz2"
   sha256 "5845c9c0da66bb30b209ed8421f5b4805bf6e8863fd58a790a59f856902e67f3"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   head "https://github.com/gazebosim/sdformat.git", branch: "sdf13"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "848982919f5bde647932a1e9717624339a2cca27151c8562d44a9f4534a00aad"
-    sha256 monterey: "ac1984c4463e4e82fbe4f0d6a57f11c270a7db5942af7a674baf6a8b863953c3"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/sdformat14.rb
+++ b/Formula/sdformat14.rb
@@ -4,15 +4,9 @@ class Sdformat14 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-14.0.0.tar.bz2"
   sha256 "88c0858a23ef4a4f36a9b3162e4b438878ae8670608af73d1797d67a3aaa4246"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   head "https://github.com/gazebosim/sdformat.git", branch: "main"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "e4f8d9362d94b305d1a6d3d8c403e895b26f728ab646883367c682b045626808"
-    sha256 monterey: "a1e0ef45738e72783c5e21866d262fa00aa0a04964b5a1f7df8d4007a558e9fe"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]


### PR DESCRIPTION
Part of #2504.

I noticed some formulae that link against `tinyxml2` didn't have an explicit `depends_on` tag, so I added that and then used the following script to remove bottles for everything depending on tinyxml2:

~~~
for f in $(grep -l '^ *bottle do' $(grep -rlI depend.*tinyxml2 .) | sort)
do
   brew bump-revision --remove-bottle-block --message="broken bottle" $f
done
~~~