### PR TITLE
sdformat15: support multiple python versions

### DIFF
--- a/Formula/gz-math8.rb
+++ b/Formula/gz-math8.rb
@@ -11,11 +11,11 @@ class GzMath8 < Formula
   depends_on "doxygen" => :build
   depends_on "pybind11" => :build
   depends_on "python@3.12" => [:build, :test]
+  depends_on "python@3.13" => [:build, :test]
   depends_on "pkg-config" => :test
   depends_on "eigen"
   depends_on "gz-cmake4"
   depends_on "gz-utils3"
-  depends_on "python@3.13"
   depends_on "ruby"
 
   def pythons

--- a/Formula/gz-math8.rb
+++ b/Formula/gz-math8.rb
@@ -1,46 +1,54 @@
 class GzMath8 < Formula
   desc "Math API for robotic applications"
   homepage "https://gazebosim.org"
-  url "https://osrf-distributions.s3.amazonaws.com/gz-math/releases/gz-math-8.0.0.tar.bz2"
-  sha256 "dfc15a78aa52f5e200da991e92ebcbd0bd6f9529326dbe3a1a365ad6d7da9669"
+  url "https://github.com/gazebosim/gz-math.git", branch: "scpeters/build_python_bindings_separately"
+  version "8.0.0~pre1"
   license "Apache-2.0"
 
   head "https://github.com/gazebosim/gz-math.git", branch: "gz-math8"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "d8579d9bf3c0daf39405ef8b7d5695988e5cadd12af596a887b12f7c1ca3e426"
-    sha256 cellar: :any, ventura: "abd335fc1d7e07926aa272efdf4158bf369f4b47b7f86312a71653e39373c177"
-  end
-
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
   depends_on "pybind11" => :build
+  depends_on "python@3.12" => [:build, :test]
   depends_on "pkg-config" => :test
   depends_on "eigen"
   depends_on "gz-cmake4"
   depends_on "gz-utils3"
-  depends_on "python@3.12"
+  depends_on "python@3.13"
   depends_on "ruby"
 
-  def python_cmake_arg
-    "-DPython3_EXECUTABLE=#{which("python3")}"
+  def pythons
+    deps.map(&:to_formula)
+        .select { |f| f.name.match?(/^python@3\.\d+$/) }
+  end
+
+  def python_cmake_arg(python = "python@3.13".to_formula)
+    "-DPython3_EXECUTABLE=#{python.opt_libexec}/bin/python"
   end
 
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=OFF"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
-    cmake_args << python_cmake_arg
 
-    # Use a build folder
+    # first build without python bindings
     mkdir "build" do
-      system "cmake", "..", *cmake_args
+      system "cmake", "..", *cmake_args, "-DSKIP_PYBIND11=ON"
       system "make", "install"
     end
 
-    (lib/"python3.12/site-packages").install Dir[lib/"python/*"]
-    rmdir prefix/"lib/python"
+    # now build only the python bindings
+    pythons.each do |python|
+      # remove @ from formula name
+      python_name = python.name.tr("@", "")
+      mkdir "build_#{python_name}" do
+        system "cmake", "../src/python_pybind11", *cmake_args, python_cmake_arg(python)
+        system "make", "install"
+        (lib/"#{python_name}/site-packages").install Dir[lib/"python/*"]
+        rmdir prefix/"lib/python"
+      end
+    end
   end
 
   test do
@@ -78,6 +86,8 @@ class GzMath8 < Formula
     cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
     system cmd_not_grep_xcode
     # check python import
-    system Formula["python@3.12"].opt_bin/"python3.12", "-c", "import gz.math8"
+    pythons.each do |python|
+      system python.opt_libexec/"bin/python", "-c", "import gz.math8"
+    end
   end
 end

--- a/Formula/sdformat15.rb
+++ b/Formula/sdformat15.rb
@@ -1,21 +1,17 @@
 class Sdformat15 < Formula
   desc "Simulation Description Format"
   homepage "http://sdformat.org"
-  url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-15.0.0.tar.bz2"
-  sha256 "c6c65ac60c502143afc2e4e258d66b92d12c4ab37cf91b5852a50eab4d0f3b1f"
+  url "https://github.com/gazebosim/sdformat.git", branch: "scpeters/build_python_bindings_separately"
+  version "15.0.0~pre1"
   license "Apache-2.0"
 
   head "https://github.com/gazebosim/sdformat.git", branch: "sdf15"
 
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "30f1dd8393161bebe0bb8f3bd3e5cc90462e09e3d04294ea1ed0b6928df19159"
-    sha256 ventura: "212c79cc2989ba711db1a1cbef8dc86b3ed804c61b1278443767a3e475f33473"
-  end
-
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
   depends_on "pybind11" => :build
+  depends_on "python@3.12" => [:build, :test]
+  depends_on "python@3.13" => [:build, :test]
 
   depends_on "doxygen"
   depends_on "gz-cmake4"
@@ -23,28 +19,40 @@ class Sdformat15 < Formula
   depends_on "gz-tools2"
   depends_on "gz-utils3"
   depends_on macos: :mojave # c++17
-  depends_on "python@3.12"
   depends_on "tinyxml2"
   depends_on "urdfdom"
 
-  def python_cmake_arg
-    "-DPython3_EXECUTABLE=#{which("python3")}"
+  def pythons
+    deps.map(&:to_formula)
+        .select { |f| f.name.match?(/^python@3\.\d+$/) }
+  end
+
+  def python_cmake_arg(python = "python@3.13".to_formula)
+    "-DPython3_EXECUTABLE=#{python.opt_libexec}/bin/python"
   end
 
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_TESTING=Off"
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
-    cmake_args << python_cmake_arg
 
-    # Use a build folder
+    # first build without python bindings
     mkdir "build" do
-      system "cmake", "..", *cmake_args
+      system "cmake", "..", *cmake_args, "-DSKIP_PYBIND11=ON"
       system "make", "install"
     end
 
-    (lib/"python3.12/site-packages").install Dir[lib/"python/*"]
-    rmdir prefix/"lib/python"
+    # now build only the python bindings
+    pythons.each do |python|
+      # remove @ from formula name
+      python_name = python.name.tr("@", "")
+      mkdir "build_#{python_name}" do
+        system "cmake", "../python", *cmake_args, python_cmake_arg(python)
+        system "make", "install"
+        (lib/"#{python_name}/site-packages").install Dir[lib/"python/*"]
+        rmdir prefix/"lib/python"
+      end
+    end
   end
 
   test do
@@ -90,6 +98,8 @@ class Sdformat15 < Formula
     cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
     system cmd_not_grep_xcode
     # check python import
-    system Formula["python@3.12"].opt_bin/"python3.12", "-c", "import sdformat15"
+    pythons.each do |python|
+      system python.opt_libexec/"bin/python", "-c", "import sdformat15"
+    end
   end
 end

--- a/Formula/sdformat15.rb
+++ b/Formula/sdformat15.rb
@@ -30,7 +30,14 @@ class Sdformat15 < Formula
   depends_on "urdfdom"
 
   patch do
-    # Support building python bindings against external sdformat library
+    # Support building python bindings against external sdformat library part 1
+    # Remove this patch with the next release
+    url "https://github.com/gazebosim/sdformat/commit/22684cbe9144f9cf15e2df7dfa55457266caca44.patch?full_index=1"
+    sha256 "3ce3f059b4e549e105ef555479979cb849b75d0ff58d1cb479b3a5cde519ff3f"
+  end
+
+  patch do
+    # Support building python bindings against external sdformat library part 2
     # Remove this patch with the next release
     url "https://github.com/gazebosim/sdformat/commit/3dcdd55ee7a3ab0ac77b5cce56ba9629b79a70ac.patch?full_index=1"
     sha256 "0e7dacc3c576d1188985c3508ed217c50b910f5f9290826703b6411958d28657"

--- a/Formula/sdformat15.rb
+++ b/Formula/sdformat15.rb
@@ -4,6 +4,7 @@ class Sdformat15 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-15.0.0.tar.bz2"
   sha256 "c6c65ac60c502143afc2e4e258d66b92d12c4ab37cf91b5852a50eab4d0f3b1f"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/sdformat.git", branch: "sdf15"
 

--- a/Formula/sdformat15.rb
+++ b/Formula/sdformat15.rb
@@ -28,12 +28,19 @@ class Sdformat15 < Formula
   depends_on "tinyxml2"
   depends_on "urdfdom"
 
+  patch do
+    # Support building python bindings against external sdformat library
+    # Remove this patch with the next release
+    url "https://github.com/gazebosim/sdformat/commit/3dcdd55ee7a3ab0ac77b5cce56ba9629b79a70ac.patch?full_index=1"
+    sha256 "0e7dacc3c576d1188985c3508ed217c50b910f5f9290826703b6411958d28657"
+  end
+
   def pythons
     deps.map(&:to_formula)
         .select { |f| f.name.match?(/^python@3\.\d+$/) }
   end
 
-  def python_cmake_arg(python = "python@3.13".to_formula)
+  def python_cmake_arg(python = Formula["python@3.13"])
     "-DPython3_EXECUTABLE=#{python.opt_libexec}/bin/python"
   end
 

--- a/Formula/sdformat15.rb
+++ b/Formula/sdformat15.rb
@@ -10,8 +10,8 @@ class Sdformat15 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "30f1dd8393161bebe0bb8f3bd3e5cc90462e09e3d04294ea1ed0b6928df19159"
-    sha256 ventura: "212c79cc2989ba711db1a1cbef8dc86b3ed804c61b1278443767a3e475f33473"
+    sha256 sonoma:  "7316ff9816a4c9b4f3d5ad729b0df09ddf1c484e8788aaa9421830151f07e784"
+    sha256 ventura: "f9758b06947efe481981dcd0420391c8341a9d3faa58481117f297e504e2ef8f"
   end
 
   depends_on "cmake" => [:build, :test]


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/2834. Build bindings for both python@3.12 and python@3.13.

The following is a test of this branch, that only fails because of a `brew audit` error, which I am discussing with homebrew maintainers in https://github.com/Homebrew/brew/pull/18552:

Test: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_math8-install_bottle-homebrew-amd64&build=303)](https://build.osrfoundation.org/view/gz-ionic/job/gz_math8-install_bottle-homebrew-amd64/303/) https://build.osrfoundation.org/view/gz-ionic/job/gz_math8-install_bottle-homebrew-amd64/303/