### PR TITLE
Citadel: rebuild bottles broken by protobuf 29

### DIFF
--- a/Formula/ignition-fuel-tools4.rb
+++ b/Formula/ignition-fuel-tools4.rb
@@ -8,6 +8,12 @@ class IgnitionFuelTools4 < Formula
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools4"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, sonoma:  "43d6dd08b031baddb3528b8e6aa0b2c8b6ff6e9565350a507247d204b673623f"
+    sha256 cellar: :any, ventura: "966df20d11a5e91949a3b0df60177d684d5777be89c630b141484099b894cfdc"
+  end
+
   depends_on "cmake"
   depends_on "ignition-cmake2"
   depends_on "ignition-common3"

--- a/Formula/ignition-fuel-tools4.rb
+++ b/Formula/ignition-fuel-tools4.rb
@@ -4,7 +4,7 @@ class IgnitionFuelTools4 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-fuel-tools/releases/ignition-fuel-tools4-4.9.1.tar.bz2"
   sha256 "35b8cdceae46f50360081eb1b310366ae085a8c64d88fee7175f2b0582e454a2"
   license "Apache-2.0"
-  revision 27
+  revision 28
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools4"
 

--- a/Formula/ignition-gazebo3.rb
+++ b/Formula/ignition-gazebo3.rb
@@ -4,7 +4,7 @@ class IgnitionGazebo3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gazebo/releases/ignition-gazebo3-3.15.1.tar.bz2"
   sha256 "c801d4205f8f88fca813cbf699cf6a077536d430e6c312a85520d6f50a7052bd"
   license "Apache-2.0"
-  revision 27
+  revision 28
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo3"
 

--- a/Formula/ignition-gazebo3.rb
+++ b/Formula/ignition-gazebo3.rb
@@ -8,6 +8,12 @@ class IgnitionGazebo3 < Formula
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo3"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "c7ffc74d4f859463f984e96a3633db891b04ae1c3371e59c8a2264efaae0bbb8"
+    sha256 ventura: "d8bd5ea42f5c19266e5c9db3a4637fa13662b8b08e4058843a8ae2a7440c67af"
+  end
+
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 
   depends_on "cmake" => :build

--- a/Formula/ignition-gui3.rb
+++ b/Formula/ignition-gui3.rb
@@ -8,6 +8,12 @@ class IgnitionGui3 < Formula
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui3"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "c779d8ae23637c038d0230066d348354d9a0baa7239b43e34f52e8b1674ac425"
+    sha256 ventura: "783438c665f959af14647b06cc9ae65f77e2ee904e4244a326487010eabd47f8"
+  end
+
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/ignition-gui3.rb
+++ b/Formula/ignition-gui3.rb
@@ -4,7 +4,7 @@ class IgnitionGui3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gui/releases/ignition-gui3-3.12.0.tar.bz2"
   sha256 "f53ee05d844449b900ecb30d5e1f812fd3f7e9e28630d309b7d8d11add3c3b1c"
   license "Apache-2.0"
-  revision 46
+  revision 47
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui3"
 

--- a/Formula/ignition-launch2.rb
+++ b/Formula/ignition-launch2.rb
@@ -8,6 +8,12 @@ class IgnitionLaunch2 < Formula
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "ign-launch2"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "f28ab961d08e29709b2e03ddba5749d32edd407e2d1653605b289bbdfdfaf9d5"
+    sha256 ventura: "d1ded37cc44abfeba318b4567fb00f93aaf6dc5224e46f39892e7ccaaa135952"
+  end
+
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 
   depends_on "cmake" => :build

--- a/Formula/ignition-launch2.rb
+++ b/Formula/ignition-launch2.rb
@@ -4,7 +4,7 @@ class IgnitionLaunch2 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-launch/releases/ignition-launch2-2.3.1.tar.bz2"
   sha256 "984e2a5df03ca220960470b6b59728edf3cd570314fbad6435b67cb26c9b7e4e"
   license "Apache-2.0"
-  revision 27
+  revision 28
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "ign-launch2"
 

--- a/Formula/ignition-msgs5.rb
+++ b/Formula/ignition-msgs5.rb
@@ -8,6 +8,12 @@ class IgnitionMsgs5 < Formula
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs5"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, sonoma:  "a8a85236dbc9df9b4ed919f4bc3950cf26f74b40c3a2ae1b4ba8c0e69c8475de"
+    sha256 cellar: :any, ventura: "c0dad8537e365ac6675c2cef9acc109eaf4f05501660a05169bf901c13d3670f"
+  end
+
   depends_on "cmake"
   depends_on "ignition-cmake2"
   depends_on "ignition-math6"

--- a/Formula/ignition-msgs5.rb
+++ b/Formula/ignition-msgs5.rb
@@ -4,7 +4,7 @@ class IgnitionMsgs5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs5-5.11.0.tar.bz2"
   sha256 "59a03770c27b4cdb6d0b0f3de9f10f1c748a47b45376a297e1f30900edb893fd"
   license "Apache-2.0"
-  revision 41
+  revision 42
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs5"
 

--- a/Formula/ignition-sensors3.rb
+++ b/Formula/ignition-sensors3.rb
@@ -4,7 +4,7 @@ class IgnitionSensors3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-sensors/releases/ignition-sensors3-3.6.0.tar.bz2"
   sha256 "b64b187333907a9e866307ccc76649672e0df9b6bdfb4a390929ebbcaa83ce64"
   license "Apache-2.0"
-  revision 27
+  revision 28
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors3"
 

--- a/Formula/ignition-sensors3.rb
+++ b/Formula/ignition-sensors3.rb
@@ -8,6 +8,12 @@ class IgnitionSensors3 < Formula
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors3"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "506b33fd782db22022b1d8194946d30ad77e21606a647192b5523f551da065d5"
+    sha256 ventura: "21eb3722dad512083f05d950c3bb886a6a65ba9f918b8836a53de2879d2aca2a"
+  end
+
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/ignition-transport8.rb
+++ b/Formula/ignition-transport8.rb
@@ -8,6 +8,12 @@ class IgnitionTransport8 < Formula
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport8"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "036f9a6f844808d1e3fddfadb850cdfa256c8fb8a26f2068b3d5184247bc6d28"
+    sha256 ventura: "63c8bf3b12a306d439a9e2e22916a2132965d12e875a72aa28e0654c9971631d"
+  end
+
   depends_on "doxygen" => [:build, :optional]
 
   depends_on "cmake"

--- a/Formula/ignition-transport8.rb
+++ b/Formula/ignition-transport8.rb
@@ -4,7 +4,7 @@ class IgnitionTransport8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases/ignition-transport8-8.5.0.tar.bz2"
   sha256 "5edd15699e35ade5ad2f814af1f5e96a866f7908e16b55333abb23978f44d4c6"
   license "Apache-2.0"
-  revision 25
+  revision 26
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport8"
 


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/2896.

Implemented with:

~~~
for f in $(.github/ci/unbottled_dependencies.sh gz-citadel)
do
    brew bump-revision --message="rebuild" $f
done
~~~