### PR TITLE
Remove bottles broken by dartsim 6.14.0

### DIFF
--- a/Formula/gazebo11.rb
+++ b/Formula/gazebo11.rb
@@ -4,15 +4,9 @@ class Gazebo11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/gazebo-11.14.0.tar.bz2"
   sha256 "7e9842c046c9e0755355b274c240a8abbf4e962be7ce7b7f59194e5f4b584f45"
   license "Apache-2.0"
-  revision 23
+  revision 24
 
   head "https://github.com/osrf/gazebo.git", branch: "gazebo11"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "b8ff5f55fd2dd47c305d83652876fba1b00d8352a972705ab9e4e5496a18ffde"
-    sha256 monterey: "47f4f042f74e823d59c1ec373becd3bee87c8451fe6a8d859786f3f343bcf8b1"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/gz-physics6.rb
+++ b/Formula/gz-physics6.rb
@@ -4,14 +4,9 @@ class GzPhysics6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-6.6.0.tar.bz2"
   sha256 "de870ef09753188a8c4a7b0ed449eb2357bd537e0b90f8a474f334e3e7a95a0f"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "894b6def94e407c3cb8a7e40bd099d6dbeeaca2643aff58d3dfc50d310fef68f"
-    sha256 monterey: "d44050051f3287947fd0017489ad6b570b5e4fe537b14c040845f53d648d010d"
-  end
 
   depends_on "cmake" => [:build, :test]
 

--- a/Formula/gz-physics7.rb
+++ b/Formula/gz-physics7.rb
@@ -4,14 +4,9 @@ class GzPhysics7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-7.3.0.tar.bz2"
   sha256 "1c37a1929a04ca90d26d1b3bbac18afd207afa66caf510868d0266e73c41ea04"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "2e17c233e8ac4da9cd80962e7057490f20cf7d3949ef5085481674a69debe4a2"
-    sha256 monterey: "b447db9f24c0c355b4d1ba7181fd80a0778824b8a6f4d91d3cd05d2ffa5c49c3"
-  end
 
   depends_on "cmake" => [:build, :test]
 

--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -4,15 +4,9 @@ class IgnitionPhysics5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics5-5.3.2.tar.bz2"
   sha256 "4262512fbb6952712234c5cbeed69cdabca338931bb6c587a1ef7d487a5f262b"
   license "Apache-2.0"
-  revision 10
+  revision 11
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "ign-physics5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "36e99720c65563dfadebd99f12048e92f0fb1433daa76ef352ec4dd4d3418bac"
-    sha256 cellar: :any, monterey: "937407d481cb310719af9f7e3653b869c6b72b7fd077a704a12883c1956aa204"
-  end
 
   depends_on "cmake" => :build
 


### PR DESCRIPTION
Part of #2688.

Merge immediately after https://github.com/Homebrew/homebrew-core/pull/175563 is merged (if not before).

Implemented using:

~~~
for f in $(.github/ci/bottled_dependents.sh dartsim)
do
    brew bump-revision --remove-bottle-block --message="broken bottle" $f
done
~~~