### PR TITLE
Remove bottles broken by protobuf 26.0

### DIFF
--- a/Formula/gz-fuel-tools9.rb
+++ b/Formula/gz-fuel-tools9.rb
@@ -4,14 +4,9 @@ class GzFuelTools9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-9.0.2.tar.bz2"
   sha256 "6d35036365043b4a66f107900e41446b194ddc626347ae14f24e1a3bb091bc5e"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "878b5422abd09bfdf4e111d0be9541d9feb3c57ba9a50e63caa6f43c2f0b6918"
-    sha256 cellar: :any, monterey: "3d30c3349feefb510839d0a9a1f6f84ee6a29cfff48566db2c58da6345eca01b"
-  end
 
   depends_on "cmake"
   depends_on "gz-cmake3"

--- a/Formula/gz-gui8.rb
+++ b/Formula/gz-gui8.rb
@@ -4,14 +4,9 @@ class GzGui8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-8.1.0.tar.bz2"
   sha256 "a7fe8addd0e92770d73e099103bf98b0372842efa08bebaa27248e6a66eecb92"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "4494c14344e63c9a782efb1011d3b47d496ca643cc473cc5ad8fd025962176b9"
-    sha256 monterey: "6f8c2822a8bbf6a04a79c8e7c11a1278eb0709c95e4c9239217faf79351b4779"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/gz-launch7.rb
+++ b/Formula/gz-launch7.rb
@@ -4,15 +4,9 @@ class GzLaunch7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-7.0.0.tar.bz2"
   sha256 "252cb170fd97d074e9d13536cda736cd481c8c2e6df30a4ee225cfb9dcd92e77"
   license "Apache-2.0"
-  revision 15
+  revision 16
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "b047fe2978d61222f35fcabe08f017b1c5c147dbae7643c08ab403184b7d21fc"
-    sha256 monterey: "8c2bd3b6f68a08e11d7394cb7926555d3b008359836762fa446b5b88c4e2fcb6"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/gz-msgs10.rb
+++ b/Formula/gz-msgs10.rb
@@ -4,14 +4,9 @@ class GzMsgs10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/gz-msgs-10.1.1.tar.bz2"
   sha256 "665a396c6982b14ff51cd0886d19906de28bd6ac9b9d41e19a7ea5d484cceb3e"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs10"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "cce1dd467dba52206c03e7f5e4e3aae9c871c6fff299791a8339b2f4f0dba5c7"
-    sha256 monterey: "8aca3d4937124745873b4b3e9b232c7fa6b8ea1d3c22e442ba4247074199cf73"
-  end
 
   depends_on "cmake"
   depends_on "gz-cmake3"

--- a/Formula/gz-sensors8.rb
+++ b/Formula/gz-sensors8.rb
@@ -4,14 +4,9 @@ class GzSensors8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-8.0.1.tar.bz2"
   sha256 "fc67417da4b6675050e52789d64c4298f1088daca3eebd036dc3be732f428bce"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "714a0811b944c3b76ff989d764bee042e26575aaa963e9585cd4f9bf7467b318"
-    sha256 cellar: :any, monterey: "91f9419f9372c99d45d7afadee6caae75b7e14eddeef4254452f69176fe5a312"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/gz-sim8.rb
+++ b/Formula/gz-sim8.rb
@@ -4,14 +4,9 @@ class GzSim8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-8.2.0.tar.bz2"
   sha256 "f5a7558a7b0c3a58c07585ada77b68b723dd5cf909132386c3b5450400116521"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "668ab748a491016f8bb736d743334a900b63682678c9e48b8f210d6beee2a6db"
-    sha256 monterey: "8653c15b6fed4ce19596657c9ee1920b5b40c78b9179c772e21c67108670a4fe"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build

--- a/Formula/gz-transport13.rb
+++ b/Formula/gz-transport13.rb
@@ -5,14 +5,9 @@ class GzTransport13 < Formula
   version "13.2.0-pre1"
   sha256 "da548d92735c44bbd5929f18e0a3830ae65a3046c9b28ae27ec9033121d70743"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport13"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "5b84493f06b23813be39487052b74adfaeadcf46b5c9284f96055209f29fcd50"
-    sha256 monterey: "0f087d8cf7eca816e35db8e6b224f371c3e3d2d5446e1d41911d2c73a7adaf11"
-  end
 
   depends_on "doxygen" => [:build, :optional]
   depends_on "pybind11" => :build

--- a/Formula/ignition-citadel.rb
+++ b/Formula/ignition-citadel.rb
@@ -6,16 +6,10 @@ class IgnitionCitadel < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-citadel/releases/ignition-citadel-1.0.2.tar.bz2"
   sha256 "2b99e7476093e78841c63d4ec348c6cf7c9d650a2e5787011723142c9f917659"
   license "Apache-2.0"
-  revision 10
+  revision 11
   version_scheme 1
 
   head "https://github.com/gazebosim/gz-citadel.git", branch: "main"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "5848224c50c6206f59b7e5078078048975d922e18fdd36e95e4868441d0bc9fa"
-    sha256 cellar: :any, monterey: "5bf26663eb735e111d6b6d3a191a30dbbfb9237f6f07999d06f0e2ca041095ac"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-fortress.rb
+++ b/Formula/ignition-fortress.rb
@@ -6,16 +6,10 @@ class IgnitionFortress < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-fortress/releases/ignition-fortress-1.0.3.tar.bz2"
   sha256 "eedbfb01e18038756eb596fa8f1c8aa955ca2be029fe40bb842ffee4d4452323"
   license "Apache-2.0"
-  revision 8
+  revision 9
   version_scheme 1
 
   head "https://github.com/gazebosim/gz-fortress.git", branch: "main"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "c2df8137576ded962712d1ba4e80e6e5353dc1f7acfd967256226c2ee8937308"
-    sha256 cellar: :any, monterey: "74578c1c39490feabfb9ec68a8356ed77ccb1aeddb50019ca889a78db1d89dd4"
-  end
 
   depends_on "cmake" => :build
   depends_on "python@3.11" => [:build, :test]

--- a/Formula/ignition-fuel-tools4.rb
+++ b/Formula/ignition-fuel-tools4.rb
@@ -4,15 +4,9 @@ class IgnitionFuelTools4 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-fuel-tools/releases/ignition-fuel-tools4-4.9.1.tar.bz2"
   sha256 "35b8cdceae46f50360081eb1b310366ae085a8c64d88fee7175f2b0582e454a2"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools4"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "f70d1702a8eb967e1af14d9bd2650fb3fd2329c92acb5d93c879c306c7e099d8"
-    sha256 cellar: :any, monterey: "a5ec1e1a8ab8f7ad6ada9df04c7442caf826d336e0e474df0588ba50c1759fd7"
-  end
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -4,15 +4,9 @@ class IgnitionFuelTools7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-fuel-tools/releases/ignition-fuel-tools7-7.3.0.tar.bz2"
   sha256 "59d06f23a054742e1f97c1f0f709e2a38c341ce96f560d6e09b3dba011dd79a5"
   license "Apache-2.0"
-  revision 23
+  revision 24
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "7d37a35ac54d83b77f5a38c847b8410b5bc9eb04d798047854742ba382419f31"
-    sha256 cellar: :any, monterey: "6fd6d01728068d08f869e64a26846835b493297c5fa5386b9392e561ed222466"
-  end
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-gazebo3.rb
+++ b/Formula/ignition-gazebo3.rb
@@ -4,15 +4,9 @@ class IgnitionGazebo3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gazebo/releases/ignition-gazebo3-3.15.1.tar.bz2"
   sha256 "c801d4205f8f88fca813cbf699cf6a077536d430e6c312a85520d6f50a7052bd"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo3"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "c0ef184e31fe448b88d906affacf894c842c123b9439c1a054f2e09a889b7055"
-    sha256 monterey: "665b0b595e5ea5e4f3325966f512630d20ebb5e7c063773bcc595e4b75c3d8d6"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -4,15 +4,9 @@ class IgnitionGazebo6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gazebo/releases/ignition-gazebo6-6.16.0.tar.bz2"
   sha256 "1e61148e8b49a5a20f4cac1e116ce5c4d8de3718a1d26e41a1cec394ce5ea9e4"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "683ce5147c9469671581d8bd14100563a30388a717397e73c179d2c6a2afa4b6"
-    sha256 monterey: "1d20e8f40d07705512f80542c0f8088154d74575007238de074c2dfe1d88200a"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build

--- a/Formula/ignition-gui3.rb
+++ b/Formula/ignition-gui3.rb
@@ -4,15 +4,9 @@ class IgnitionGui3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gui/releases/ignition-gui3-3.12.0.tar.bz2"
   sha256 "f53ee05d844449b900ecb30d5e1f812fd3f7e9e28630d309b7d8d11add3c3b1c"
   license "Apache-2.0"
-  revision 26
+  revision 27
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui3"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "f019901a50202a303f28d922dd4da83f30992ec274b41dff4bc767b123ab42b4"
-    sha256 monterey: "e53f6a1d9a373f4ee4cc00d2bc5975d92e58eb70fa078ff36637666c3fa41500"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -4,15 +4,9 @@ class IgnitionGui6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gui/releases/ignition-gui6-6.8.0.tar.bz2"
   sha256 "dd4f26100f4d1343f068ba36f2b8394a0cddb337efde7b4a21c1b0f66ce496c9"
   license "Apache-2.0"
-  revision 26
+  revision 27
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "342dc9cf4bb4534e30f14b96abe0b7ebc6d9e3dee54f6ca62f499b373e15c03c"
-    sha256 monterey: "dce854de74a3537438e7be9da3a4e79192eeeb7292472eed786686bbbc282ef1"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/ignition-launch2.rb
+++ b/Formula/ignition-launch2.rb
@@ -4,15 +4,9 @@ class IgnitionLaunch2 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-launch/releases/ignition-launch2-2.3.1.tar.bz2"
   sha256 "984e2a5df03ca220960470b6b59728edf3cd570314fbad6435b67cb26c9b7e4e"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "ign-launch2"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "15576b3e746a89920b1d0d0f5238e62c5716d55e798ff6e1816b0dbf6fc1ff0f"
-    sha256 monterey: "3b9645ad9cf04bba8ea702a74df1d68738f12e6366047a726d1d00e81a434d84"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-launch5.rb
+++ b/Formula/ignition-launch5.rb
@@ -4,15 +4,9 @@ class IgnitionLaunch5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-launch/releases/ignition-launch5-5.3.0.tar.bz2"
   sha256 "84d356b9c85609da1bb7feda2f90ae6d1a1fd2d6713b284799d5605de42e2613"
   license "Apache-2.0"
-  revision 24
+  revision 25
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "ign-launch5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "28e1d72af4f31524f0f38a504a9fdc582656ba2eb666a7de3ad30f04392119bf"
-    sha256 monterey: "fa984585a0f525c0d0a5d000d22d90431f472c70afb8103d9a66373c999648ad"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/ignition-msgs5.rb
+++ b/Formula/ignition-msgs5.rb
@@ -4,15 +4,9 @@ class IgnitionMsgs5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs5-5.11.0.tar.bz2"
   sha256 "59a03770c27b4cdb6d0b0f3de9f10f1c748a47b45376a297e1f30900edb893fd"
   license "Apache-2.0"
-  revision 24
+  revision 25
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "c817041a63d7594cb551f8b238fad67b18b27d2f4534764afd351753a8aca3a9"
-    sha256 cellar: :any, monterey: "3aaa6e2dd228c36ea01bab5671bfdece52bdc430dfeec929689ea6d3372a757a"
-  end
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-msgs8.rb
+++ b/Formula/ignition-msgs8.rb
@@ -4,15 +4,9 @@ class IgnitionMsgs8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs8-8.7.0.tar.bz2"
   sha256 "b17a8e16fe56a84891bd0654a2ac09427e9a567b9cd2255bb2cfa830f8e1af45"
   license "Apache-2.0"
-  revision 25
+  revision 26
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "eec4b9517014ed49a6ee4fa939f2b1984b83783993674d91a96156abb912924e"
-    sha256 cellar: :any, monterey: "e4867df1d3c408ab303577b3bf7a78b1ff3491dfc9bcd10094b690aec9f54255"
-  end
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-sensors3.rb
+++ b/Formula/ignition-sensors3.rb
@@ -4,15 +4,9 @@ class IgnitionSensors3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-sensors/releases/ignition-sensors3-3.6.0.tar.bz2"
   sha256 "b64b187333907a9e866307ccc76649672e0df9b6bdfb4a390929ebbcaa83ce64"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors3"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "c0d3ad033ef0c6251cd9866ca81d5c0afdc8eae3e189d66916623b432ff95292"
-    sha256 monterey: "d4d950d3841830e2638929e6635c7a783c219ab294710b4d7ce17d6b2f4e8f51"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-sensors6.rb
+++ b/Formula/ignition-sensors6.rb
@@ -4,15 +4,9 @@ class IgnitionSensors6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-sensors/releases/ignition-sensors6-6.8.0.tar.bz2"
   sha256 "4bd5cd637dc624fe8d2a5244b3282ed74558c0fd50e040ba4770c312fcb8c1f5"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "5aa7ba5f8a4b7f9c02775b23a555116f0827a42733feb0c96210328a0a712620"
-    sha256 cellar: :any, monterey: "3f989a31f5fde9024c85d91590812f8ab59f621dd37f63a4a120241c95d8cbd0"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -4,16 +4,10 @@ class IgnitionTransport11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases/ignition-transport11-11.4.1.tar.bz2"
   sha256 "f18501cbd5c78b584b3db1960a3049d6ae416bab7f0289af64eadda13d1c5da5"
   license "Apache-2.0"
-  revision 18
+  revision 19
   version_scheme 1
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport11"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "5f7fa259effe7266ea70617afa190c756e061b375157024645c3cfabdabfc231"
-    sha256 monterey: "ff9b7882cfec740edc2b7dcc520915f4e41cc2b5f31e3efde8da109160d816d5"
-  end
 
   depends_on "doxygen" => [:build, :optional]
 

--- a/Formula/ignition-transport8.rb
+++ b/Formula/ignition-transport8.rb
@@ -4,15 +4,9 @@ class IgnitionTransport8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases/ignition-transport8-8.5.0.tar.bz2"
   sha256 "5edd15699e35ade5ad2f814af1f5e96a866f7908e16b55333abb23978f44d4c6"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "e6fe2a7b47a309c20f83e64e10c1af37a8605a352e34c8c85487502f8d4d936a"
-    sha256 monterey: "4b3ec9dd56430085fc9f9d2ed31c04f31a115856057aa0233481485e1badb84b"
-  end
 
   depends_on "doxygen" => [:build, :optional]
 


### PR DESCRIPTION
Part of #2611.

Implemented using a script from https://github.com/osrf/homebrew-simulation/pull/2610:

~~~
for m in gz-msgs10 gz-msgs9 gz-msgs8 gz-msgs5
do
    brew bump-revision --remove-bottle-block --message="broken bottle" $m
    for f in $(.github/ci/bottled_dependents.sh $m)
    do
        brew bump-revision --remove-bottle-block --message="broken bottle" $f
    done
done
~~~

The garden bottles (dependents of gz-msgs9) hadn't been rebuilt from the last failure, so there's fewer bottles to remove.