### PR TITLE
Add aliases for versions post-Ionic

### DIFF
--- a/Aliases/gz-cmake5
+++ b/Aliases/gz-cmake5
@@ -1,0 +1,1 @@
+../Formula/gz-cmake4.rb

--- a/Aliases/gz-common7
+++ b/Aliases/gz-common7
@@ -1,0 +1,1 @@
+../Formula/gz-common6.rb

--- a/Aliases/gz-fuel-tools11
+++ b/Aliases/gz-fuel-tools11
@@ -1,0 +1,1 @@
+../Formula/gz-fuel-tools10.rb

--- a/Aliases/gz-gui10
+++ b/Aliases/gz-gui10
@@ -1,0 +1,1 @@
+../Formula/gz-gui9.rb

--- a/Aliases/gz-launch9
+++ b/Aliases/gz-launch9
@@ -1,0 +1,1 @@
+../Formula/gz-launch8.rb

--- a/Aliases/gz-math9
+++ b/Aliases/gz-math9
@@ -1,0 +1,1 @@
+../Formula/gz-math8.rb

--- a/Aliases/gz-msgs12
+++ b/Aliases/gz-msgs12
@@ -1,0 +1,1 @@
+../Formula/gz-msgs11.rb

--- a/Aliases/gz-physics9
+++ b/Aliases/gz-physics9
@@ -1,0 +1,1 @@
+../Formula/gz-physics8.rb

--- a/Aliases/gz-plugin4
+++ b/Aliases/gz-plugin4
@@ -1,0 +1,1 @@
+../Formula/gz-plugin3.rb

--- a/Aliases/gz-rendering10
+++ b/Aliases/gz-rendering10
@@ -1,0 +1,1 @@
+../Formula/gz-rendering9.rb

--- a/Aliases/gz-sensors10
+++ b/Aliases/gz-sensors10
@@ -1,0 +1,1 @@
+../Formula/gz-sensors9.rb

--- a/Aliases/gz-sim10
+++ b/Aliases/gz-sim10
@@ -1,0 +1,1 @@
+../Formula/gz-sim9.rb

--- a/Aliases/gz-transport15
+++ b/Aliases/gz-transport15
@@ -1,0 +1,1 @@
+../Formula/gz-transport14.rb

--- a/Aliases/gz-utils4
+++ b/Aliases/gz-utils4
@@ -1,0 +1,1 @@
+../Formula/gz-utils3.rb

--- a/Aliases/sdformat16
+++ b/Aliases/sdformat16
@@ -1,0 +1,1 @@
+../Formula/sdformat15.rb


### PR DESCRIPTION
https://github.com/gazebo-tooling/release-tools/issues/1092

Add aliases for the next major version of all libraries (except gz-tools3 which exists already).