### PR TITLE
Rebuild gazebo11 dependencies for tinyxml2

### DIFF
--- a/Formula/ignition-common3.rb
+++ b/Formula/ignition-common3.rb
@@ -8,6 +8,12 @@ class IgnitionCommon3 < Formula
 
   head "https://github.com/gazebosim/gz-common.git", branch: "ign-common3"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, ventura:  "42b4200807d3a3aa532a61b77e20b35abd1b7397ef83a82064d6e5a1d1355b6d"
+    sha256 cellar: :any, monterey: "d165757f10ab6b9a7b4ddbf281bf4e50e3615f594792766bc95230d9c0106358"
+  end
+
   depends_on "cmake"
   depends_on "ffmpeg"
   depends_on "freeimage"

--- a/Formula/ignition-common3.rb
+++ b/Formula/ignition-common3.rb
@@ -4,7 +4,7 @@ class IgnitionCommon3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-common/releases/ignition-common3-3.17.0.tar.bz2"
   sha256 "243aa94babb37c7f0d58575b31127cc49181cd96f1a24d91cfdb66ffbc5976ef"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-common.git", branch: "ign-common3"
 

--- a/Formula/ignition-fuel-tools4.rb
+++ b/Formula/ignition-fuel-tools4.rb
@@ -8,6 +8,12 @@ class IgnitionFuelTools4 < Formula
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools4"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, ventura:  "0fa33a0199253e953faad5ef0f5faf2896e3ebdc26833851ca23a3e7a067bc63"
+    sha256 cellar: :any, monterey: "5db63350e38454c7010e225468e2809a6918528e223071d0ee4662adf702ac25"
+  end
+
   depends_on "cmake"
   depends_on "ignition-cmake2"
   depends_on "ignition-common3"

--- a/Formula/ignition-fuel-tools4.rb
+++ b/Formula/ignition-fuel-tools4.rb
@@ -4,7 +4,7 @@ class IgnitionFuelTools4 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-fuel-tools/releases/ignition-fuel-tools4-4.9.1.tar.bz2"
   sha256 "35b8cdceae46f50360081eb1b310366ae085a8c64d88fee7175f2b0582e454a2"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools4"
 

--- a/Formula/ignition-msgs5.rb
+++ b/Formula/ignition-msgs5.rb
@@ -8,6 +8,12 @@ class IgnitionMsgs5 < Formula
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs5"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, ventura:  "54787254bfbec81fd787dcd60c087e6bef9cedda9863a54afd448f0a3cbe5390"
+    sha256 cellar: :any, monterey: "41d35f3c9fe3264782a6151dd9af944a52c94eb2b6d9385ab36a7868917a9dc6"
+  end
+
   depends_on "cmake"
   depends_on "ignition-cmake2"
   depends_on "ignition-math6"

--- a/Formula/ignition-msgs5.rb
+++ b/Formula/ignition-msgs5.rb
@@ -4,7 +4,7 @@ class IgnitionMsgs5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs5-5.11.0.tar.bz2"
   sha256 "59a03770c27b4cdb6d0b0f3de9f10f1c748a47b45376a297e1f30900edb893fd"
   license "Apache-2.0"
-  revision 19
+  revision 20
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs5"
 

--- a/Formula/ignition-transport8.rb
+++ b/Formula/ignition-transport8.rb
@@ -4,7 +4,7 @@ class IgnitionTransport8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases/ignition-transport8-8.5.0.tar.bz2"
   sha256 "5edd15699e35ade5ad2f814af1f5e96a866f7908e16b55333abb23978f44d4c6"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport8"
 

--- a/Formula/ignition-transport8.rb
+++ b/Formula/ignition-transport8.rb
@@ -8,6 +8,12 @@ class IgnitionTransport8 < Formula
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport8"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 ventura:  "26c7ff18377167c295718b523ba46b8ee757a7d75e81c0baf9a0c91d4354f5b1"
+    sha256 monterey: "15fd8a5b5d9f5d27ca8e74f0e07b843711e380541edd48cf01a29c95341aa4e9"
+  end
+
   depends_on "doxygen" => [:build, :optional]
 
   depends_on "cmake"


### PR DESCRIPTION
Part of #2504.

There are several dependencies shared by Citadel and Gazebo11. This rebuilds those common dependencies so that gazebo11 and the rest of Citadel can be built separately.

Pull request commits created with the following command:

~~~
for f in $(grep -L '^ *bottle do' $(grep -rnI 'depend.*"ignition-' gazebo11.rb | sed -e 's@.* "@@' -e 's@"@.rb@'))
do
     brew bump-revision --message="rebuild bottle" $f
done
~~~