### PR TITLE
Remove bottles broken by gdal 3.10.0

### DIFF
--- a/Formula/gz-common5.rb
+++ b/Formula/gz-common5.rb
@@ -4,16 +4,9 @@ class GzCommon5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-common/releases/gz-common-5.6.0.tar.bz2"
   sha256 "c2e0b3ca2c945d7ada377d780f1dbfc23338b169213e91814529ec6ac45dc70a"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   head "https://github.com/gazebosim/gz-common.git", branch: "gz-common5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:   "9df415665958448541543b0658751bd19b4ccb829d1b7c70530dd7f821e9c31d"
-    sha256 cellar: :any, ventura:  "9dbabf09eda7c2917a9ded66c8fdfab8641ed0d7c1a11c1543aa9a00cc4959fc"
-    sha256 cellar: :any, monterey: "3e19b281adebb3023bdc32c739bb383925db6faf5fb8849dc6270789a442e2c0"
-  end
 
   depends_on "assimp"
   depends_on "cmake"

--- a/Formula/gz-common6.rb
+++ b/Formula/gz-common6.rb
@@ -4,14 +4,9 @@ class GzCommon6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-common/releases/gz-common-6.0.0.tar.bz2"
   sha256 "55ea0e8b51e8c7ba9eb7e0f9a516f0d54b6d48d8d29a961a838e7bdc2531c517"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-common.git", branch: "gz-common6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "e5404d5540e5197e73d1d8872f78489be760ede6be0d5cb0708f7b025ab3a921"
-    sha256 cellar: :any, ventura: "22474f372e26ad68717267aec993946430c9335906fa769f875ccefd4b02ef4b"
-  end
 
   depends_on "assimp"
   depends_on "cmake"

--- a/Formula/gz-fuel-tools8.rb
+++ b/Formula/gz-fuel-tools8.rb
@@ -4,14 +4,9 @@ class GzFuelTools8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-8.2.0.tar.bz2"
   sha256 "ce224a4de6c63b573514d2fa3c96f0063d5d427b7b8ea05561d19a876afccea2"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "0c747ea5022a8aa664a38f2de229ea15b39a5d4153725893028f48149e9ac4be"
-    sha256 cellar: :any, ventura: "bef63a636bb0cd19b17b63a57584dba1b11c04a584bb41a97cac2d74ccedf2ff"
-  end
 
   depends_on "abseil"
   depends_on "cmake"

--- a/Formula/gz-physics6.rb
+++ b/Formula/gz-physics6.rb
@@ -4,16 +4,9 @@ class GzPhysics6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-6.6.0.tar.bz2"
   sha256 "de870ef09753188a8c4a7b0ed449eb2357bd537e0b90f8a474f334e3e7a95a0f"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:   "65d7517ad92e0f7c079ecbff555175000138acb9432b1ec0917505b4ee9a06c4"
-    sha256 ventura:  "022503835075db6fa87c3c99adb03a1b29feaf8f78183531df2b076e38c3243e"
-    sha256 monterey: "250f9b761daa4b3f2b0759da687caa68b9360007da5e822669210447dd7e4566"
-  end
 
   depends_on "cmake" => [:build, :test]
 

--- a/Formula/gz-physics7.rb
+++ b/Formula/gz-physics7.rb
@@ -4,16 +4,9 @@ class GzPhysics7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-7.3.0.tar.bz2"
   sha256 "1c37a1929a04ca90d26d1b3bbac18afd207afa66caf510868d0266e73c41ea04"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:   "ae5f0865f47d6c53709e352bb0830805e9ef9a403519eee518856f3570cee29c"
-    sha256 ventura:  "62aef3a1d84a53e1790bcc5563c4ceef7440c37c1775e7136317c416cdb09046"
-    sha256 monterey: "ab30b6e82ae271d0e7c8b8f3ac844a48a535de6d6e80a02bbd70e8ee3ea6e048"
-  end
 
   depends_on "cmake" => [:build, :test]
 

--- a/Formula/gz-physics8.rb
+++ b/Formula/gz-physics8.rb
@@ -4,14 +4,9 @@ class GzPhysics8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-8.0.0.tar.bz2"
   sha256 "f842ea942ccb27b6f0854eedc1314c3e0bdd415cdac000ce4320d209ff3a42ee"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "d106e00b8cfa500f3cf5c12fbadf23fe5e350dc59150fe6cb92f8dd193476012"
-    sha256 ventura: "202532ee7e31604f10ee7c305758176ae576d062b8928ffe727f97a21587b2e6"
-  end
 
   depends_on "cmake" => [:build, :test]
 

--- a/Formula/gz-rendering7.rb
+++ b/Formula/gz-rendering7.rb
@@ -4,16 +4,9 @@ class GzRendering7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-rendering/releases/gz-rendering-7.4.2.tar.bz2"
   sha256 "81101ddb26c630dd0292c34a83d7736596d8ee1ac5d7b8ec4980f485de8ba87d"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:   "d88c5d96ae4832ff25cd3f01913ace3dd642346205b1ded9d79c0b7daa621a13"
-    sha256 ventura:  "8f748dcc57e30d6f9ee340fe134d6e330ced424b97009d8457f2968ceebad2ee"
-    sha256 monterey: "7b352e82f58ae87ecfe427369e79aca436e44febac731a63743a05837dff1ba5"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/gz-rendering8.rb
+++ b/Formula/gz-rendering8.rb
@@ -4,15 +4,9 @@ class GzRendering8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-rendering/releases/gz-rendering-8.2.0.tar.bz2"
   sha256 "0ccf502558522ff5f9fe882c3f5a381c789acc5a0521dc6ec7a08ea0fa05afce"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:   "eb5071db7b5c86b7965d4fa9d52e30c9313ac4172ed85c899417ed787e8488bc"
-    sha256 ventura:  "5df6d5ac91701767bf8981793e4cc2cdf781ca88facff856a81a92d4a1709943"
-    sha256 monterey: "65f65d7b5b566489d0a514f3caeaa0ac70e07542ab26517dc41a8085a50e1ddf"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/gz-rendering9.rb
+++ b/Formula/gz-rendering9.rb
@@ -4,14 +4,9 @@ class GzRendering9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-rendering/releases/gz-rendering-9.0.0.tar.bz2"
   sha256 "3b761f62d86db395aa989881e5bdaaff845f7d55c57962a919851c7287f48a42"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "6eff7e43f5eb64b45eb2cb28fdcd6e763bbeda15ee74efc07a30aa804c667f42"
-    sha256 ventura: "039b9f7ec269c7084871a6ff41e936478e30d7cd3f7189f7da794360d0c42639"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/2845.

Implemented with:

~~~
for m in gz-common5 gz-common6
do
    brew bump-revision --remove-bottle-block --message="broken bottle" $m
    for f in $(.github/ci/bottled_dependents.sh $m)
    do
        brew bump-revision --remove-bottle-block --message="broken bottle" $f
    done
done
~~~