### PR TITLE
gz-msgs10: support multiple python versions

### DIFF
--- a/Formula/gz-msgs10.rb
+++ b/Formula/gz-msgs10.rb
@@ -8,6 +8,8 @@ class GzMsgs10 < Formula
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs10"
 
+  depends_on "python@3.12" => [:build, :test]
+  depends_on "python@3.13" => [:build, :test]
   depends_on "abseil"
   depends_on "cmake"
   depends_on "gz-cmake3"
@@ -17,11 +19,15 @@ class GzMsgs10 < Formula
   depends_on macos: :high_sierra # c++17
   depends_on "pkg-config"
   depends_on "protobuf"
-  depends_on "python@3.12"
   depends_on "tinyxml2"
 
-  def python_cmake_arg
-    "-DPython3_EXECUTABLE=#{which("python3")}"
+  def pythons
+    deps.map(&:to_formula)
+        .select { |f| f.name.match?(/^python@3\.\d+$/) }
+  end
+
+  def python_cmake_arg(python = Formula["python@3.13"])
+    "-DPython3_EXECUTABLE=#{python.opt_libexec}/bin/python"
   end
 
   def install
@@ -35,8 +41,15 @@ class GzMsgs10 < Formula
       system "make", "install"
     end
 
-    (lib/"python3.12/site-packages").install Dir[lib/"python/*"]
-    rmdir prefix/"lib/python"
+    # this installs python files for each message that can be used by multiple
+    # versions of python, so symlink the files to versioned python folders
+    pythons.each do |python|
+      # remove @ from formula name
+      python_name = python.name.tr("@", "")
+      # symlink the python files directly instead of the parent folder to avoid
+      # brew link errors if there is a pre-existing __pycache__ folder
+      (lib/"#{python_name}/site-packages/gz/msgs10").install_symlink Dir[lib/"python/gz/msgs10/*"]
+    end
   end
 
   test do
@@ -73,6 +86,8 @@ class GzMsgs10 < Formula
     cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
     system cmd_not_grep_xcode
     # check python import
-    system Formula["python@3.12"].opt_libexec/"bin/python", "-c", "import gz.msgs10"
+    pythons.each do |python|
+      system python.opt_libexec/"bin/python", "-c", "import gz.msgs10"
+    end
   end
 end

--- a/Formula/gz-msgs10.rb
+++ b/Formula/gz-msgs10.rb
@@ -8,6 +8,12 @@ class GzMsgs10 < Formula
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "09a74f0522f615809badfbfdd4c31809da04605c41501556c4f975cd8d770542"
+    sha256 ventura: "96f16dc00fa63906c6c8c223916ff2e82fa3aa51eaa6cdd69ae9a8b0de11508d"
+  end
+
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
   depends_on "abseil"

--- a/Formula/gz-msgs10.rb
+++ b/Formula/gz-msgs10.rb
@@ -4,7 +4,7 @@ class GzMsgs10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/gz-msgs-10.3.0.tar.bz2"
   sha256 "501e475f5602448428a11d16e3d11972a87d5212bd1655d9154e74aa80bd8454"
   license "Apache-2.0"
-  revision 9
+  revision 10
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs10"
 


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/2834.

This package doesn't generate python binaries, just python files, so we can just symlink the generated python files to versioned python folders.
