### PR TITLE
ogre1.9: remove configuration forcing x86_64

### DIFF
--- a/Formula/ogre1.9.rb
+++ b/Formula/ogre1.9.rb
@@ -103,7 +103,6 @@ class Ogre19 < Formula
   def install
     cmake_args = [
       "-DCMAKE_CXX_STANDARD='14'",
-      "-DCMAKE_OSX_ARCHITECTURES='x86_64'",
       "-DOGRE_BUILD_LIBS_AS_FRAMEWORKS=OFF",
       "-DOGRE_FULL_RPATH:BOOL=FALSE",
       "-DOGRE_BUILD_DOCS:BOOL=FALSE",


### PR DESCRIPTION
Part of #2699.

I tested this locally with gazebo-classic on an intel machine and it still works, so I think this is safe, and it has been suggested that this improves support for arm-based processors.