### PR TITLE
Remove bottles broken by protobuf 25.3

### DIFF
--- a/Formula/gazebo11.rb
+++ b/Formula/gazebo11.rb
@@ -4,15 +4,9 @@ class Gazebo11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/gazebo-11.14.0.tar.bz2"
   sha256 "7e9842c046c9e0755355b274c240a8abbf4e962be7ce7b7f59194e5f4b584f45"
   license "Apache-2.0"
-  revision 10
+  revision 11
 
   head "https://github.com/osrf/gazebo.git", branch: "gazebo11"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "9bcaa386b2f82380509a48a1ee2b761751cd5bc0b6084a54eff0b468c4bf5aa4"
-    sha256 monterey: "daedf02940c3eea3ddfae07e21dfb0f208afad91ac88e4ca4739f2f8b084b33e"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/gz-fuel-tools8.rb
+++ b/Formula/gz-fuel-tools8.rb
@@ -4,15 +4,9 @@ class GzFuelTools8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-8.1.0.tar.bz2"
   sha256 "18a25e2bc31e61539c890bdd377068b5192646a6647267e76d9b0bb0d0349545"
   license "Apache-2.0"
-  revision 16
+  revision 17
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "4b1301380b8951f4e2960de0fd7ff76ad21dfb603bf733ef69ec4588814c42bb"
-    sha256 cellar: :any, monterey: "b4c9d26e535532b5d790cd60a5b891a58f7157eea1644af8b86179b4920813d7"
-  end
 
   depends_on "cmake"
   depends_on "gz-cmake3"

--- a/Formula/gz-fuel-tools9.rb
+++ b/Formula/gz-fuel-tools9.rb
@@ -4,15 +4,9 @@ class GzFuelTools9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-9.0.0.tar.bz2"
   sha256 "f6bff36311390bbdf169a767d94efd7657f6b44ee620dbe096ab122135f7c780"
   license "Apache-2.0"
-  revision 10
+  revision 11
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "0e8efcf042d3053c0f06087a8b1efe9fee6788d7255ce53b2c875374dbae81e5"
-    sha256 cellar: :any, monterey: "5c98297d52a9ade6f8bb9d858823d592071368b115bb13575da8e07ee81a8917"
-  end
 
   depends_on "cmake"
   depends_on "gz-cmake3"

--- a/Formula/gz-gui7.rb
+++ b/Formula/gz-gui7.rb
@@ -4,15 +4,9 @@ class GzGui7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-7.2.1.tar.bz2"
   sha256 "d6a9d0a14fc535773b23e06106a58238b03c04f7551aa642d28768119272042f"
   license "Apache-2.0"
-  revision 10
+  revision 11
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "bb065a392189eb40477ca6fb88a06feff5a5a66d76572c0e736dd6306625d173"
-    sha256 monterey: "8e9be6d38951d9c2c4a224990e44efc24368ff841893b9bba792a713f73d92dc"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/gz-gui8.rb
+++ b/Formula/gz-gui8.rb
@@ -4,15 +4,9 @@ class GzGui8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-8.0.0.tar.bz2"
   sha256 "50815c1e81f985a616068e9c3d425ee035edfa2e7a13bd14ce3de41d9500fa40"
   license "Apache-2.0"
-  revision 10
+  revision 11
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "153c1ca05409103d13f14192ace9070e6e66c462a9af42e9f3fea749cd7d9b07"
-    sha256 monterey: "ac9eb4a9ebfc3f45ece8807feef9d48876670f7e04e64458b27fcd9ea7f8e86e"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/gz-launch6.rb
+++ b/Formula/gz-launch6.rb
@@ -4,15 +4,9 @@ class GzLaunch6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-6.1.0.tar.bz2"
   sha256 "7c789c85ffb422ebbc4adb6f93c9b2aa7fdd7eccd521b7895297a6b8c525acc1"
   license "Apache-2.0"
-  revision 11
+  revision 12
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "ecb42957e87f62b86926b0575d37c53744e58352111eb5765a76d7801a18d202"
-    sha256 monterey: "16d9cd41d2d7db1a10d08aeac65a2ed57bec89c4f04f9802a6dcfc7f39fd7b50"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/gz-launch7.rb
+++ b/Formula/gz-launch7.rb
@@ -4,15 +4,9 @@ class GzLaunch7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-7.0.0.tar.bz2"
   sha256 "252cb170fd97d074e9d13536cda736cd481c8c2e6df30a4ee225cfb9dcd92e77"
   license "Apache-2.0"
-  revision 11
+  revision 12
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "16da09e8a12d1b6ddf48db070af9ad50610f3b88fa795b8b2cd37a26572b253e"
-    sha256 monterey: "6e03fd2e479a4ebdd06e3af40c9838ab2de61d5cf9abea74f2ff2574ef0b069b"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/gz-msgs10.rb
+++ b/Formula/gz-msgs10.rb
@@ -4,15 +4,9 @@ class GzMsgs10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/gz-msgs-10.1.0.tar.bz2"
   sha256 "4f0463f5967314bcde63499a47ea88892d4b141c572910cc00fb415357f993d0"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs10"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "247732d4ac1a3b76e6844b7eac9a72ccc6eba8ceee254cdcf54bb44b1ba6d982"
-    sha256 monterey: "89f4fbe0bf3431a23c7d2893e28f26db86e0ecf543a47cabdd5c7cb0f3287424"
-  end
 
   depends_on "cmake"
   depends_on "gz-cmake3"

--- a/Formula/gz-msgs9.rb
+++ b/Formula/gz-msgs9.rb
@@ -4,15 +4,9 @@ class GzMsgs9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/gz-msgs-9.5.0.tar.bz2"
   sha256 "693f403fca86e9956b393a86fd46505d94e27b7b2c1d39bc631ba9c3029b91f9"
   license "Apache-2.0"
-  revision 16
+  revision 17
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "9166fdb6bf119a662e2383463e2bf9d7ea9535ec3ba113230879df6a6d57106d"
-    sha256 cellar: :any, monterey: "1383964b01e24afa36f6ea2ba7c9fed90b7d891ca20190a737499c2c685710d5"
-  end
 
   depends_on "cmake"
   depends_on "gz-cmake3"

--- a/Formula/gz-sensors7.rb
+++ b/Formula/gz-sensors7.rb
@@ -4,15 +4,9 @@ class GzSensors7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-7.3.0.tar.bz2"
   sha256 "92b9e0bf4707bdbf318142b0a17c1cd1ca8c94bfee9f8911bcd0b3a7c6cbd169"
   license "Apache-2.0"
-  revision 11
+  revision 12
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "88fdafc75eae430806d956c3eb215fab43f3cad10c9bfc987b17f41fc7bad435"
-    sha256 cellar: :any, monterey: "91ad8c5205a665fdd50c582e38c5e2a916bdec51e6d1a0d06f751909dabc5b97"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/gz-sensors8.rb
+++ b/Formula/gz-sensors8.rb
@@ -4,15 +4,9 @@ class GzSensors8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-8.0.0.tar.bz2"
   sha256 "17a3be4fbcc338a22928c7d5b96d4369f05be801470e37f580c0f83299609bf4"
   license "Apache-2.0"
-  revision 11
+  revision 12
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "f79ef66014773b88dc30e5b782a1bb7c84ce6d4a50eb1097cfae2523d774c4a6"
-    sha256 cellar: :any, monterey: "ff00631077ea20e0cee19e253801860b5e5b87985ad45651afe9c88215fa3cfd"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/gz-sim7.rb
+++ b/Formula/gz-sim7.rb
@@ -4,15 +4,9 @@ class GzSim7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-7.7.0.tar.bz2"
   sha256 "48d89b5e913eb8bb9925373eeb18616d512cd43f7e45be4413ce8c66bf1ca0d1"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "7d8c7a93b32c27e69134b3a1c40b01bcc64828fd207d6d6878e78312c1009b81"
-    sha256 monterey: "b68273af95ed99f9e9b6aebf1fea11540e46f50504811786cfe3f24e944ff4ff"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build

--- a/Formula/gz-sim8.rb
+++ b/Formula/gz-sim8.rb
@@ -4,15 +4,9 @@ class GzSim8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-8.1.0.tar.bz2"
   sha256 "7a2f3e13f7eb2a15f2fd012df03cd14e53b841d141f03b4841966252b3bf5263"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "63f5f07c770f86aed649a8b41d7d870086cb4ad346eab4dc8204d8b5dcd76401"
-    sha256 monterey: "ae006698a9a6b0f888b468e45a6b2db480c154922902cb814e9d116e43ff746c"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build

--- a/Formula/gz-transport12.rb
+++ b/Formula/gz-transport12.rb
@@ -4,15 +4,9 @@ class GzTransport12 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/gz-transport-12.2.1.tar.bz2"
   sha256 "62fb97a722dea804da262610061688f675222d4e33a7a1a59868fdefe6ae2d92"
   license "Apache-2.0"
-  revision 10
+  revision 11
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport12"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "ad6eec7e263e57eeae94c2fc634aded02d51041454797cc00c4b4799a212ec2a"
-    sha256 monterey: "020c7ea6d78e57935e45b1dd76cce8262e9e95a84085c048cdf4c4db6e75123f"
-  end
 
   depends_on "doxygen" => [:build, :optional]
 

--- a/Formula/gz-transport13.rb
+++ b/Formula/gz-transport13.rb
@@ -4,15 +4,9 @@ class GzTransport13 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/gz-transport-13.0.0.tar.bz2"
   sha256 "d44b4ed089110a1a7dfc3b59f782e33f27668a980ededdbf3c21171f72a82968"
   license "Apache-2.0"
-  revision 11
+  revision 12
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport13"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "20d0114af142a3d649ffcb97162d0defe09414a9e9207a95ea00bb70f4519e43"
-    sha256 monterey: "f3ac255ddb08e8717c4fa82774c621d78367032dad368487407a7878f4647598"
-  end
 
   depends_on "doxygen" => [:build, :optional]
   depends_on "pybind11" => :build

--- a/Formula/ignition-fuel-tools4.rb
+++ b/Formula/ignition-fuel-tools4.rb
@@ -4,15 +4,9 @@ class IgnitionFuelTools4 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-fuel-tools/releases/ignition-fuel-tools4-4.9.1.tar.bz2"
   sha256 "35b8cdceae46f50360081eb1b310366ae085a8c64d88fee7175f2b0582e454a2"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools4"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "0fa33a0199253e953faad5ef0f5faf2896e3ebdc26833851ca23a3e7a067bc63"
-    sha256 cellar: :any, monterey: "5db63350e38454c7010e225468e2809a6918528e223071d0ee4662adf702ac25"
-  end
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -4,15 +4,9 @@ class IgnitionFuelTools7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-fuel-tools/releases/ignition-fuel-tools7-7.3.0.tar.bz2"
   sha256 "59d06f23a054742e1f97c1f0f709e2a38c341ce96f560d6e09b3dba011dd79a5"
   license "Apache-2.0"
-  revision 19
+  revision 20
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "55eb30a0ffcceaf5d7f261093bf442614f4adaacb43d8c1769844ced0ff7bbcf"
-    sha256 cellar: :any, monterey: "81bf42ed1df829cc97162ca23969cdb7438d85a3010af842feb6917504709247"
-  end
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-gazebo3.rb
+++ b/Formula/ignition-gazebo3.rb
@@ -4,15 +4,9 @@ class IgnitionGazebo3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gazebo/releases/ignition-gazebo3-3.15.1.tar.bz2"
   sha256 "c801d4205f8f88fca813cbf699cf6a077536d430e6c312a85520d6f50a7052bd"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo3"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "4dc2a5907a2eb7368d0b6c81b72ff4bf66b23a6b98f1346061c80c13788de065"
-    sha256 monterey: "c3330f1566d4f664fe6563c46c293f4dfb92e8420a316ee65bd9bf8b1789c101"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -4,15 +4,9 @@ class IgnitionGazebo6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gazebo/releases/ignition-gazebo6-6.16.0.tar.bz2"
   sha256 "1e61148e8b49a5a20f4cac1e116ce5c4d8de3718a1d26e41a1cec394ce5ea9e4"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "bdcc01fd3527aea61d56e64c7212646122019aebac4f239e62e650219dd13f39"
-    sha256 monterey: "d205cc005e2f14b33a207a8df83031539e24a10a5b916559bff30e2652b0349b"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build

--- a/Formula/ignition-gui3.rb
+++ b/Formula/ignition-gui3.rb
@@ -4,15 +4,9 @@ class IgnitionGui3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gui/releases/ignition-gui3-3.12.0.tar.bz2"
   sha256 "f53ee05d844449b900ecb30d5e1f812fd3f7e9e28630d309b7d8d11add3c3b1c"
   license "Apache-2.0"
-  revision 22
+  revision 23
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui3"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "884de6481ffec3c1ceec189f5efa981705a985d00fda817785a7a2bfd7b704ab"
-    sha256 monterey: "62e1cd53742d6f6d66f064512850717e21449435830d8b177bbd38d24e7c2dc1"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -4,15 +4,9 @@ class IgnitionGui6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gui/releases/ignition-gui6-6.8.0.tar.bz2"
   sha256 "dd4f26100f4d1343f068ba36f2b8394a0cddb337efde7b4a21c1b0f66ce496c9"
   license "Apache-2.0"
-  revision 22
+  revision 23
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "086c8211b365a4fa94de13919f0c52f30f70b8a9d8e2da32b4ccbbfada7f7b32"
-    sha256 monterey: "ae832590f33b6013e94dddd268b9d8c521cadf9d5aebc3579b1a746f33cd920f"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/ignition-launch2.rb
+++ b/Formula/ignition-launch2.rb
@@ -4,15 +4,9 @@ class IgnitionLaunch2 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-launch/releases/ignition-launch2-2.3.1.tar.bz2"
   sha256 "984e2a5df03ca220960470b6b59728edf3cd570314fbad6435b67cb26c9b7e4e"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "ign-launch2"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "4dcfa3ca8ed17aae63aadbd03d79177dc8613a83a9e67fac3ae7ab5f769a5546"
-    sha256 monterey: "66fa00c2204d9c0d8dae94e7dbded814f2b17c2007948d8060adbad32e277afe"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-launch5.rb
+++ b/Formula/ignition-launch5.rb
@@ -4,15 +4,9 @@ class IgnitionLaunch5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-launch/releases/ignition-launch5-5.3.0.tar.bz2"
   sha256 "84d356b9c85609da1bb7feda2f90ae6d1a1fd2d6713b284799d5605de42e2613"
   license "Apache-2.0"
-  revision 20
+  revision 21
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "ign-launch5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "c27d8f1117999e775f8a23241e9735cdaec46bdf243157551a7c8f0bb84872ce"
-    sha256 monterey: "c008f9998e7d156d2a404c7c405331e426266e84cb1f466efdf2f9ee70629aa2"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/ignition-msgs5.rb
+++ b/Formula/ignition-msgs5.rb
@@ -4,15 +4,9 @@ class IgnitionMsgs5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs5-5.11.0.tar.bz2"
   sha256 "59a03770c27b4cdb6d0b0f3de9f10f1c748a47b45376a297e1f30900edb893fd"
   license "Apache-2.0"
-  revision 20
+  revision 21
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "54787254bfbec81fd787dcd60c087e6bef9cedda9863a54afd448f0a3cbe5390"
-    sha256 cellar: :any, monterey: "41d35f3c9fe3264782a6151dd9af944a52c94eb2b6d9385ab36a7868917a9dc6"
-  end
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-msgs8.rb
+++ b/Formula/ignition-msgs8.rb
@@ -4,15 +4,9 @@ class IgnitionMsgs8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs8-8.7.0.tar.bz2"
   sha256 "b17a8e16fe56a84891bd0654a2ac09427e9a567b9cd2255bb2cfa830f8e1af45"
   license "Apache-2.0"
-  revision 21
+  revision 22
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "9e16ba2fc29ecb442eff60310237c889c0d41d5fb7e8762696005714e8dfc23a"
-    sha256 cellar: :any, monterey: "e9306cd07252eb5135458cbd8b560e4626698665c6dd50bce847da708a7850f1"
-  end
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-sensors3.rb
+++ b/Formula/ignition-sensors3.rb
@@ -4,15 +4,9 @@ class IgnitionSensors3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-sensors/releases/ignition-sensors3-3.6.0.tar.bz2"
   sha256 "b64b187333907a9e866307ccc76649672e0df9b6bdfb4a390929ebbcaa83ce64"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors3"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "90b1bdbe3f15d15118422dd2ccf91669c6451d86d823bcdb39d6efef8cacda07"
-    sha256 monterey: "2207d00f0f151e3c6892a5e642cb6e820f3d85ddff685c6c6990248244e28512"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-sensors6.rb
+++ b/Formula/ignition-sensors6.rb
@@ -4,15 +4,9 @@ class IgnitionSensors6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-sensors/releases/ignition-sensors6-6.8.0.tar.bz2"
   sha256 "4bd5cd637dc624fe8d2a5244b3282ed74558c0fd50e040ba4770c312fcb8c1f5"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "2440b4841e8983a45c61472b2e5103e9abde55997213613a62b3592ccc6571c0"
-    sha256 cellar: :any, monterey: "804cb7c0f425ae10727173ab9bd7265e136160acdbe9672c4e8886e8c103246a"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -4,16 +4,10 @@ class IgnitionTransport11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases/ignition-transport11-11.4.1.tar.bz2"
   sha256 "f18501cbd5c78b584b3db1960a3049d6ae416bab7f0289af64eadda13d1c5da5"
   license "Apache-2.0"
-  revision 14
+  revision 15
   version_scheme 1
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport11"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "779ff797bd01125bf594031df8a30273e18a953d7502c22ac660951c01f76aca"
-    sha256 monterey: "29939630d621a35ec6589e7d05bdc48da0bcfe0bbbc7bc3fda332fa9006867b4"
-  end
 
   depends_on "doxygen" => [:build, :optional]
 

--- a/Formula/ignition-transport8.rb
+++ b/Formula/ignition-transport8.rb
@@ -4,15 +4,9 @@ class IgnitionTransport8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases/ignition-transport8-8.5.0.tar.bz2"
   sha256 "5edd15699e35ade5ad2f814af1f5e96a866f7908e16b55333abb23978f44d4c6"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "26c7ff18377167c295718b523ba46b8ee757a7d75e81c0baf9a0c91d4354f5b1"
-    sha256 monterey: "15fd8a5b5d9f5d27ca8e74f0e07b843711e380541edd48cf01a29c95341aa4e9"
-  end
 
   depends_on "doxygen" => [:build, :optional]
 


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/2571.

Commits for the pull request were created with the following command:

~~~
for f in $(grep -l '^ *bottle do' $(grep -rlI depend.*protobuf .) | sort)
do
  brew bump-revision --remove-bottle-block --message="broken bottle" $f
done
~~~