### PR TITLE
gz-math8: remove test based on manual compiler flags

### DIFF
--- a/Formula/gz-math8.rb
+++ b/Formula/gz-math8.rb
@@ -52,7 +52,6 @@ class GzMath8 < Formula
       add_executable(test_cmake test.cpp)
       target_link_libraries(test_cmake gz-math8::gz-math8)
     EOS
-    system "./test"
     # test building with cmake
     mkdir "build" do
       system "cmake", ".."

--- a/Formula/gz-math8.rb
+++ b/Formula/gz-math8.rb
@@ -52,14 +52,6 @@ class GzMath8 < Formula
       add_executable(test_cmake test.cpp)
       target_link_libraries(test_cmake gz-math8::gz-math8)
     EOS
-    # test building with manual compiler flags
-    system ENV.cc, "test.cpp",
-                   "--std=c++14",
-                   "-I#{include}/gz/math8",
-                   "-L#{lib}",
-                   "-lgz-math8",
-                   "-lc++",
-                   "-o", "test"
     system "./test"
     # test building with cmake
     mkdir "build" do


### PR DESCRIPTION
As reported in https://github.com/gazebosim/gz-math/pull/614#issuecomment-2284101515, the gz-math8 bottle install jobs are broken after https://github.com/gazebosim/gz-math/pull/614. This is because the PR made changes to the `SignalStats.hh` file to include a header from `gz-utils`. One solution is to update the manual flags to include `gz-utils3`, but that proved to be nontrivial because the variables defined by homebrew are specific to the package being built, in this case gz-math8. Figuring out the library and include directories for `gz-utils3` would involve using the `HOMEBREW_PREFIX` variable and somehow determining the version of `gz-utils3`. So, instead I opted to remove this test. @scpeters suggested implementing a replacement with `pkg-config`, but I think we should do that in follow up PR.