### PR TITLE
gz-math7: patch to build multiple python bindings

### DIFF
--- a/Formula/gz-math7.rb
+++ b/Formula/gz-math7.rb
@@ -10,9 +10,8 @@ class GzMath7 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:   "8ce91642ee2f4bdc18be0a63b758a7d634a200eebc95cd4a4e20a0940c5202b3"
-    sha256 cellar: :any, ventura:  "faef596eaa7c1686fca3bcfa3ff0595d21128b480dd70ff66cef4fb542c3de0e"
-    sha256 cellar: :any, monterey: "30ff425a806ecc8894772834cc3a7ef07cb5c6808c48504fee7876d9dc2ca13b"
+    sha256 cellar: :any, sonoma:  "fc68e0969e29460070b13ce4cbb49e53c9802821267ef6aad64e55bffca068ec"
+    sha256 cellar: :any, ventura: "1d95728e7a681a67aa0ac9899e9bcc1e7ca0f03835ba4c79f3e17eaa0b26d0a7"
   end
 
   depends_on "cmake" => :build

--- a/Formula/gz-math7.rb
+++ b/Formula/gz-math7.rb
@@ -30,14 +30,14 @@ class GzMath7 < Formula
     # Support building python bindings against external gz-math library (1)
     # Remove this patch with the next release
     url "https://github.com/gazebosim/gz-math/commit/97ad436a0d561c77422de83cebb600379cc9c94a.patch?full_index=1"
-    sha256 ""
+    sha256 "6d2ed400c7067ac123c80d762f796d2b75e3b4ab479ee71b019e253ca41724e8"
   end
 
   patch do
     # Support building python bindings against external gz-math library (2)
     # Remove this patch with the next release
     url "https://github.com/gazebosim/gz-math/commit/a48b8937eadd4010a69b9f9613ca07aaa1f87d63.patch?full_index=1"
-    sha256 ""
+    sha256 "fbd10f7b886511586ab84c7c03771a43da2fbb5c9445037a6534bbdbd2d05062"
   end
 
   def pythons

--- a/Formula/gz-math7.rb
+++ b/Formula/gz-math7.rb
@@ -4,6 +4,7 @@ class GzMath7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-math/releases/gz-math-7.5.1.tar.bz2"
   sha256 "cb1fc3436fd57ff9663613576fc208018ed6c11776972e555400d1b8bb7d2426"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-math.git", branch: "gz-math7"
 


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/2834. Applies patches from https://github.com/gazebosim/gz-math/pull/640.