### PR TITLE
Remove bottles broken by spdlog 1.15.0

### DIFF
--- a/Formula/gz-common6.rb
+++ b/Formula/gz-common6.rb
@@ -4,15 +4,9 @@ class GzCommon6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-common/releases/gz-common-6.0.0.tar.bz2"
   sha256 "55ea0e8b51e8c7ba9eb7e0f9a516f0d54b6d48d8d29a961a838e7bdc2531c517"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-common.git", branch: "gz-common6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "f097f0d1bdde0a50b7da6629ef8ecdda8a96f5f716ba6e07ca50b7ba791cec58"
-    sha256 cellar: :any, ventura: "4bce6465326ada3f0b18b3bd1bb957272f1c5f38b81dbc97dadabb0fe57af476"
-  end
 
   depends_on "assimp"
   depends_on "cmake"

--- a/Formula/gz-fuel-tools10.rb
+++ b/Formula/gz-fuel-tools10.rb
@@ -4,15 +4,9 @@ class GzFuelTools10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-10.0.0.tar.bz2"
   sha256 "dce4fb51a6af8d15d3ebdd98ecff4baf47c02ffb4d6aed48b284a7ce9188778e"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools10"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "a7d71656a8aa86b3c2ec85fc9b0088339a410cb6128f43b4844a365bd6151d51"
-    sha256 cellar: :any, ventura: "192e87564eb20da9ae78ce96962572d8124dfe66364a02b2c60fd8c118eca028"
-  end
 
   depends_on "abseil"
   depends_on "cmake"

--- a/Formula/gz-gui9.rb
+++ b/Formula/gz-gui9.rb
@@ -4,15 +4,9 @@ class GzGui9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-9.0.0.tar.bz2"
   sha256 "2534cc688197c973029a43723de50c12a560320106d6b70a27aa4173c0a2d832"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "002173e89542c9ac24ea74cc62bcde3f5bcbf9e2c520534567183586e99b940b"
-    sha256 ventura: "3dd35cf2ab2895abf7c551fb0fa5e195461e65b2d1f26c05baa5805df4ec1166"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/gz-math8.rb
+++ b/Formula/gz-math8.rb
@@ -4,15 +4,9 @@ class GzMath8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-math/releases/gz-math-8.0.0.tar.bz2"
   sha256 "dfc15a78aa52f5e200da991e92ebcbd0bd6f9529326dbe3a1a365ad6d7da9669"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-math.git", branch: "gz-math8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "29a96837fce649d976b595f52a33aa017699255bb9670d36fc2f2c3ec7ad0a6e"
-    sha256 cellar: :any, ventura: "44c40f86186d7750ba293edbce14cae8a4a04b25a6419889cbd316761644baa8"
-  end
 
   depends_on "cmake" => :build
   depends_on "doxygen" => :build

--- a/Formula/gz-msgs11.rb
+++ b/Formula/gz-msgs11.rb
@@ -4,15 +4,9 @@ class GzMsgs11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/gz-msgs-11.0.1.tar.bz2"
   sha256 "4154cea1cf4e8c2b9b40962e44d6ab46b4f767ffab3809e4b6b4022904524fcb"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs11"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "97c50f8eeb15c758fc6c5676c87ab866b33bd50fda9679f201dbe34ac81286b8"
-    sha256 ventura: "01f8c71a773518ed8fcd17d0c2bc91c30920753d149ccb7de0af0f2eb00421b6"
-  end
 
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]

--- a/Formula/gz-plugin3.rb
+++ b/Formula/gz-plugin3.rb
@@ -4,14 +4,9 @@ class GzPlugin3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-plugin/releases/gz-plugin-3.0.0.tar.bz2"
   sha256 "5f69afaec39cb26224bbfb7d84f80dc814221e3606181ed0753a5d5ef7a15ee0"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-plugin.git", branch: "gz-plugin3"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "b4e255cddd1059b266f8849839840156e34d966b1b3a8cade8ab7ea0a24afe9b"
-    sha256 cellar: :any, ventura: "89b015835b64b32016deeb206f6d699e0f1ab843f7c9512cb1df3f331187d77b"
-  end
 
   depends_on "cmake"
   depends_on "gz-cmake4"

--- a/Formula/gz-rendering9.rb
+++ b/Formula/gz-rendering9.rb
@@ -4,15 +4,9 @@ class GzRendering9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-rendering/releases/gz-rendering-9.0.0.tar.bz2"
   sha256 "3b761f62d86db395aa989881e5bdaaff845f7d55c57962a919851c7287f48a42"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "9c7525e47e85a0bb2204c282a04cc25ae5907fe5d77308b1427b36f715715cff"
-    sha256 ventura: "bcfb7fb850c9bd7d4b24b9ec15ab7b358e1014154aca18b83a52c50e71cc6818"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/gz-sensors9.rb
+++ b/Formula/gz-sensors9.rb
@@ -4,15 +4,9 @@ class GzSensors9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-9.0.0.tar.bz2"
   sha256 "f6f3b1bf67ce81a5f3f99feffe44a4de5a7e170ace401b2272d9d5e1814521ec"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "1ecae5070f60ea630130b7fdeb7468f05d42d78faf4e9119b4b3ecf34464c274"
-    sha256 cellar: :any, ventura: "fd665bcea7fe00712675eefcc4d5d825af5dab6091a18b056f88f67110c58831"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/gz-transport14.rb
+++ b/Formula/gz-transport14.rb
@@ -4,15 +4,9 @@ class GzTransport14 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/gz-transport-14.0.0.tar.bz2"
   sha256 "88cbcef69f16ea5124ff41766cc59c0277bfc3ae57c405f3fbae1dbee874a1c0"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport14"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "75690bd5d5f2a5d291ade581f3ebcd65dd26d6b56864e0ffc2b46730fe669786"
-    sha256 ventura: "c49af19223e326ab340c666daa9643c18e0ec3c50db37c2c8d7cab695ca8862d"
-  end
 
   depends_on "doxygen" => [:build, :optional]
   depends_on "pybind11" => :build

--- a/Formula/gz-utils3.rb
+++ b/Formula/gz-utils3.rb
@@ -4,12 +4,7 @@ class GzUtils3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-utils/releases/gz-utils-3.1.0.tar.bz2"
   sha256 "3089407a57af7462b82566110341cc48232d4312c492ff7b9fa1099a9014a10a"
   license "Apache-2.0"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "1156123f3ca137828b17d82510c65b909affe71cfe5cafa985f52b7fc78e70c6"
-    sha256 cellar: :any, ventura: "9ac5532ff8f13159f8940b384fc8b99cc024dfe6a4a7dd991ab3a978a5821a78"
-  end
+  revision 1
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/sdformat15.rb
+++ b/Formula/sdformat15.rb
@@ -4,14 +4,9 @@ class Sdformat15 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-15.1.1.tar.bz2"
   sha256 "1f034179c617004b94063f6aa268cac3b375231ee4ae7160fe289c3d9003ab3b"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/sdformat.git", branch: "sdf15"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "c0fe37ba7dd81bead5f6df325020194e10b7f323819e7390a17fce28e8386557"
-    sha256 ventura: "c3bc9eb55ac4d3a2a40cf3348e5c677153bcc0df4d00114fea769d07c293c8be"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkg-config" => [:build, :test]


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/2882.

Implemented with:

~~~
for m in gz-utils3
do
    brew bump-revision --remove-bottle-block --message="broken bottle" $m
    for f in $(.github/ci/bottled_dependents.sh $m)
    do
        brew bump-revision --remove-bottle-block --message="broken bottle" $f
    done
done
~~~