### PR TITLE
Harmonic: rebuild gz-sim8 dependencies

### DIFF
--- a/Formula/gz-fuel-tools9.rb
+++ b/Formula/gz-fuel-tools9.rb
@@ -8,6 +8,12 @@ class GzFuelTools9 < Formula
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, sonoma:  "4501d260b2a464afa53160d723a8ef3acc494c76dbd50e371456f0c7f584f02f"
+    sha256 cellar: :any, ventura: "18b5aeb21d2cfd5af3900bd433b2681f90e1a3f4a436a2558547623b880e7041"
+  end
+
   depends_on "abseil"
   depends_on "cmake"
   depends_on "gz-cmake3"

--- a/Formula/gz-gui8.rb
+++ b/Formula/gz-gui8.rb
@@ -8,6 +8,12 @@ class GzGui8 < Formula
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui8"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "06e991e69c44f82d48a5d6bfeb610af8c24ab66dc8eaf400b00aaaa51d735ba8"
+    sha256 ventura: "be5ee36cfddefa26a10e6c4b11e2868f29fd04c70f8d3c024ddd004d5f78a9e6"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
   depends_on "abseil"

--- a/Formula/gz-physics7.rb
+++ b/Formula/gz-physics7.rb
@@ -8,6 +8,12 @@ class GzPhysics7 < Formula
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics7"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "e210dde2a1d5e4b820fa6ed608788f012402240905d0cee6d0f048d6087e6c6e"
+    sha256 ventura: "c78191937cbb57d404dea85d769ed49fa1f026716e87d2eaef6653c488843910"
+  end
+
   depends_on "cmake" => [:build, :test]
 
   depends_on "bullet"

--- a/Formula/gz-sensors8.rb
+++ b/Formula/gz-sensors8.rb
@@ -8,6 +8,12 @@ class GzSensors8 < Formula
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors8"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, sonoma:  "312457356d8a9a18dd6b4e49f8920169108880ed42fa6b40c419e75ea8f43404"
+    sha256 cellar: :any, ventura: "a56af3cc8acc85ec452b5a814c52d9a740faf7b23ca4c63e9cfb6ef97e460413"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]
 


### PR DESCRIPTION
Part of #2876, #2837, #2845.

Implemented with:

~~~
for f in $(.github/ci/unbottled_dependencies.sh gz-sim8)
do
    brew bump-revision --message="rebuild" $f
done
~~~