### PR TITLE
Remove bottles broken by gdal 3.9.0

### DIFF
--- a/Formula/gz-common5.rb
+++ b/Formula/gz-common5.rb
@@ -4,15 +4,9 @@ class GzCommon5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-common/releases/gz-common-5.6.0.tar.bz2"
   sha256 "c2e0b3ca2c945d7ada377d780f1dbfc23338b169213e91814529ec6ac45dc70a"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-common.git", branch: "gz-common5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "d5511f1c6bebb9b10da17fdd7244f588fb56fba1b515e94c7d8dd6d4a5f7d584"
-    sha256 cellar: :any, monterey: "8b5efc2e19ec5f184ea14a0128c978fb234a2a625048b29291b1dbcc51b9ee4e"
-  end
 
   depends_on "assimp"
   depends_on "cmake"

--- a/Formula/gz-fuel-tools8.rb
+++ b/Formula/gz-fuel-tools8.rb
@@ -4,15 +4,9 @@ class GzFuelTools8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-8.1.0.tar.bz2"
   sha256 "18a25e2bc31e61539c890bdd377068b5192646a6647267e76d9b0bb0d0349545"
   license "Apache-2.0"
-  revision 24
+  revision 25
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "253d9774c2d9b0f56a738a8ca12691b00f849a214b1afd343eb715ec33c4fd85"
-    sha256 cellar: :any, monterey: "01c36a24df0062c13d3f3bf94668a31bfd50f77ae45260bcf4dda5a1880934c5"
-  end
 
   depends_on "cmake"
   depends_on "gz-cmake3"

--- a/Formula/gz-fuel-tools9.rb
+++ b/Formula/gz-fuel-tools9.rb
@@ -4,15 +4,9 @@ class GzFuelTools9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-9.0.3.tar.bz2"
   sha256 "242687de20af956485372a43f47a0fd093ecb17ee62d268211c6223e204f94cf"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "c731c5f0f0dfb336378c0ce57f2f8939151e67c4d077426807fd83bcfb1fed04"
-    sha256 cellar: :any, monterey: "624a356efa943057f42f78f6fbc6ce047772169ed2e4d1b672934b986b6353ce"
-  end
 
   depends_on "cmake"
   depends_on "gz-cmake3"

--- a/Formula/gz-gui7.rb
+++ b/Formula/gz-gui7.rb
@@ -4,15 +4,9 @@ class GzGui7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-7.2.1.tar.bz2"
   sha256 "d6a9d0a14fc535773b23e06106a58238b03c04f7551aa642d28768119272042f"
   license "Apache-2.0"
-  revision 18
+  revision 19
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "e69c3ca2202a954c3c033099d74ba4e1226d61bc4180dfb001c07bd702005946"
-    sha256 monterey: "b14e6c56fd9dbf87962800f45ce2fb8de8ae61d122c944838d70cd0bdaa26e86"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/gz-gui8.rb
+++ b/Formula/gz-gui8.rb
@@ -4,15 +4,9 @@ class GzGui8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-8.1.1.tar.bz2"
   sha256 "039b8f1025e8a248ecb1875e0ab7fee978e3e282d80b1db7928ec8091ae6556f"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "5d90872834b39c5c4df7c49f688dc1d380fc1871d215c5a77786c657dd93f8f5"
-    sha256 monterey: "fee49c82ec10d1e3dcb28e4e6f8c90153f1d9ab2ed7462e86ae6b694bf0996f8"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/gz-launch6.rb
+++ b/Formula/gz-launch6.rb
@@ -4,15 +4,9 @@ class GzLaunch6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-6.1.0.tar.bz2"
   sha256 "7c789c85ffb422ebbc4adb6f93c9b2aa7fdd7eccd521b7895297a6b8c525acc1"
   license "Apache-2.0"
-  revision 19
+  revision 20
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "3b5a713e945f3b36e8454c8f11456dc6d130001a9e1bacdc1bf373e0f5b8fefd"
-    sha256 monterey: "a37db9e409a5b51c39447ce625d1603b2379036ce364a7cb7779eebea5a8daf6"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/gz-launch7.rb
+++ b/Formula/gz-launch7.rb
@@ -4,15 +4,9 @@ class GzLaunch7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-7.1.0.tar.bz2"
   sha256 "320606c71b6a2cbbcab683cd8569af9145ece157d5ebd23bc80218e8d148cd09"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "32f64591f87a112a2896eb73b401c68455c4affe48910784da417b9e15f7e7c1"
-    sha256 monterey: "1f90395595b1fe63a97c8b34b1d9935c0dc1e641156a6937e95ae8a6065d7dc6"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/gz-physics6.rb
+++ b/Formula/gz-physics6.rb
@@ -4,15 +4,9 @@ class GzPhysics6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-6.5.1.tar.bz2"
   sha256 "6556a066f88e48eb3a5d9219245b988e02778ce8c1f90cceb9359e87cbced828"
   license "Apache-2.0"
-  revision 9
+  revision 10
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "81a8f72436fb41b853dc811b9d9c82169ff403bdd862c07823a426cf159b3181"
-    sha256 monterey: "aa120a230d7aab5ab038d8e60fe224b4b9c454a53d0f3beffd0888c2e657003d"
-  end
 
   depends_on "cmake" => [:build, :test]
 

--- a/Formula/gz-physics7.rb
+++ b/Formula/gz-physics7.rb
@@ -4,15 +4,9 @@ class GzPhysics7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-7.2.0.tar.bz2"
   sha256 "6c9cd827c0355fbc0d3cd8ed05d511eec473beec55866da4c0446a9e6434733c"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "85154aafc9c75d65bf34e2948a728b0377eb5012827c0bcef25a50dd84f306f0"
-    sha256 monterey: "9b4b6dbc4c99c83213ef85abd2f56637131935a1c196d286a77b53a5cdfedba0"
-  end
 
   depends_on "cmake" => [:build, :test]
 

--- a/Formula/gz-rendering7.rb
+++ b/Formula/gz-rendering7.rb
@@ -4,15 +4,9 @@ class GzRendering7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-rendering/releases/gz-rendering-7.4.2.tar.bz2"
   sha256 "81101ddb26c630dd0292c34a83d7736596d8ee1ac5d7b8ec4980f485de8ba87d"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "ab03d209591e3093964981bb937fb27df888fb34e994fd1875d78f92bd689a69"
-    sha256 monterey: "37c3e75c3a402dc217c53a8087d0327223db419a397f32d47f03e420b5b81702"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/gz-rendering8.rb
+++ b/Formula/gz-rendering8.rb
@@ -4,15 +4,9 @@ class GzRendering8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-rendering/releases/gz-rendering-8.1.1.tar.bz2"
   sha256 "3d41b18ad2f9032d23f4d8742b8e32589ccb128c67b5826085893b4177b6a4de"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "6139cd83f5f64206c8fab0f646cf206c3c987b249868de01171a3a0785c195ff"
-    sha256 monterey: "fdbd276de99b2bea61e7199e53ea7c6466e85685af1ff5c23053588c61140e17"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/gz-sensors7.rb
+++ b/Formula/gz-sensors7.rb
@@ -4,15 +4,9 @@ class GzSensors7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-7.3.0.tar.bz2"
   sha256 "92b9e0bf4707bdbf318142b0a17c1cd1ca8c94bfee9f8911bcd0b3a7c6cbd169"
   license "Apache-2.0"
-  revision 19
+  revision 20
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "63e590e6cae1bbbdecbf4d930c44f0226b1299dedf715d6635d10f03acbc3d4a"
-    sha256 cellar: :any, monterey: "fc1bee27f216aa68e9884e25953e9acf49d932c3b211ca54e0e30b20d8a606ab"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/gz-sensors8.rb
+++ b/Formula/gz-sensors8.rb
@@ -4,15 +4,9 @@ class GzSensors8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-8.0.1.tar.bz2"
   sha256 "fc67417da4b6675050e52789d64c4298f1088daca3eebd036dc3be732f428bce"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "f12d9eae3ca8c665ec0f3d990b330095ffa2449ae9cd6832a8abe819bd1780c3"
-    sha256 cellar: :any, monterey: "9dba2c945bcd75345f59d64437c1bdeac2ef315e10b933c4ce6785b9bce326d3"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/gz-sim7.rb
+++ b/Formula/gz-sim7.rb
@@ -4,15 +4,9 @@ class GzSim7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-7.7.0.tar.bz2"
   sha256 "48d89b5e913eb8bb9925373eeb18616d512cd43f7e45be4413ce8c66bf1ca0d1"
   license "Apache-2.0"
-  revision 13
+  revision 14
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "a1f0ad66646621a3c1ed913171fb7779507f2b2a1ea428f338621af9b11ef7b4"
-    sha256 monterey: "d095d9243d47b70437cdd214c6cfa9841aaaf465e132b2ca7a2bfd066d3b587c"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build

--- a/Formula/gz-sim8.rb
+++ b/Formula/gz-sim8.rb
@@ -4,15 +4,9 @@ class GzSim8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-8.3.0.tar.bz2"
   sha256 "0bc1386261c62a42af54905a69c300bddd34b2f5e34e2f48d8d2b9c181d8a9eb"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "135b9a172e5d2a68a2e58b6fa53c46e442ef2788b9beaa8931a7da33e0c96a7b"
-    sha256 monterey: "dd11f662ff5cee64808cf2e8d63be4fd3a9d7e0632159328f3f10bdb440f2ffc"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/2651.

Implemented using a script from https://github.com/osrf/homebrew-simulation/pull/2610:

~~~
for m in gz-common5
do
    brew bump-revision --remove-bottle-block --message="broken bottle" $m
    for f in $(.github/ci/bottled_dependents.sh $m)
    do
        brew bump-revision --remove-bottle-block --message="broken bottle" $f
    done
done
~~~