### PR TITLE
gz-transport14: support multiple python versions

### DIFF
--- a/Formula/gz-transport14.rb
+++ b/Formula/gz-transport14.rb
@@ -1,8 +1,8 @@
 class GzTransport14 < Formula
   desc "Transport middleware for robotics"
   homepage "https://gazebosim.org"
-  url "https://github.com/gazebosim/gz-transport.git", branch: "scpeters/build_python_bindings_separately"
-  version "14.0.0~pre1"
+  url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/gz-transport-14.0.0.tar.bz2"
+  sha256 "88cbcef69f16ea5124ff41766cc59c0277bfc3ae57c405f3fbae1dbee874a1c0"
   license "Apache-2.0"
   revision 1
 
@@ -28,6 +28,13 @@ class GzTransport14 < Formula
   depends_on "sqlite"
   depends_on "tinyxml2"
   depends_on "zeromq"
+
+  patch do
+    # Support building python bindings against external gz-transport library
+    # Remove this patch with the next release
+    url "https://github.com/gazebosim/gz-transport/commit/250e95f0757af410adfaab213b3077c0a501252e.patch?full_index=1"
+    sha256 "b7184cc5a1e505ff31a43eacb5b5aa6ac217a07b4eec81e1585f14db6806abb0"
+  end
 
   def pythons
     deps.map(&:to_formula)

--- a/Formula/gz-transport14.rb
+++ b/Formula/gz-transport14.rb
@@ -4,7 +4,7 @@ class GzTransport14 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/gz-transport-14.0.0.tar.bz2"
   sha256 "88cbcef69f16ea5124ff41766cc59c0277bfc3ae57c405f3fbae1dbee874a1c0"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport14"
 

--- a/Formula/gz-transport14.rb
+++ b/Formula/gz-transport14.rb
@@ -8,6 +8,12 @@ class GzTransport14 < Formula
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport14"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "75690bd5d5f2a5d291ade581f3ebcd65dd26d6b56864e0ffc2b46730fe669786"
+    sha256 ventura: "c49af19223e326ab340c666daa9643c18e0ec3c50db37c2c8d7cab695ca8862d"
+  end
+
   depends_on "doxygen" => [:build, :optional]
   depends_on "pybind11" => :build
   depends_on "python@3.12" => [:build, :test]


### PR DESCRIPTION
Part of #2834, currently pointing to branch for https://github.com/gazebosim/gz-transport/pull/554.

Testing:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_transport14-install_bottle-homebrew-amd64&build=330)](https://build.osrfoundation.org/view/gz-ionic/job/gz_transport14-install_bottle-homebrew-amd64/330/) https://build.osrfoundation.org/view/gz-ionic/job/gz_transport14-install_bottle-homebrew-amd64/330/