### PR TITLE
Fix style

### DIFF
--- a/Formula/bullet@2.87.rb
+++ b/Formula/bullet@2.87.rb
@@ -53,7 +53,7 @@ class BulletAT287 < Formula
       system "make", "install"
 
       if build.with? "demo"
-        rm_rf Dir["examples/**/Makefile", "examples/**/*.cmake", "examples/**/CMakeFiles"]
+        rm_r(Dir["examples/**/Makefile", "examples/**/*.cmake", "examples/**/CMakeFiles"])
         pkgshare.install "examples"
         (pkgshare/"examples").install "../data"
       end


### PR DESCRIPTION
I saw a style complaint in https://github.com/osrf/homebrew-simulation/pull/2705, so I have fixed it here with `brew style osrf/simulation --fix`.

~~~
Offenses:

Taps/osrf/homebrew-simulation/Formula/bullet@2.87.rb:56:9: C: [Corrected] Homebrew/NoFileutilsRmrf: Use rm or rm_r instead of rm_rf, rm_f, or rmtree.
        rm_rf Dir["examples/**/Makefile", "examples/**/*.cmake", "examples/**/CMakeFiles"]
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

106 files inspected, 1 offense detected, 1 offense corrected
~~~