### PR TITLE
Add scripts to help identify bottled / unbottled formulae

### DIFF
--- a/.github/ci/bottled_dependents.sh
+++ b/.github/ci/bottled_dependents.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Copyright (C) 2024 Open Source Robotics Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# The script will print the bottled dependents from the osrf/simulation
+# tap of a specified formula.
+#
+# Usage:
+# $ ./bottled_dependents.sh <formula>
+#
+# For example, to print the bottled dependents of gz-msgs10 from the
+# osrf/simulation tap:
+#
+# ./bottled_dependents.sh gz-msgs10
+
+FORMULA=${1}
+
+if [ $# -ne 1 ]; then
+  echo "bottled_dependents.sh <formula>"
+  exit 1
+fi
+
+for f in $(brew uses ${FORMULA} --formulae --eval-all | grep ^osrf/simulation/)
+do
+  # brew unbottled prints "already bottled" for bottled formulae
+  if brew unbottled $f | grep --quiet "already bottled"; then
+    echo $f
+  fi
+done

--- a/.github/ci/unbottled_dependencies.bash
+++ b/.github/ci/unbottled_dependencies.bash
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Copyright (C) 2024 Open Source Robotics Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# The script will print the unbottled dependencies from the osrf/simulation
+# tap of a specified formula.
+#
+# Usage:
+# $ ./unbottled_dependencies.bash <formula>
+#
+# For example, to print the unbottled dependencies of gz-harmonic from the
+# osrf/simulation tap:
+#
+# ./unbottled_dependencies.bash gz-harmonic
+
+FORMULA=${1}
+
+if [[ $# -ne 1 ]]; then
+  echo "./unbottled_dependencies.bash <formula>"
+  exit 1
+fi
+
+for f in $(brew deps ${FORMULA} --full-name | grep osrf/simulation)
+do
+  # brew unbottled prints "already bottled" for bottled formulae
+  # but has different output for formulae that are "ready to bottle" or
+  # that have "unbottled deps". So just echo the name of any formula for which
+  # `brew unbottled` doesn't print "already bottled"
+  brew unbottled $f | grep "already bottled" > /dev/null \
+    || echo $f
+done

--- a/.github/ci/unbottled_dependencies.bash
+++ b/.github/ci/unbottled_dependencies.bash
@@ -27,17 +27,18 @@
 
 FORMULA=${1}
 
-if [[ $# -ne 1 ]]; then
+if [ $# -ne 1 ]; then
   echo "./unbottled_dependencies.bash <formula>"
   exit 1
 fi
 
-for f in $(brew deps ${FORMULA} --full-name | grep osrf/simulation)
+for f in $(brew deps ${FORMULA} --full-name | grep ^osrf/simulation/)
 do
   # brew unbottled prints "already bottled" for bottled formulae
   # but has different output for formulae that are "ready to bottle" or
   # that have "unbottled deps". So just echo the name of any formula for which
   # `brew unbottled` doesn't print "already bottled"
-  brew unbottled $f | grep "already bottled" > /dev/null \
-    || echo $f
+  if ! brew unbottled $f | grep --quiet "already bottled"; then
+    echo $f
+  fi
 done

--- a/.github/ci/unbottled_dependencies.sh
+++ b/.github/ci/unbottled_dependencies.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Copyright (C) 2024 Open Source Robotics Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/.github/ci/unbottled_dependencies.sh
+++ b/.github/ci/unbottled_dependencies.sh
@@ -18,17 +18,17 @@
 # tap of a specified formula.
 #
 # Usage:
-# $ ./unbottled_dependencies.bash <formula>
+# $ ./unbottled_dependencies.sh <formula>
 #
 # For example, to print the unbottled dependencies of gz-harmonic from the
 # osrf/simulation tap:
 #
-# ./unbottled_dependencies.bash gz-harmonic
+# ./unbottled_dependencies.sh gz-harmonic
 
 FORMULA=${1}
 
 if [ $# -ne 1 ]; then
-  echo "./unbottled_dependencies.bash <formula>"
+  echo "unbottled_dependencies.sh <formula>"
   exit 1
 fi
 


### PR DESCRIPTION
I'm working on a GitHub actions workflows to automate removing broken bottles and rebuilding missing bottles, and I'm starting with two scripts:

* `unbottled_dependencies.sh` prints the unbottled dependencies needed by a given formula (useful for rebuilding bottles)
* `bottled_dependents.sh` prints the bottled dependents that use a given formula (useful for removing broken bottles)

## unbottled_dependencies.sh examples

Gazebo Ionic not yet bottled, so it has lots of unbottled dependencies:

~~~
$ ./unbottled_dependencies.sh gz-ionic
osrf/simulation/gz-cmake4
osrf/simulation/gz-common6
osrf/simulation/gz-fuel-tools10
osrf/simulation/gz-gui9
osrf/simulation/gz-launch8
osrf/simulation/gz-math8
osrf/simulation/gz-msgs11
osrf/simulation/gz-physics8
osrf/simulation/gz-plugin3
osrf/simulation/gz-rendering9
osrf/simulation/gz-sensors9
osrf/simulation/gz-sim9
osrf/simulation/gz-transport14
osrf/simulation/gz-utils3
osrf/simulation/sdformat15
~~~

but several other collections have some bottles missing:

~~~
$ ./unbottled_dependencies.sh gz-harmonic
osrf/simulation/gz-physics7
~~~

~~~
$ ./unbottled_dependencies.sh gz-garden
osrf/simulation/gz-fuel-tools8
osrf/simulation/gz-gui7
osrf/simulation/gz-launch6
osrf/simulation/gz-msgs9
osrf/simulation/gz-physics6
osrf/simulation/gz-sensors7
osrf/simulation/gz-sim7
osrf/simulation/gz-transport12
~~~

## bottled_dependents.sh examples

When a new protobuf version lands in homebrew-core, we have to remove bottles for all dependents that use `gz-msgs*`:

~~~
$ ./bottled_dependents.sh gz-msgs10
osrf/simulation/gz-fuel-tools9
osrf/simulation/gz-gui8
osrf/simulation/gz-launch7
osrf/simulation/gz-sensors8
osrf/simulation/gz-sim8
osrf/simulation/gz-transport13
~~~