### PR TITLE
Fix python path in tests

### DIFF
--- a/Formula/gz-math7.rb
+++ b/Formula/gz-math7.rb
@@ -78,6 +78,6 @@ class GzMath7 < Formula
     cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
     system cmd_not_grep_xcode
     # check python import
-    system Formula["python@3.12"].opt_bin/"python3", "-c", "import gz.math7"
+    system Formula["python@3.12"].opt_libexec/"bin/python", "-c", "import gz.math7"
   end
 end

--- a/Formula/gz-msgs10.rb
+++ b/Formula/gz-msgs10.rb
@@ -73,6 +73,6 @@ class GzMsgs10 < Formula
     cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
     system cmd_not_grep_xcode
     # check python import
-    system Formula["python@3.12"].opt_bin/"python3", "-c", "import gz.msgs10"
+    system Formula["python@3.12"].opt_libexec/"bin/python", "-c", "import gz.msgs10"
   end
 end

--- a/Formula/gz-msgs11.rb
+++ b/Formula/gz-msgs11.rb
@@ -73,6 +73,6 @@ class GzMsgs11 < Formula
     cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
     system cmd_not_grep_xcode
     # check python import
-    system Formula["python@3.12"].opt_bin/"python3.12", "-c", "import gz.msgs11"
+    system Formula["python@3.12"].opt_libexec/"bin/python", "-c", "import gz.msgs11"
   end
 end

--- a/Formula/gz-sim7.rb
+++ b/Formula/gz-sim7.rb
@@ -148,6 +148,6 @@ class GzSim7 < Formula
     cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
     system cmd_not_grep_xcode
     # check python import
-    system Formula["python@3.12"].opt_bin/"python3", "-c", "import gz.sim7"
+    system Formula["python@3.12"].opt_libexec/"bin/python", "-c", "import gz.sim7"
   end
 end

--- a/Formula/gz-sim8.rb
+++ b/Formula/gz-sim8.rb
@@ -148,6 +148,6 @@ class GzSim8 < Formula
     cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
     system cmd_not_grep_xcode
     # check python import
-    system Formula["python@3.12"].opt_bin/"python3", "-c", "import gz.sim8"
+    system Formula["python@3.12"].opt_libexec/"bin/python", "-c", "import gz.sim8"
   end
 end

--- a/Formula/gz-sim9.rb
+++ b/Formula/gz-sim9.rb
@@ -148,6 +148,6 @@ class GzSim9 < Formula
     cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
     system cmd_not_grep_xcode
     # check python import
-    system Formula["python@3.12"].opt_bin/"python3.12", "-c", "import gz.sim9"
+    system Formula["python@3.12"].opt_libexec/"bin/python", "-c", "import gz.sim9"
   end
 end

--- a/Formula/gz-transport13.rb
+++ b/Formula/gz-transport13.rb
@@ -90,6 +90,6 @@ class GzTransport13 < Formula
     cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
     system cmd_not_grep_xcode
     # check python import
-    system Formula["python@3.12"].opt_bin/"python3", "-c", "import gz.transport13"
+    system Formula["python@3.12"].opt_libexec/"bin/python", "-c", "import gz.transport13"
   end
 end

--- a/Formula/gz-transport14.rb
+++ b/Formula/gz-transport14.rb
@@ -90,6 +90,6 @@ class GzTransport14 < Formula
     cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
     system cmd_not_grep_xcode
     # check python import
-    system Formula["python@3.12"].opt_bin/"python3.12", "-c", "import gz.transport14"
+    system Formula["python@3.12"].opt_libexec/"bin/python", "-c", "import gz.transport14"
   end
 end

--- a/Formula/sdformat13.rb
+++ b/Formula/sdformat13.rb
@@ -91,6 +91,6 @@ class Sdformat13 < Formula
     cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
     system cmd_not_grep_xcode
     # check python import
-    system Formula["python@3.12"].opt_bin/"python3", "-c", "import sdformat13"
+    system Formula["python@3.12"].opt_libexec/"bin/python", "-c", "import sdformat13"
   end
 end

--- a/Formula/sdformat14.rb
+++ b/Formula/sdformat14.rb
@@ -92,6 +92,6 @@ class Sdformat14 < Formula
     cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
     system cmd_not_grep_xcode
     # check python import
-    system Formula["python@3.12"].opt_bin/"python3", "-c", "import sdformat14"
+    system Formula["python@3.12"].opt_libexec/"bin/python", "-c", "import sdformat14"
   end
 end

--- a/Formula/sdformat15.rb
+++ b/Formula/sdformat15.rb
@@ -90,6 +90,6 @@ class Sdformat15 < Formula
     cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
     system cmd_not_grep_xcode
     # check python import
-    system Formula["python@3.12"].opt_bin/"python3.12", "-c", "import sdformat15"
+    system Formula["python@3.12"].opt_libexec/"bin/python", "-c", "import sdformat15"
   end
 end


### PR DESCRIPTION
Use opt_libexec/bin/python, which works for python@3.11, python@3.12, and python@3.13 formulae.

This is particularly needed because the `bin/python3` symlink has been removed from `python@3.12`, which caused a bottle failure in #2840.