### PR TITLE
Citadel: rebuild some bottles for protobuf

### DIFF
--- a/Formula/ignition-fuel-tools4.rb
+++ b/Formula/ignition-fuel-tools4.rb
@@ -4,7 +4,7 @@ class IgnitionFuelTools4 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-fuel-tools/releases/ignition-fuel-tools4-4.9.1.tar.bz2"
   sha256 "35b8cdceae46f50360081eb1b310366ae085a8c64d88fee7175f2b0582e454a2"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools4"
 

--- a/Formula/ignition-fuel-tools4.rb
+++ b/Formula/ignition-fuel-tools4.rb
@@ -8,6 +8,12 @@ class IgnitionFuelTools4 < Formula
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools4"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, ventura:  "c2c532474c14c3427e4b56387e4d6035a8e4fb714aca23fc9d0e51aab845a8e6"
+    sha256 cellar: :any, monterey: "0c28173c01bdd882120bac5faa34d05cab3fc0e891dc8510a44a1f02fa1084d1"
+  end
+
   depends_on "cmake"
   depends_on "ignition-cmake2"
   depends_on "ignition-common3"

--- a/Formula/ignition-msgs5.rb
+++ b/Formula/ignition-msgs5.rb
@@ -8,6 +8,12 @@ class IgnitionMsgs5 < Formula
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs5"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, ventura:  "285ace59f4be33400615d7c0c399faaa619b0af289d0343bbda3c5aec7d6f28d"
+    sha256 cellar: :any, monterey: "31fda8b53b226b1d4ee6b27d5b418124d5ec6c22034d6c4444388d089767aa18"
+  end
+
   depends_on "cmake"
   depends_on "ignition-cmake2"
   depends_on "ignition-math6"

--- a/Formula/ignition-msgs5.rb
+++ b/Formula/ignition-msgs5.rb
@@ -4,7 +4,7 @@ class IgnitionMsgs5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs5-5.11.0.tar.bz2"
   sha256 "59a03770c27b4cdb6d0b0f3de9f10f1c748a47b45376a297e1f30900edb893fd"
   license "Apache-2.0"
-  revision 21
+  revision 22
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs5"
 

--- a/Formula/ignition-transport8.rb
+++ b/Formula/ignition-transport8.rb
@@ -8,6 +8,12 @@ class IgnitionTransport8 < Formula
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport8"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 ventura:  "6d0298e923c414060ab6e8361680f7f27c3e09872e934bf4435a92b20d3db1ba"
+    sha256 monterey: "75c09ea82b714c5a6d98ce08b25141786f4cef164dbe1435661d7bc427962231"
+  end
+
   depends_on "doxygen" => [:build, :optional]
 
   depends_on "cmake"

--- a/Formula/ignition-transport8.rb
+++ b/Formula/ignition-transport8.rb
@@ -4,7 +4,7 @@ class IgnitionTransport8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases/ignition-transport8-8.5.0.tar.bz2"
   sha256 "5edd15699e35ade5ad2f814af1f5e96a866f7908e16b55333abb23978f44d4c6"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport8"
 


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/2571.

This rebuilds the dependencies shared by Citadel and gazebo11, with commits generated using the following command:

~~~
for f in $(grep -L '^ *bottle do' $(grep -rnI 'depend.*"[gsi][zdg][-fn]' gazebo11.rb | sed -e 's@.* "@@' -e 's@"@.rb@'))
do
    brew bump-revision --message="rebuild bottle" $f
done
~~~