### PR TITLE
gz-cmake4: use stable branch in url

### DIFF
--- a/Formula/gz-cmake4.rb
+++ b/Formula/gz-cmake4.rb
@@ -1,7 +1,7 @@
 class GzCmake4 < Formula
   desc "CMake helper functions for building robotic applications"
   homepage "https://gazebosim.org"
-  url "https://github.com/gazebosim/gz-cmake.git", branch: "main"
+  url "https://github.com/gazebosim/gz-cmake.git", branch: "gz-cmake4"
   version "3.999.999-0-20231006"
   license "Apache-2.0"
 
@@ -23,7 +23,7 @@ class GzCmake4 < Formula
 
   test do
     (testpath/"CMakeLists.txt").write <<-EOS
-      cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
+      cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
       project(gz-test VERSION 0.1.0)
       find_package(gz-cmake4 REQUIRED)
       gz_configure_project()


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1092

Note that I didn't have to change the `head` statement on line 8. For some reason it was already set to `gz-cmake4` instead of `main`.

I also updated the `cmake_minimum_required` version to 3.22.1 since it's been updated in gz-cmake.