### PR TITLE
gz-garden, gz-harmonic: simplify test

### DIFF
--- a/Formula/gz-garden.rb
+++ b/Formula/gz-garden.rb
@@ -11,7 +11,6 @@ class GzGarden < Formula
   head "https://github.com/gazebosim/gz-garden.git", branch: "main"
 
   depends_on "cmake" => :build
-  depends_on "python@3.12" => [:build, :test]
 
   depends_on "gz-cmake3"
   depends_on "gz-common5"
@@ -32,26 +31,14 @@ class GzGarden < Formula
   depends_on "pkg-config"
   depends_on "sdformat13"
 
-  resource "PyYAML" do
-    url "https://files.pythonhosted.org/packages/64/c2/b80047c7ac2478f9501676c988a5411ed5572f35d1beff9cae07d321512c/PyYAML-5.3.1.tar.gz"
-    sha256 "b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"
-  end
-
   def install
     mkdir "build" do
       system "cmake", "..", *std_cmake_args
       system "make", "install"
     end
-
-    # install vcstool for use in the test
-    venv = virtualenv_create(libexec, Formula["python@3.12"].opt_libexec/"bin/python")
-    %w[PyYAML vcstool].each do |pkg|
-      venv.pip_install pkg
-    end
   end
 
   test do
-    yaml_file = share/"gz/gz-garden/gazebodistro/collection-garden.yaml"
-    system libexec/"bin/vcs", "validate", "--input", yaml_file
+    assert_predicate share/"gz/gz-garden/gazebodistro/collection-garden.yaml", :exist?
   end
 end

--- a/Formula/gz-harmonic.rb
+++ b/Formula/gz-harmonic.rb
@@ -11,7 +11,6 @@ class GzHarmonic < Formula
   head "https://github.com/gazebosim/gz-harmonic.git", branch: "main"
 
   depends_on "cmake" => :build
-  depends_on "python@3.12" => [:build, :test]
 
   depends_on "gz-cmake3"
   depends_on "gz-common5"
@@ -31,25 +30,14 @@ class GzHarmonic < Formula
   depends_on "pkg-config"
   depends_on "sdformat14"
 
-  resource "PyYAML" do
-    url "https://files.pythonhosted.org/packages/64/c2/b80047c7ac2478f9501676c988a5411ed5572f35d1beff9cae07d321512c/PyYAML-5.3.1.tar.gz"
-    sha256 "b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"
-  end
-
   def install
     mkdir "build" do
       system "cmake", "..", *std_cmake_args
       system "make", "install"
     end
-
-    venv = virtualenv_create(libexec, Formula["python@3.12"].opt_libexec/"bin/python")
-    %w[PyYAML vcstool].each do |pkg|
-      venv.pip_install pkg
-    end
   end
 
   test do
-    yaml_file = share/"gz/gz-harmonic/gazebodistro/collection-harmonic.yaml"
-    system libexec/"bin/vcs", "validate", "--input", yaml_file
+    assert_predicate share/"gz/gz-harmonic/gazebodistro/collection-harmonic.yaml", :exist?
   end
 end


### PR DESCRIPTION
Test the existence of the collection yaml file instead of trying to verify it with vcstool since there are some python issues. This more closely matches the test for gz-ionic.

This should fix the broken bottle install builds:

* [![gz-garden](https://build.osrfoundation.org/buildStatus/icon?job=gz_garden-install_bottle-homebrew-amd64)](https://build.osrfoundation.org/view/gz-garden/job/gz_garden-install_bottle-homebrew-amd64/) https://build.osrfoundation.org/view/gz-garden/job/gz_garden-install_bottle-homebrew-amd64/
* [![gz-harmonic](https://build.osrfoundation.org/buildStatus/icon?job=gz_harmonic-install_bottle-homebrew-amd64)](https://build.osrfoundation.org/view/gz-harmonic/job/gz_harmonic-install_bottle-homebrew-amd64/) https://build.osrfoundation.org/view/gz-harmonic/job/gz_harmonic-install_bottle-homebrew-amd64/