### PR TITLE
gz-msgs11: support multiple python versions

### DIFF
--- a/Formula/gz-msgs11.rb
+++ b/Formula/gz-msgs11.rb
@@ -8,6 +8,12 @@ class GzMsgs11 < Formula
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs11"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "97c50f8eeb15c758fc6c5676c87ab866b33bd50fda9679f201dbe34ac81286b8"
+    sha256 ventura: "01f8c71a773518ed8fcd17d0c2bc91c30920753d149ccb7de0af0f2eb00421b6"
+  end
+
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
   depends_on "abseil"

--- a/Formula/gz-msgs11.rb
+++ b/Formula/gz-msgs11.rb
@@ -4,7 +4,7 @@ class GzMsgs11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/gz-msgs-11.0.1.tar.bz2"
   sha256 "4154cea1cf4e8c2b9b40962e44d6ab46b4f767ffab3809e4b6b4022904524fcb"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs11"
 

--- a/Formula/gz-msgs11.rb
+++ b/Formula/gz-msgs11.rb
@@ -8,6 +8,8 @@ class GzMsgs11 < Formula
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs11"
 
+  depends_on "python@3.12" => [:build, :test]
+  depends_on "python@3.13" => [:build, :test]
   depends_on "abseil"
   depends_on "cmake"
   depends_on "gz-cmake4"
@@ -17,11 +19,15 @@ class GzMsgs11 < Formula
   depends_on macos: :high_sierra # c++17
   depends_on "pkg-config"
   depends_on "protobuf"
-  depends_on "python@3.12"
   depends_on "tinyxml2"
 
-  def python_cmake_arg
-    "-DPython3_EXECUTABLE=#{which("python3")}"
+  def pythons
+    deps.map(&:to_formula)
+        .select { |f| f.name.match?(/^python@3\.\d+$/) }
+  end
+
+  def python_cmake_arg(python = Formula["python@3.13"])
+    "-DPython3_EXECUTABLE=#{python.opt_libexec}/bin/python"
   end
 
   def install
@@ -35,8 +41,15 @@ class GzMsgs11 < Formula
       system "make", "install"
     end
 
-    (lib/"python3.12/site-packages").install Dir[lib/"python/*"]
-    rmdir prefix/"lib/python"
+    # this installs python files for each message that can be used by multiple
+    # versions of python, so symlink the files to versioned python folders
+    pythons.each do |python|
+      # remove @ from formula name
+      python_name = python.name.tr("@", "")
+      # symlink the python files directly instead of the parent folder to avoid
+      # brew link errors if there is a pre-existing __pycache__ folder
+      (lib/"#{python_name}/site-packages/gz/msgs11").install_symlink Dir[lib/"python/gz/msgs11/*"]
+    end
   end
 
   test do
@@ -73,6 +86,8 @@ class GzMsgs11 < Formula
     cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
     system cmd_not_grep_xcode
     # check python import
-    system Formula["python@3.12"].opt_libexec/"bin/python", "-c", "import gz.msgs11"
+    pythons.each do |python|
+      system python.opt_libexec/"bin/python", "-c", "import gz.msgs11"
+    end
   end
 end


### PR DESCRIPTION
Part of #2834.

This package doesn't generate python binaries, just python files, so we can just symlink the generated python files to versioned python folders.