### PR TITLE
gz-common6: depend on spdlog

### DIFF
--- a/Formula/gz-common6.rb
+++ b/Formula/gz-common6.rb
@@ -18,8 +18,8 @@ class GzCommon6 < Formula
   depends_on macos: :high_sierra # c++17
   depends_on "ossp-uuid"
   depends_on "pkg-config"
-  depends_on "tinyxml2"
   depends_on "spdlog"
+  depends_on "tinyxml2"
 
   def install
     cmake_args = std_cmake_args

--- a/Formula/gz-common6.rb
+++ b/Formula/gz-common6.rb
@@ -19,6 +19,7 @@ class GzCommon6 < Formula
   depends_on "ossp-uuid"
   depends_on "pkg-config"
   depends_on "tinyxml2"
+  depends_on "spdlog"
 
   def install
     cmake_args = std_cmake_args


### PR DESCRIPTION
to go with: https://github.com/gazebosim/gz-common/pull/615

note: `gz-utils3` should pull in `spdlog` so this may not be necessary.