### PR TITLE
Disable deprecated formulae on 2024-08-31

### DIFF
--- a/Formula/cmake@3.21.4.rb
+++ b/Formula/cmake@3.21.4.rb
@@ -23,6 +23,7 @@ class CmakeAT3214 < Formula
 
   keg_only :versioned_formula
 
+  disable! date: "2024-08-31", because: "is past end-of-life date"
   deprecate! date: "2023-01-25", because: "is past end-of-life date"
 
   uses_from_macos "ncurses"

--- a/Formula/gazebo9.rb
+++ b/Formula/gazebo9.rb
@@ -8,6 +8,7 @@ class Gazebo9 < Formula
 
   head "https://github.com/osrf/gazebo.git", branch: "gazebo9"
 
+  disable! date: "2024-08-31", because: "is past end-of-life date"
   deprecate! date: "2023-01-25", because: "is past end-of-life date"
 
   depends_on "cmake" => :build

--- a/Formula/ignition-cmake0.rb
+++ b/Formula/ignition-cmake0.rb
@@ -14,6 +14,7 @@ class IgnitionCmake0 < Formula
     sha256 cellar: :any_skip_relocation, sierra:   "051534970fe3657c173e89d566b134a7e0185cc13afdac722817949594757691"
   end
 
+  disable! date: "2024-08-31", because: "is past end-of-life date"
   deprecate! date: "2023-01-25", because: "is past end-of-life date"
 
   depends_on "cmake"

--- a/Formula/ignition-common1.rb
+++ b/Formula/ignition-common1.rb
@@ -8,6 +8,7 @@ class IgnitionCommon1 < Formula
 
   head "https://github.com/gazebosim/gz-common.git", branch: "ign-common1"
 
+  disable! date: "2024-08-31", because: "is past end-of-life date"
   deprecate! date: "2023-01-25", because: "is past end-of-life date"
 
   depends_on "cmake"

--- a/Formula/ignition-fuel-tools1.rb
+++ b/Formula/ignition-fuel-tools1.rb
@@ -13,6 +13,7 @@ class IgnitionFuelTools1 < Formula
     sha256 catalina: "8c56876ee6b0fd4f69a82e7c28e1c8b672ce228433128bf8630c4a2eb706fec9"
   end
 
+  disable! date: "2024-08-31", because: "is past end-of-life date"
   deprecate! date: "2023-01-25", because: "is past end-of-life date"
 
   depends_on "cmake"

--- a/Formula/ignition-math4.rb
+++ b/Formula/ignition-math4.rb
@@ -17,6 +17,7 @@ class IgnitionMath4 < Formula
     sha256 cellar: :any, el_capitan:  "e7c3f313b025c4733bd79cb3a27f54846e910e11c34e12d78e1c054eb06bbd48"
   end
 
+  disable! date: "2024-08-31", because: "is past end-of-life date"
   deprecate! date: "2023-01-25", because: "is past end-of-life date"
 
   depends_on "cmake" => :build

--- a/Formula/ignition-msgs1.rb
+++ b/Formula/ignition-msgs1.rb
@@ -9,6 +9,7 @@ class IgnitionMsgs1 < Formula
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs1"
 
+  disable! date: "2024-08-31", because: "is past end-of-life date"
   deprecate! date: "2023-01-25", because: "is past end-of-life date"
 
   depends_on "protobuf-c" => :build

--- a/Formula/ignition-transport4.rb
+++ b/Formula/ignition-transport4.rb
@@ -8,6 +8,7 @@ class IgnitionTransport4 < Formula
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport4"
 
+  disable! date: "2024-08-31", because: "is past end-of-life date"
   deprecate! date: "2023-01-25", because: "is past end-of-life date"
 
   depends_on "doxygen" => [:build, :optional]

--- a/Formula/ogre.rb
+++ b/Formula/ogre.rb
@@ -8,6 +8,8 @@ class Ogre < Formula
 
   option "with-cg"
 
+  deprecate! date: "2024-08-31", because: "is past end-of-life date"
+
   depends_on "cmake" => :build
 
   depends_on "boost"

--- a/Formula/sdformat6.rb
+++ b/Formula/sdformat6.rb
@@ -14,6 +14,7 @@ class Sdformat6 < Formula
     sha256 catalina: "06b6bf07eca09d4fdfff48e006747adc6d9f7f50d075f551322ead27513c6e9b"
   end
 
+  disable! date: "2024-08-31", because: "is past end-of-life date"
   deprecate! date: "2023-01-25", because: "is past end-of-life date"
 
   depends_on "cmake" => :build

--- a/Formula/tbb@2020_u3.rb
+++ b/Formula/tbb@2020_u3.rb
@@ -15,6 +15,7 @@ class TbbAT2020U3 < Formula
 
   keg_only :versioned_formula
 
+  disable! date: "2024-08-31", because: "is past end-of-life date"
   deprecate! date: "2023-01-25", because: "is past end-of-life date"
 
   depends_on "cmake" => :build


### PR DESCRIPTION
This includes gazebo9 and dependencies. These have all been deprecated since January 2023.

Also deprecate `ogre` 1.7 formula since it is past its end-of-life.