### PR TITLE
gz-math8: add pkg-config test

### DIFF
--- a/Formula/gz-math8.rb
+++ b/Formula/gz-math8.rb
@@ -10,6 +10,7 @@ class GzMath8 < Formula
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
   depends_on "pybind11" => :build
+  depends_on "pkg-config" => :test
   depends_on "eigen"
   depends_on "gz-cmake4"
   depends_on "gz-utils3"
@@ -52,6 +53,15 @@ class GzMath8 < Formula
       add_executable(test_cmake test.cpp)
       target_link_libraries(test_cmake gz-math8::gz-math8)
     EOS
+    system "pkg-config", "gz-math8"
+    cflags = `pkg-config --cflags gz-math8`.split
+    system ENV.cc, "test.cpp",
+                   *cflags,
+                   "-L#{lib}",
+                   "-lgz-math8",
+                   "-lc++",
+                   "-o", "test"
+    system "./test"
     # test building with cmake
     mkdir "build" do
       system "cmake", ".."

--- a/Formula/gz-math8.rb
+++ b/Formula/gz-math8.rb
@@ -55,10 +55,10 @@ class GzMath8 < Formula
     EOS
     system "pkg-config", "gz-math8"
     cflags = `pkg-config --cflags gz-math8`.split
+    ldflags = `pkg-config --libs gz-math8`.split
     system ENV.cc, "test.cpp",
                    *cflags,
-                   "-L#{lib}",
-                   "-lgz-math8",
+                   *ldflags,
                    "-lc++",
                    "-o", "test"
     system "./test"


### PR DESCRIPTION
Follow-up to #2723. The test is adapted from that used in other formulae, like [sdformat14](https://github.com/osrf/homebrew-simulation/blob/master/Formula/sdformat14.rb#L74-L82).