### PR TITLE
Ionic: rebuild gz-sim9 dependents broken by protobuf 29

### DIFF
--- a/Formula/gz-fuel-tools10.rb
+++ b/Formula/gz-fuel-tools10.rb
@@ -4,7 +4,7 @@ class GzFuelTools10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-10.0.0.tar.bz2"
   sha256 "dce4fb51a6af8d15d3ebdd98ecff4baf47c02ffb4d6aed48b284a7ce9188778e"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools10"
 

--- a/Formula/gz-fuel-tools10.rb
+++ b/Formula/gz-fuel-tools10.rb
@@ -8,6 +8,12 @@ class GzFuelTools10 < Formula
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, sonoma:  "037171d786f4d1b3dae589ff310addff051ad4497f2ec3d6c0525e8c20d589b7"
+    sha256 cellar: :any, ventura: "672d99b135d6223d4c5b0ec43cd87eb32f1814cc7b96b04bc9397e53feb5b937"
+  end
+
   depends_on "abseil"
   depends_on "cmake"
   depends_on "gz-cmake4"

--- a/Formula/gz-gui9.rb
+++ b/Formula/gz-gui9.rb
@@ -8,6 +8,12 @@ class GzGui9 < Formula
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "29b0798e7e8d191e9c9491c197bff9bf82e9422a68b52fa64b919149f23eaf06"
+    sha256 ventura: "eb808d334aeb791aad1de68119c4ff84cb824edcfcb460832b044d7481377988"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
   depends_on "abseil"

--- a/Formula/gz-gui9.rb
+++ b/Formula/gz-gui9.rb
@@ -4,7 +4,7 @@ class GzGui9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-9.0.0.tar.bz2"
   sha256 "2534cc688197c973029a43723de50c12a560320106d6b70a27aa4173c0a2d832"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui9"
 

--- a/Formula/gz-msgs11.rb
+++ b/Formula/gz-msgs11.rb
@@ -4,7 +4,7 @@ class GzMsgs11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/gz-msgs-11.0.1.tar.bz2"
   sha256 "4154cea1cf4e8c2b9b40962e44d6ab46b4f767ffab3809e4b6b4022904524fcb"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs11"
 

--- a/Formula/gz-msgs11.rb
+++ b/Formula/gz-msgs11.rb
@@ -8,6 +8,12 @@ class GzMsgs11 < Formula
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs11"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "1914d79f3e9b11e51663aa58071eb09d292431399313c629e4c4f7ea653b5380"
+    sha256 ventura: "a9193843250b70a1bccaca8424f618f88969982a4ec82003127bb0250c287844"
+  end
+
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
   depends_on "abseil"

--- a/Formula/gz-sensors9.rb
+++ b/Formula/gz-sensors9.rb
@@ -4,7 +4,7 @@ class GzSensors9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-9.0.0.tar.bz2"
   sha256 "f6f3b1bf67ce81a5f3f99feffe44a4de5a7e170ace401b2272d9d5e1814521ec"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors9"
 

--- a/Formula/gz-sensors9.rb
+++ b/Formula/gz-sensors9.rb
@@ -8,6 +8,12 @@ class GzSensors9 < Formula
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, sonoma:  "b4500482287aab54825abad8256bcc4d138bac1c983c97a9fe3cb84fc7b9e051"
+    sha256 cellar: :any, ventura: "f05b0bea283ea10f54a760a4fafc8a555b85f754174310e9cd233b827093d3c0"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
 

--- a/Formula/gz-transport14.rb
+++ b/Formula/gz-transport14.rb
@@ -8,6 +8,12 @@ class GzTransport14 < Formula
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport14"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "9764a3f783e069eb362fea5077b8ae2ba67c1a1d816b019fb3a6089541430434"
+    sha256 ventura: "7b87276a8a834ca78db9d7b62f5616a3a665bde8ff4a0cf7b186abc0669b54df"
+  end
+
   depends_on "doxygen" => [:build, :optional]
   depends_on "pybind11" => :build
   depends_on "python@3.12" => [:build, :test]

--- a/Formula/gz-transport14.rb
+++ b/Formula/gz-transport14.rb
@@ -4,7 +4,7 @@ class GzTransport14 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/gz-transport-14.0.0.tar.bz2"
   sha256 "88cbcef69f16ea5124ff41766cc59c0277bfc3ae57c405f3fbae1dbee874a1c0"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport14"
 


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/2896.

Implemented with:

~~~
for f in $(.github/ci/unbottled_dependencies.sh gz-sim9)
do
    brew bump-revision --message="rebuild" $f
done
~~~