### PR TITLE
Harmonic: rebuild gz-sim9 dependents broken by protobuf 29

### DIFF
--- a/Formula/gz-fuel-tools9.rb
+++ b/Formula/gz-fuel-tools9.rb
@@ -8,6 +8,12 @@ class GzFuelTools9 < Formula
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, sonoma:  "942dc53aa9c127e37d905a3672ad68707f95020eaa52a75e027c1cfea9ad0544"
+    sha256 cellar: :any, ventura: "81d90507543a4ddf97faa33a0f00d2bbf5bdc05bffd0510471f6a2239e949dab"
+  end
+
   depends_on "abseil"
   depends_on "cmake"
   depends_on "gz-cmake3"

--- a/Formula/gz-fuel-tools9.rb
+++ b/Formula/gz-fuel-tools9.rb
@@ -4,7 +4,7 @@ class GzFuelTools9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-9.1.0.tar.bz2"
   sha256 "6335f8c6906f052527c97fb1991afffcfe9991122bce3a7c7ffc02df7c8e4d8d"
   license "Apache-2.0"
-  revision 7
+  revision 8
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools9"
 

--- a/Formula/gz-gui8.rb
+++ b/Formula/gz-gui8.rb
@@ -8,6 +8,12 @@ class GzGui8 < Formula
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui8"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "95920c5f2ce07dc06a70e377434f54d68c3dd91851eec7c1fd856e18cc081de8"
+    sha256 ventura: "e2dee50d78b32e11b7d87056f692453cda075bf9efca95c3a540f075b7da6803"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
   depends_on "abseil"

--- a/Formula/gz-gui8.rb
+++ b/Formula/gz-gui8.rb
@@ -4,7 +4,7 @@ class GzGui8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-8.3.0.tar.bz2"
   sha256 "ba772f4a1cf59d2b29fbb24bb13c618f52c3dc345f363b0a8d2f46d19bea0eb9"
   license "Apache-2.0"
-  revision 11
+  revision 12
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui8"
 

--- a/Formula/gz-msgs10.rb
+++ b/Formula/gz-msgs10.rb
@@ -4,7 +4,7 @@ class GzMsgs10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/gz-msgs-10.3.1.tar.bz2"
   sha256 "b5df1050dc01e74bb996a9d66955ae4f18d058af4e5d5d52341f7d515849db24"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs10"
 

--- a/Formula/gz-msgs10.rb
+++ b/Formula/gz-msgs10.rb
@@ -8,6 +8,12 @@ class GzMsgs10 < Formula
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "a9da65ceb6c327b8980b73ef860d28f7ccb7a4188754dc1b6c7f75cd2575e47e"
+    sha256 ventura: "a7ae46f1c2ef274f01b7a40b50bd61334a372e0b44de541776b93e251d99b554"
+  end
+
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
   depends_on "abseil"

--- a/Formula/gz-sensors8.rb
+++ b/Formula/gz-sensors8.rb
@@ -8,6 +8,12 @@ class GzSensors8 < Formula
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors8"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, sonoma:  "9d8460ff141a106be6e5db1eef27682c4d64b4eb72a408b303de2f03dd18ae88"
+    sha256 cellar: :any, ventura: "097750acd6f99824d3d0166722aedabe1f6fd9c50bb9c045f3b4bfbe6557ced4"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
 

--- a/Formula/gz-sensors8.rb
+++ b/Formula/gz-sensors8.rb
@@ -4,7 +4,7 @@ class GzSensors8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-8.2.1.tar.bz2"
   sha256 "a651f8970e07055d7abdc32734e638ebf5904a99ab87b6ad1091ab65974cf6a9"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors8"
 

--- a/Formula/gz-transport13.rb
+++ b/Formula/gz-transport13.rb
@@ -8,6 +8,12 @@ class GzTransport13 < Formula
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport13"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "68fc487e60785b1ca424cf2b9eb2fd9404b1a74909d0d90a4f587f5a258beec6"
+    sha256 ventura: "ba6abe0f1d734a5d4a881b6d42e3d3138155f86a7f02769e89950b3e6fd9f335"
+  end
+
   depends_on "doxygen" => [:build, :optional]
   depends_on "pybind11" => :build
   depends_on "python@3.12" => [:build, :test]

--- a/Formula/gz-transport13.rb
+++ b/Formula/gz-transport13.rb
@@ -4,7 +4,7 @@ class GzTransport13 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/gz-transport-13.4.0.tar.bz2"
   sha256 "bec7a13e2f40df963afcf8dc87a9c2e34369daec80f36636965c92d4c8bf5a46"
   license "Apache-2.0"
-  revision 11
+  revision 12
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport13"
 


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/2896.

Implemented with:

~~~
for f in $(.github/ci/unbottled_dependencies.sh gz-sim8)
do
    brew bump-revision --message="rebuild" $f
done
~~~