### PR TITLE
Revert "sdformat14: update 14.5.0 (#2716)"

### DIFF
--- a/Formula/sdformat14.rb
+++ b/Formula/sdformat14.rb
@@ -1,8 +1,8 @@
 class Sdformat14 < Formula
   desc "Simulation Description Format"
   homepage "http://sdformat.org"
-  url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-14.5.0.tar.bz2"
-  sha256 "4b0a99a51378a73e0e3bc209c244eff127ded55a3724d614b8cf051e7d905273"
+  url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-14.4.0.tar.bz2"
+  sha256 "5352b60626a5255060ac40c3fb8ed4189e02b7abf5bdd2ee5f5af720eee1e129"
   license "Apache-2.0"
 
   head "https://github.com/gazebosim/sdformat.git", branch: "main"


### PR DESCRIPTION
@iche033 This reverts commit dcc70d5c4a23ce49fab23e8fbf8a30537c6757a9 so that Harmonic is not broken on macOS until we rebuild all the bottles and resolve the root issue.