### PR TITLE
Citadel: build sonoma bottles part 2

### DIFF
--- a/Formula/dartsim@6.10.0.rb
+++ b/Formula/dartsim@6.10.0.rb
@@ -60,6 +60,7 @@ class DartsimAT6100 < Formula
       args << "-DGLUT_glut_LIBRARY=#{glut_lib}"
     end
 
+    # Use a build folder
     mkdir "build" do
       system "cmake", "..", *args, "-DCMAKE_INSTALL_RPATH=#{rpath}"
       system "make", "install"

--- a/Formula/dartsim@6.10.0.rb
+++ b/Formula/dartsim@6.10.0.rb
@@ -10,6 +10,7 @@ class DartsimAT6100 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:   "6a8f7ed80ac217878eb8942fd32c9f113b3391823c9e4e5783d4426df1c58800"
     sha256 ventura:  "27c011d2caef02255071d6c3b44d28280f44e1f24346ab2150f00923f881873c"
     sha256 monterey: "00698a44e88f9251a8561d1e98fde48b08e286400bd725ffae204b61f90f34ee"
   end

--- a/Formula/ignition-common3.rb
+++ b/Formula/ignition-common3.rb
@@ -10,6 +10,7 @@ class IgnitionCommon3 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, sonoma:   "ae04590a187cb8226acbe47f85afe6c0bae16a20a04fe87028204bd03b78caa5"
     sha256 cellar: :any, ventura:  "c695d8d2b29c77fb252d591fee117b7f1ec4cddcceb85f905ca35356bba83e16"
     sha256 cellar: :any, monterey: "362c300cf97228d5656103f381b8cbddbf83888cf48cc68bd0ee892339e93386"
   end

--- a/Formula/ignition-common3.rb
+++ b/Formula/ignition-common3.rb
@@ -36,6 +36,7 @@ class IgnitionCommon3 < Formula
       cmake_args << "-DIGN_PROFILER_REMOTERY=Off"
     end
 
+    # Use a build folder
     mkdir "build" do
       system "cmake", "..", *cmake_args
       system "make", "install"

--- a/Formula/ignition-physics2.rb
+++ b/Formula/ignition-physics2.rb
@@ -10,6 +10,7 @@ class IgnitionPhysics2 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, sonoma:   "abc7291bed2274882eb0622567e9d7fd54d3834aa6504efa9bf8c2e3ac0e4146"
     sha256 cellar: :any, ventura:  "cbd8b95f2a1a6c28398783a22ff0631454fdd9979cf4156b50e72dd58d743084"
     sha256 cellar: :any, monterey: "fdcd6a292848a1da7398cd5dfb5bf97a98846dc316ccd2b78dc0bb877c92fcf3"
   end

--- a/Formula/ignition-physics2.rb
+++ b/Formula/ignition-physics2.rb
@@ -36,6 +36,7 @@ class IgnitionPhysics2 < Formula
     cmake_args << "-DBUILD_TESTING=OFF"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
 
+    # Use a build folder
     mkdir "build" do
       system "cmake", "..", *cmake_args
       system "make", "install"

--- a/Formula/ignition-rendering3.rb
+++ b/Formula/ignition-rendering3.rb
@@ -33,6 +33,7 @@ class IgnitionRendering3 < Formula
     cmake_args << "-DBUILD_TESTING=OFF"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
 
+    # Use a build folder
     mkdir "build" do
       system "cmake", "..", *cmake_args
       system "make", "install"

--- a/Formula/ignition-rendering3.rb
+++ b/Formula/ignition-rendering3.rb
@@ -33,7 +33,6 @@ class IgnitionRendering3 < Formula
     cmake_args << "-DBUILD_TESTING=OFF"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
 
-    # Use a build folder
     mkdir "build" do
       system "cmake", "..", *cmake_args
       system "make", "install"

--- a/Formula/ogre2.1.rb
+++ b/Formula/ogre2.1.rb
@@ -12,6 +12,7 @@ class Ogre21 < Formula
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
     rebuild 1
+    sha256 cellar: :any, sonoma:   "16b189f2303d56df9f81feadc27e815fc4d6b6a9bbf5e44d3eef711d54313edb"
     sha256 cellar: :any, ventura:  "165c40d5f7aad925113c8c84549037b5bd285138a6160252aa8d8c6fe78c7a00"
     sha256 cellar: :any, monterey: "84b8e64c2a4b28afadb0ac267a84fcc341bdb34ead89c41a67e7a173e4c004fa"
     sha256 cellar: :any, big_sur:  "7049b87b9bbd4406dd9d37c97e0fa15aa8c8752c54e67ba620b485a38c69e262"

--- a/Formula/ogre2.1.rb
+++ b/Formula/ogre2.1.rb
@@ -64,6 +64,7 @@ class Ogre21 < Formula
     # cmake_args << "-DOGRE_BUILD_RENDERSYSTEM_GL3PLUS:BOOL=OFF" if MacOS::Xcode.version >= "10"
     cmake_args.concat std_cmake_args
 
+    # Use a build folder
     mkdir "build" do
       system "cmake", "..", *cmake_args
       system "make", "install"

--- a/Formula/sdformat9.rb
+++ b/Formula/sdformat9.rb
@@ -10,6 +10,7 @@ class Sdformat9 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:   "b7a50cebce58dc261605949c8b796739036876f3c185e2d225309d60c9c7acf8"
     sha256 ventura:  "ac0f11dbdb6bfd75df7aa11b13d014bb2624febd625de524625f250198baa0b4"
     sha256 monterey: "0d72b95fa548878ccb2272c1bf793e65a274af39ce0de5fb41c4b8a5a647b50d"
   end

--- a/Formula/sdformat9.rb
+++ b/Formula/sdformat9.rb
@@ -29,6 +29,7 @@ class Sdformat9 < Formula
     cmake_args << "-DBUILD_TESTING=OFF"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
 
+    # Use a build folder
     mkdir "build" do
       system "cmake", "..", *cmake_args
       system "make", "install"

--- a/Formula/simbody.rb
+++ b/Formula/simbody.rb
@@ -26,7 +26,7 @@ class Simbody < Formula
     ENV.delete("MACOSX_DEPLOYMENT_TARGET")
     ENV.delete("SDKROOT")
 
-    # use build folder
+    # use a build folder
     mkdir "build" do
       system "cmake", "..", *std_cmake_args, "-DCMAKE_INSTALL_RPATH=#{rpath}"
       system "make", "doxygen"

--- a/Formula/simbody.rb
+++ b/Formula/simbody.rb
@@ -9,6 +9,7 @@ class Simbody < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:      "e8c8bab971357305f977cab2ca8e0f7c8ca7c6c1a140de723ec7fa3d2047519d"
     sha256 ventura:     "580a4b24af28f9231e699023882be6c73cec56b561c44e918502aab1cfba870c"
     sha256 monterey:    "4550130d4b54cfdd6c6f3bef8c376c0cf4c86f4cb5a1d07332a4200766a39ba5"
     sha256 big_sur:     "e78642e3e328773da2dca9faf741fd7b620501213046017eab1d117b890a373d"

--- a/Formula/tinyxml1.rb
+++ b/Formula/tinyxml1.rb
@@ -7,6 +7,7 @@ class Tinyxml1 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, sonoma:   "208bcf4695e626df9abfbe03593e2ef4b643ec96d5d2d062e7c8888421a4f3c4"
     sha256 cellar: :any, ventura:  "dfb19813b715788d17243281a131d24882cf33f921e2998819243e9676fa9af9"
     sha256 cellar: :any, monterey: "99460c19db8e2b1e8512362b4bf504e62f5f9449e6fa8d8b4abdefdb89ca5db3"
   end

--- a/Formula/tinyxml1.rb
+++ b/Formula/tinyxml1.rb
@@ -13,7 +13,7 @@ class Tinyxml1 < Formula
 
   depends_on "cmake" => :build
 
-  conflicts_with "tinyxml", because: "differing version of the same formula"
+  conflicts_with "tinyxml", because: "differing version of same formula"
 
   # The first two patches are taken from the debian packaging of tinyxml.
   #   The first patch enforces use of stl strings, rather than a custom string type.


### PR DESCRIPTION
Make trivial changes to allow building all formulae used in citadel and gazebo11 that don't use protobuf, since that will be addressed by #2791.