### PR TITLE
gz-physics*: remove bottles for fmt

### DIFF
--- a/Formula/gz-physics6.rb
+++ b/Formula/gz-physics6.rb
@@ -4,20 +4,15 @@ class GzPhysics6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-6.6.0.tar.bz2"
   sha256 "de870ef09753188a8c4a7b0ed449eb2357bd537e0b90f8a474f334e3e7a95a0f"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "f07a2f775aef558c14620b8a26270ed1814d9d944031764b8db5fa0d5433e47d"
-    sha256 monterey: "22988cfcd7a2cb32fe8a66f4f14724a27fd8e4b9b4720db08e8b62d33cde2267"
-  end
 
   depends_on "cmake" => [:build, :test]
 
   depends_on "bullet"
   depends_on "dartsim"
+  depends_on "fmt"
   depends_on "google-benchmark"
   depends_on "gz-cmake3"
   depends_on "gz-common5"

--- a/Formula/gz-physics7.rb
+++ b/Formula/gz-physics7.rb
@@ -4,20 +4,15 @@ class GzPhysics7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-7.3.0.tar.bz2"
   sha256 "1c37a1929a04ca90d26d1b3bbac18afd207afa66caf510868d0266e73c41ea04"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 ventura:  "e6acb01c4781ad416d44a7584f58b01547da5a2ae0193b2ee5fc4e4d8280274e"
-    sha256 monterey: "9a8fcb04c0205b23db83cd94c52168f1461d139986725ab579e3f4abf8f33f9b"
-  end
 
   depends_on "cmake" => [:build, :test]
 
   depends_on "bullet"
   depends_on "dartsim"
+  depends_on "fmt"
   depends_on "google-benchmark"
   depends_on "gz-cmake3"
   depends_on "gz-common5"

--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -4,15 +4,9 @@ class IgnitionPhysics5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics5-5.3.2.tar.bz2"
   sha256 "4262512fbb6952712234c5cbeed69cdabca338931bb6c587a1ef7d487a5f262b"
   license "Apache-2.0"
-  revision 12
+  revision 13
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "ign-physics5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, ventura:  "66b9cf6e14152339e00af961ba2a5b4ddbb72d694b28228fa2c785b210b15db5"
-    sha256 cellar: :any, monterey: "debb833c7c0ef7f22bc3b33cab2d828e442905efa9c09ea02394d4316e21d84e"
-  end
 
   depends_on "cmake" => :build
 
@@ -20,6 +14,7 @@ class IgnitionPhysics5 < Formula
 
   depends_on "bullet"
   depends_on "dartsim"
+  depends_on "fmt"
   depends_on "google-benchmark"
   depends_on "ignition-cmake2"
   depends_on "ignition-common4"


### PR DESCRIPTION
A recent update to fmt has broken several gz-physics bottles, via its usage by dartsim. I've added an explicit dependency on fmt to help with identifying future issues like this.

Part of #2745.