### PR TITLE
gz-common5, dependents: remove ventura bottle

### DIFF
--- a/Formula/gz-common5.rb
+++ b/Formula/gz-common5.rb
@@ -10,7 +10,6 @@ class GzCommon5 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "7802568e0720ddd8157bdda560f60daf584b9d7285d95fd5c0b9c35aef68042c"
     sha256 cellar: :any, monterey: "88d0a4fea6bf066fb95a80fcb1262f7d9fae29d8fa52e42db4a5259809a31c40"
   end
 

--- a/Formula/gz-fuel-tools8.rb
+++ b/Formula/gz-fuel-tools8.rb
@@ -10,7 +10,6 @@ class GzFuelTools8 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "ecf5d33a11de839a1cb1868d888a7a958698dc8e5acb029d92fcb139c7f09e8b"
     sha256 cellar: :any, monterey: "7d640277fd23e90f27bafe535a9fac2860583bbff874d63068965179579661e6"
   end
 

--- a/Formula/gz-fuel-tools9.rb
+++ b/Formula/gz-fuel-tools9.rb
@@ -10,7 +10,6 @@ class GzFuelTools9 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "bb43e3e8ecddd01456773e681a92dc31435351bd90402cda215cb6314c004817"
     sha256 cellar: :any, monterey: "8cfef1620373330429747162c513ffd92fd0c1916e0960a30d0f5d4f349d4102"
   end
 

--- a/Formula/gz-gui7.rb
+++ b/Formula/gz-gui7.rb
@@ -10,7 +10,6 @@ class GzGui7 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "8b2279badb737f441d4e949d4ccb102911d0c9f4f1949b4690653c97fed28446"
     sha256 monterey: "e940009293462dc8e0d31ed36d6fb96773d0b0343a2093fc77fbf349d52bdb94"
   end
 

--- a/Formula/gz-gui8.rb
+++ b/Formula/gz-gui8.rb
@@ -9,7 +9,6 @@ class GzGui8 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "361c7f4172874d60e7c32634e534898b7baf317d89880ebef3ca56841d7fa663"
     sha256 monterey: "2e198bf3943307cc5154dde3a910f549a88595f097d9ff49f50f0474e2836d4b"
   end
 

--- a/Formula/gz-launch6.rb
+++ b/Formula/gz-launch6.rb
@@ -10,7 +10,6 @@ class GzLaunch6 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "ba894457bb30783369b39c8fa811d119e42a9f2a62063f927157c3b3ec9102ad"
     sha256 monterey: "03f5969bd43398dc24b028c7501d363d55a5d374804476bcd1a746a0f12173b7"
   end
 

--- a/Formula/gz-launch7.rb
+++ b/Formula/gz-launch7.rb
@@ -9,7 +9,6 @@ class GzLaunch7 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "4dc2ded2e7924f6dea08787b4f098110f0cde7ac48e71f5ae29c91d72833a20c"
     sha256 monterey: "b4d0beac0270f92441f1fafd7300ecd2ef1309260203d60c2480aec78bfba343"
   end
 

--- a/Formula/gz-physics6.rb
+++ b/Formula/gz-physics6.rb
@@ -10,7 +10,6 @@ class GzPhysics6 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "e28e8305b71511cb71b8c75c8131edac88612f113ddf3119bca5fc8b71ec4e70"
     sha256 monterey: "4ea95b9eeaed8c6f513f8daaa3bdfb6ea1ef16a24829425c267b8ca59121ef7f"
   end
 

--- a/Formula/gz-physics7.rb
+++ b/Formula/gz-physics7.rb
@@ -9,7 +9,6 @@ class GzPhysics7 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "857ca022b2d3c0be77c0c6d599bd2884d632f455aa90767ca57a34c3779746d0"
     sha256 monterey: "f506c3c2f44cb0f8d345e90c7de65662b1b1969bcaf249e925e70cb352668506"
   end
 

--- a/Formula/gz-rendering7.rb
+++ b/Formula/gz-rendering7.rb
@@ -10,7 +10,6 @@ class GzRendering7 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "97d4bda4135f3948c027ae532f7e0a487c31cd4a3076b0af110a50f14f86e0f6"
     sha256 monterey: "8ebe66a51400fc047925cc4a095f2eea65518aaa8608c5da8245c2546fc0a0b3"
   end
 

--- a/Formula/gz-rendering8.rb
+++ b/Formula/gz-rendering8.rb
@@ -9,7 +9,6 @@ class GzRendering8 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "a6c565b3b85698ea0e16f54d18bcf0e7f3d5ed02137100d4b909d50743bd8a05"
     sha256 monterey: "738d2d6dbae437faaf208573e17a7d46d9e351371cfe6aa31c0f7ae1acf8e211"
   end
 

--- a/Formula/gz-sensors7.rb
+++ b/Formula/gz-sensors7.rb
@@ -10,7 +10,6 @@ class GzSensors7 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "8d0d49ae76c25ac7554c2a5ab3850f77768d02a49dbb7cd3abb6a6cbf4e4b86f"
     sha256 cellar: :any, monterey: "cd1a0ec0d39fe1ea0bce9a843c7ec9bab5becbf80563f3e9c4633336289cca00"
   end
 

--- a/Formula/gz-sensors8.rb
+++ b/Formula/gz-sensors8.rb
@@ -10,7 +10,6 @@ class GzSensors8 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "6c90be119e0bd8aedeae65a867bee8913a5a02bacd882c820594eb5de0df5bc1"
     sha256 cellar: :any, monterey: "d19de80504f204dad50fbdb8efdac01b9cdee77f22602604edf4be31a528fa63"
   end
 

--- a/Formula/gz-sim7.rb
+++ b/Formula/gz-sim7.rb
@@ -10,7 +10,6 @@ class GzSim7 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "1954ad8241b410405c1f8dcd020b3ceb0bd08bb1dcb882512b09c875f45b3947"
     sha256 monterey: "aeb388da54eb12e3e1434bb961e12c6034136b7d77f3d2a4e12a5331880cb593"
   end
 

--- a/Formula/gz-sim8.rb
+++ b/Formula/gz-sim8.rb
@@ -9,7 +9,6 @@ class GzSim8 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "b0355e1dc034b8e30cb9d48db41d512393a39cad2ec2831a7d42804c137676e7"
     sha256 monterey: "bd4de5fd1b9e24ab1953bbc1a1a1971874ec1a58e0ce2c6e5d9ca941d7f65f08"
   end
 


### PR DESCRIPTION
Part of #2639.

Only the ventura bottles are affected, so use a targeted sed script to delete the ventura bottle line with the following command:

~~~
sed -i -e '/sha256 .*ventura: /d' $(brew --repo osrf/simulation)/Formula/gz-common5.rb
for f in $(.github/ci/bottled_dependents.sh gz-common5 | sed -e 's@osrf/simulation/@@')
do
    sed -i -e '/sha256 .*ventura: /d' $(brew --repo osrf/simulation)/Formula/$f.rb
done
~~~