### PR TITLE
gz-utils3: use stable branch in url

### DIFF
--- a/Formula/gz-utils3.rb
+++ b/Formula/gz-utils3.rb
@@ -1,7 +1,7 @@
 class GzUtils3 < Formula
   desc "General purpose classes and functions designed for robotic applications"
   homepage "https://github.com/gazebosim/gz-utils"
-  url "https://github.com/gazebosim/gz-utils.git", branch: "main"
+  url "https://github.com/gazebosim/gz-utils.git", branch: "gz-utils3"
   version "2.999.999-0-20231011"
   license "Apache-2.0"
 
@@ -39,7 +39,7 @@ class GzUtils3 < Formula
       }
     EOS
     (testpath/"CMakeLists.txt").write <<-EOS
-      cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+      cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
       find_package(gz-utils3 QUIET REQUIRED)
       add_executable(test_cmake test.cpp)
       target_link_libraries(test_cmake gz-utils3::gz-utils3)


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1092

I also updated the `cmake_minimum_required` version to 3.22.1 since it's been updated in gz-cmake.