### PR TITLE
Remove bottles broken by abseil 20240722.0

### DIFF
--- a/Formula/gz-msgs10.rb
+++ b/Formula/gz-msgs10.rb
@@ -4,15 +4,9 @@ class GzMsgs10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/gz-msgs-10.3.0.tar.bz2"
   sha256 "501e475f5602448428a11d16e3d11972a87d5212bd1655d9154e74aa80bd8454"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs10"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "fc1a1ee8fcf202055873738951edff8cdb4af24f250115d51ffa50c39d2acd47"
-    sha256 monterey: "5e431b795eb79d1bdb52760d421cb8810cd58eb1087349ce9f2578a50bde1eb4"
-  end
 
   depends_on "abseil"
   depends_on "cmake"

--- a/Formula/ignition-msgs5.rb
+++ b/Formula/ignition-msgs5.rb
@@ -4,15 +4,9 @@ class IgnitionMsgs5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs5-5.11.0.tar.bz2"
   sha256 "59a03770c27b4cdb6d0b0f3de9f10f1c748a47b45376a297e1f30900edb893fd"
   license "Apache-2.0"
-  revision 32
+  revision 33
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "317b4cdaa19d1da0e8e025ed318e73a137cd11ae3c8b3243d3c1bd061ac764f8"
-    sha256 cellar: :any, monterey: "0fa19c81d651d3f668a0d40421869d436a97abd3e31de6fe098a592b3fd8bb9e"
-  end
 
   depends_on "cmake"
   depends_on "ignition-cmake2"


### PR DESCRIPTION
Bottles are broken due to https://github.com/Homebrew/homebrew-core/pull/179381

Patch from running

```
for m in gz-msgs10 gz-msgs9 gz-msgs8 gz-msgs5
do
    brew bump-revision --remove-bottle-block --message="broken bottle" $m
    for f in $(.github/ci/bottled_dependents.sh $m)
    do
        brew bump-revision --remove-bottle-block --message="broken bottle" $f
    done
done
```