### PR TITLE
Fix hash syntax

### DIFF
--- a/Formula/gz-gui7.rb
+++ b/Formula/gz-gui7.rb
@@ -54,7 +54,7 @@ class GzGui7 < Formula
       # print command and check return code
       system cmd, *args
       # check that library was loaded properly
-      _, stderr = system_command(cmd, args: args)
+      _, stderr = system_command(cmd, args:)
       error_string = "Error while loading the library"
       assert stderr.exclude?(error_string), error_string
     end

--- a/Formula/gz-gui8.rb
+++ b/Formula/gz-gui8.rb
@@ -54,7 +54,7 @@ class GzGui8 < Formula
       # print command and check return code
       system cmd, *args
       # check that library was loaded properly
-      _, stderr = system_command(cmd, args: args)
+      _, stderr = system_command(cmd, args:)
       error_string = "Error while loading the library"
       assert stderr.exclude?(error_string), error_string
     end

--- a/Formula/gz-gui9.rb
+++ b/Formula/gz-gui9.rb
@@ -47,7 +47,7 @@ class GzGui9 < Formula
       # print command and check return code
       system cmd, *args
       # check that library was loaded properly
-      _, stderr = system_command(cmd, args: args)
+      _, stderr = system_command(cmd, args:)
       error_string = "Error while loading the library"
       assert stderr.exclude?(error_string), error_string
     end

--- a/Formula/gz-launch6.rb
+++ b/Formula/gz-launch6.rb
@@ -60,7 +60,7 @@ class GzLaunch6 < Formula
       # print command and check return code
       system cmd, *args
       # check that library was loaded properly
-      _, stderr = system_command(cmd, args: args)
+      _, stderr = system_command(cmd, args:)
       error_string = "Error while loading the library"
       assert stderr.exclude?(error_string), error_string
     end

--- a/Formula/gz-launch7.rb
+++ b/Formula/gz-launch7.rb
@@ -60,7 +60,7 @@ class GzLaunch7 < Formula
       # print command and check return code
       system cmd, *args
       # check that library was loaded properly
-      _, stderr = system_command(cmd, args: args)
+      _, stderr = system_command(cmd, args:)
       error_string = "Error while loading the library"
       assert stderr.exclude?(error_string), error_string
     end

--- a/Formula/gz-launch8.rb
+++ b/Formula/gz-launch8.rb
@@ -53,7 +53,7 @@ class GzLaunch8 < Formula
       # print command and check return code
       system cmd, *args
       # check that library was loaded properly
-      _, stderr = system_command(cmd, args: args)
+      _, stderr = system_command(cmd, args:)
       error_string = "Error while loading the library"
       assert stderr.exclude?(error_string), error_string
     end

--- a/Formula/gz-physics6.rb
+++ b/Formula/gz-physics6.rb
@@ -58,7 +58,7 @@ class GzPhysics6 < Formula
       # print command and check return code
       system cmd, *args
       # check that library was loaded properly
-      _, stderr = system_command(cmd, args: args)
+      _, stderr = system_command(cmd, args:)
       error_string = "Error while loading the library"
       assert stderr.exclude?(error_string), error_string
     end

--- a/Formula/gz-physics7.rb
+++ b/Formula/gz-physics7.rb
@@ -57,7 +57,7 @@ class GzPhysics7 < Formula
       # print command and check return code
       system cmd, *args
       # check that library was loaded properly
-      _, stderr = system_command(cmd, args: args)
+      _, stderr = system_command(cmd, args:)
       error_string = "Error while loading the library"
       assert stderr.exclude?(error_string), error_string
     end

--- a/Formula/gz-physics8.rb
+++ b/Formula/gz-physics8.rb
@@ -50,7 +50,7 @@ class GzPhysics8 < Formula
       # print command and check return code
       system cmd, *args
       # check that library was loaded properly
-      _, stderr = system_command(cmd, args: args)
+      _, stderr = system_command(cmd, args:)
       error_string = "Error while loading the library"
       assert stderr.exclude?(error_string), error_string
     end

--- a/Formula/gz-rendering7.rb
+++ b/Formula/gz-rendering7.rb
@@ -53,7 +53,7 @@ class GzRendering7 < Formula
       # print command and check return code
       system cmd, *args
       # check that library was loaded properly
-      _, stderr = system_command(cmd, args: args)
+      _, stderr = system_command(cmd, args:)
       error_string = "Error while loading the library"
       assert stderr.exclude?(error_string), error_string
     end

--- a/Formula/gz-rendering8.rb
+++ b/Formula/gz-rendering8.rb
@@ -53,7 +53,7 @@ class GzRendering8 < Formula
       # print command and check return code
       system cmd, *args
       # check that library was loaded properly
-      _, stderr = system_command(cmd, args: args)
+      _, stderr = system_command(cmd, args:)
       error_string = "Error while loading the library"
       assert stderr.exclude?(error_string), error_string
     end

--- a/Formula/gz-rendering9.rb
+++ b/Formula/gz-rendering9.rb
@@ -47,7 +47,7 @@ class GzRendering9 < Formula
       # print command and check return code
       system cmd, *args
       # check that library was loaded properly
-      _, stderr = system_command(cmd, args: args)
+      _, stderr = system_command(cmd, args:)
       error_string = "Error while loading the library"
       assert stderr.exclude?(error_string), error_string
     end

--- a/Formula/gz-sim7.rb
+++ b/Formula/gz-sim7.rb
@@ -76,7 +76,7 @@ class GzSim7 < Formula
       # print command and check return code
       system cmd, *args
       # check that library was loaded properly
-      _, stderr = system_command(cmd, args: args)
+      _, stderr = system_command(cmd, args:)
       error_string = "Error while loading the library"
       assert stderr.exclude?(error_string), error_string
     }

--- a/Formula/gz-sim8.rb
+++ b/Formula/gz-sim8.rb
@@ -76,7 +76,7 @@ class GzSim8 < Formula
       # print command and check return code
       system cmd, *args
       # check that library was loaded properly
-      _, stderr = system_command(cmd, args: args)
+      _, stderr = system_command(cmd, args:)
       error_string = "Error while loading the library"
       assert stderr.exclude?(error_string), error_string
     }

--- a/Formula/gz-sim9.rb
+++ b/Formula/gz-sim9.rb
@@ -69,7 +69,7 @@ class GzSim9 < Formula
       # print command and check return code
       system cmd, *args
       # check that library was loaded properly
-      _, stderr = system_command(cmd, args: args)
+      _, stderr = system_command(cmd, args:)
       error_string = "Error while loading the library"
       assert stderr.exclude?(error_string), error_string
     }

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -69,7 +69,7 @@ class IgnitionGazebo6 < Formula
       # print command and check return code
       system cmd, *args
       # check that library was loaded properly
-      _, stderr = system_command(cmd, args: args)
+      _, stderr = system_command(cmd, args:)
       error_string = "Error while loading the library"
       assert stderr.exclude?(error_string), error_string
     }

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -63,7 +63,7 @@ class IgnitionGui6 < Formula
       # print command and check return code
       system cmd, *args
       # check that library was loaded properly
-      _, stderr = system_command(cmd, args: args)
+      _, stderr = system_command(cmd, args:)
       error_string = "Error while loading the library"
       assert stderr.exclude?(error_string), error_string
     end

--- a/Formula/ignition-launch5.rb
+++ b/Formula/ignition-launch5.rb
@@ -68,7 +68,7 @@ class IgnitionLaunch5 < Formula
       # print command and check return code
       system cmd, *args
       # check that library was loaded properly
-      _, stderr = system_command(cmd, args: args)
+      _, stderr = system_command(cmd, args:)
       error_string = "Error while loading the library"
       assert stderr.exclude?(error_string), error_string
     end

--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -65,7 +65,7 @@ class IgnitionPhysics5 < Formula
       # print command and check return code
       system cmd, *args
       # check that library was loaded properly
-      _, stderr = system_command(cmd, args: args)
+      _, stderr = system_command(cmd, args:)
       error_string = "Error while loading the library"
       assert stderr.exclude?(error_string), error_string
     end

--- a/Formula/ignition-rendering6.rb
+++ b/Formula/ignition-rendering6.rb
@@ -54,7 +54,7 @@ class IgnitionRendering6 < Formula
       # print command and check return code
       system cmd, *args
       # check that library was loaded properly
-      _, stderr = system_command(cmd, args: args)
+      _, stderr = system_command(cmd, args:)
       error_string = "Error while loading the library"
       assert stderr.exclude?(error_string), error_string
     end

--- a/Formula/ogre2.2.rb
+++ b/Formula/ogre2.2.rb
@@ -137,7 +137,7 @@ class Ogre22 < Formula
       # print command and check return code
       system cmd, *args
       # check that library was loaded properly
-      _, stderr = system_command(cmd, args: args)
+      _, stderr = system_command(cmd, args:)
       error_string = "Error while loading the library"
       assert stderr.exclude?(error_string), error_string
     end

--- a/Formula/ogre2.3.rb
+++ b/Formula/ogre2.3.rb
@@ -114,7 +114,7 @@ class Ogre23 < Formula
       # print command and check return code
       system cmd, *args
       # check that library was loaded properly
-      _, stderr = system_command(cmd, args: args)
+      _, stderr = system_command(cmd, args:)
       error_string = "Error while loading the library"
       assert stderr.exclude?(error_string), error_string
     end


### PR DESCRIPTION
Follow-up to Homebrew/brew#16848.

First noticed in the following build:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_rendering7-install_bottle-homebrew-amd64&build=87)](https://build.osrfoundation.org/view/gz-garden/job/gz_rendering7-install_bottle-homebrew-amd64/87/) https://build.osrfoundation.org/view/gz-garden/job/gz_rendering7-install_bottle-homebrew-amd64/87/

~~~
+ brew audit --strict gz-rendering7
osrf/simulation/gz-rendering7
  * line 56, col 45: Omit the hash value.
Error: 1 problem in 1 formula detected.
~~~