### PR TITLE
gz-physics*:  bump versions to rebuild bottles for new fmt

### DIFF
--- a/Formula/gz-physics6.rb
+++ b/Formula/gz-physics6.rb
@@ -8,6 +8,12 @@ class GzPhysics6 < Formula
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics6"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 ventura:  "022503835075db6fa87c3c99adb03a1b29feaf8f78183531df2b076e38c3243e"
+    sha256 monterey: "250f9b761daa4b3f2b0759da687caa68b9360007da5e822669210447dd7e4566"
+  end
+
   depends_on "cmake" => [:build, :test]
 
   depends_on "bullet"

--- a/Formula/gz-physics6.rb
+++ b/Formula/gz-physics6.rb
@@ -4,7 +4,7 @@ class GzPhysics6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-6.6.0.tar.bz2"
   sha256 "de870ef09753188a8c4a7b0ed449eb2357bd537e0b90f8a474f334e3e7a95a0f"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics6"
 

--- a/Formula/gz-physics7.rb
+++ b/Formula/gz-physics7.rb
@@ -8,6 +8,12 @@ class GzPhysics7 < Formula
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics7"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 ventura:  "62aef3a1d84a53e1790bcc5563c4ceef7440c37c1775e7136317c416cdb09046"
+    sha256 monterey: "ab30b6e82ae271d0e7c8b8f3ac844a48a535de6d6e80a02bbd70e8ee3ea6e048"
+  end
+
   depends_on "cmake" => [:build, :test]
 
   depends_on "bullet"

--- a/Formula/gz-physics7.rb
+++ b/Formula/gz-physics7.rb
@@ -4,7 +4,7 @@ class GzPhysics7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-7.3.0.tar.bz2"
   sha256 "1c37a1929a04ca90d26d1b3bbac18afd207afa66caf510868d0266e73c41ea04"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics7"
 

--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -8,6 +8,12 @@ class IgnitionPhysics5 < Formula
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "ign-physics5"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, ventura:  "253754eb6b0f61b2fed72231c46ee9d4383abfb5c3e397a316ceac8a1ad7388b"
+    sha256 cellar: :any, monterey: "908769f79d837b8bc444d5adc13ae7df430c3392fe0da114f9eb29c27f251b81"
+  end
+
   depends_on "cmake" => :build
 
   depends_on "gz-plugin2" => :test

--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -4,7 +4,7 @@ class IgnitionPhysics5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics5-5.3.2.tar.bz2"
   sha256 "4262512fbb6952712234c5cbeed69cdabca338931bb6c587a1ef7d487a5f262b"
   license "Apache-2.0"
-  revision 13
+  revision 14
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "ign-physics5"
 


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/2745.