### PR TITLE
Ionic: Rebuild bottles after gz-common6

### DIFF
--- a/Formula/gz-fuel-tools10.rb
+++ b/Formula/gz-fuel-tools10.rb
@@ -5,6 +5,7 @@ class GzFuelTools10 < Formula
   version "10.0.0-pre2"
   sha256 "6b6691068c0c1d3f715abbb003f185d700ef8f43c495ec22a2927fc0e22df062"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools10"
 

--- a/Formula/gz-fuel-tools10.rb
+++ b/Formula/gz-fuel-tools10.rb
@@ -9,6 +9,12 @@ class GzFuelTools10 < Formula
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, ventura:  "04fb08def82f3f8fc07f8205136e9563a9aa680bb91a7b8baeed2ea928e1e413"
+    sha256 cellar: :any, monterey: "8e3a53d778aa59747f5876cb2fc6e7d694c83ee8f138fd3cd1f1f9191699cebd"
+  end
+
   depends_on "abseil"
   depends_on "cmake"
   depends_on "gz-cmake4"

--- a/Formula/gz-gui9.rb
+++ b/Formula/gz-gui9.rb
@@ -5,6 +5,7 @@ class GzGui9 < Formula
   version "9.0.0-pre1"
   sha256 "4cac0025d97bf99be5a8d6ac8b7ebbb5068c3a0944d0a197fed764a21eabf962"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui9"
 

--- a/Formula/gz-launch8.rb
+++ b/Formula/gz-launch8.rb
@@ -5,6 +5,7 @@ class GzLaunch8 < Formula
   version "8.0.0-pre1"
   sha256 "ff03e09388400fc962d4d2db1679e48f174fc62006c2cb5855d23a7cf60ca350"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch8"
 

--- a/Formula/gz-physics8.rb
+++ b/Formula/gz-physics8.rb
@@ -9,6 +9,12 @@ class GzPhysics8 < Formula
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics8"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 ventura:  "aec042ebb4310e8c2200b970c865d5fe0f07865294ded60787e56795f0e4d241"
+    sha256 monterey: "94c903595271599483d690b76ac59f37bbbae0500317e8062bfb6abcd6affd34"
+  end
+
   depends_on "cmake" => [:build, :test]
 
   depends_on "bullet"

--- a/Formula/gz-physics8.rb
+++ b/Formula/gz-physics8.rb
@@ -5,6 +5,7 @@ class GzPhysics8 < Formula
   version "8.0.0-pre1"
   sha256 "5492ee2817c4d4d914aeb02940205b9cd43a8a17c3694329901679b6cf47204a"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics8"
 

--- a/Formula/gz-rendering9.rb
+++ b/Formula/gz-rendering9.rb
@@ -9,6 +9,12 @@ class GzRendering9 < Formula
 
   head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 ventura:  "a22b5f1bf2474a7567b6128e6c2b5e9ad148500919d0fead02f04cebdc3fa69d"
+    sha256 monterey: "9bb8bb630d65bcd990b16c0bcc2e0c602facef987e36e6a93f01cf52fb13d352"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
 

--- a/Formula/gz-rendering9.rb
+++ b/Formula/gz-rendering9.rb
@@ -5,6 +5,7 @@ class GzRendering9 < Formula
   version "9.0.0-pre2"
   sha256 "6e41d96f6b9716cadc904eb2dd0d3c8f202425a2c842dc24ff761e8249bc037a"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering9"
 

--- a/Formula/gz-sensors9.rb
+++ b/Formula/gz-sensors9.rb
@@ -5,6 +5,7 @@ class GzSensors9 < Formula
   version "9.0.0-pre2"
   sha256 "6aca7a1a2808f4542385eafa69d61010dc32a0f36688b229e7e28ae9061562d9"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors9"
 

--- a/Formula/gz-sensors9.rb
+++ b/Formula/gz-sensors9.rb
@@ -9,6 +9,12 @@ class GzSensors9 < Formula
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, ventura:  "ce218d5bc2d5f3a893099b8d657f4836a82d84a6533715ee45b99688106e3e04"
+    sha256 cellar: :any, monterey: "0e6f3e3fa3abe3bf7a83a080ee9750b0831ef5d6fe387f0c858c2559221124b2"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
 

--- a/Formula/gz-sim9.rb
+++ b/Formula/gz-sim9.rb
@@ -5,6 +5,7 @@ class GzSim9 < Formula
   version "9.0.0-pre1"
   sha256 "3a166af7a15062e10a886df345204bb0cda1d14bda627aaafda128ca57d2d7ab"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim9"
 


### PR DESCRIPTION
Bottles for packages downstream of gz-common6 failed in #2773 due to a failure in gz-common6. This PR is to build the rest of the bottles now that that failure has been fixed (#2774)