### PR TITLE
Remove bottles broken by protobuf 29.2

### DIFF
--- a/Formula/gz-fuel-tools10.rb
+++ b/Formula/gz-fuel-tools10.rb
@@ -4,15 +4,9 @@ class GzFuelTools10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-10.0.0.tar.bz2"
   sha256 "dce4fb51a6af8d15d3ebdd98ecff4baf47c02ffb4d6aed48b284a7ce9188778e"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools10"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "c3f597d64c4fa406cb87d23ab2d49131126708cacec6af93cb9084e749eb3405"
-    sha256 cellar: :any, ventura: "be387f33ed13c8cb63711281764ac2511cb6a7154e3a96a212482867352e3844"
-  end
 
   depends_on "abseil"
   depends_on "cmake"

--- a/Formula/gz-fuel-tools9.rb
+++ b/Formula/gz-fuel-tools9.rb
@@ -4,15 +4,9 @@ class GzFuelTools9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-9.1.0.tar.bz2"
   sha256 "6335f8c6906f052527c97fb1991afffcfe9991122bce3a7c7ffc02df7c8e4d8d"
   license "Apache-2.0"
-  revision 10
+  revision 11
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "42f69aa3ec50c479935200a4b75a1ecf27aa4fd1a3438733b6e8203532ddbdcd"
-    sha256 cellar: :any, ventura: "ef116537ae4f2eb1166a7bdf95f433e0401370b8e2c9dfd6bc1ad0a66144c973"
-  end
 
   depends_on "abseil"
   depends_on "cmake"

--- a/Formula/gz-gui8.rb
+++ b/Formula/gz-gui8.rb
@@ -4,15 +4,9 @@ class GzGui8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-8.3.0.tar.bz2"
   sha256 "ba772f4a1cf59d2b29fbb24bb13c618f52c3dc345f363b0a8d2f46d19bea0eb9"
   license "Apache-2.0"
-  revision 14
+  revision 15
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "92acb7a6843c107fe196dcfcc57a14f2cfac04d7f54a84bb02d972f3f26f2031"
-    sha256 ventura: "5967de1eb15648ffde19b5fe620c135859c53f76717d03a8c716020b61667d72"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-gui9.rb
+++ b/Formula/gz-gui9.rb
@@ -4,15 +4,9 @@ class GzGui9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-9.0.0.tar.bz2"
   sha256 "2534cc688197c973029a43723de50c12a560320106d6b70a27aa4173c0a2d832"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "436d198ede05110be2c3443ba9bbcddb07146ba3cfcbd35b9b30080771090528"
-    sha256 ventura: "9037efeea8c9e2afd051095d820c661ebefb5845816512c632ca7c9127270eaf"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-launch7.rb
+++ b/Formula/gz-launch7.rb
@@ -4,15 +4,9 @@ class GzLaunch7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-7.1.0.tar.bz2"
   sha256 "320606c71b6a2cbbcab683cd8569af9145ece157d5ebd23bc80218e8d148cd09"
   license "Apache-2.0"
-  revision 17
+  revision 18
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "a9c9bb383e865ff757e940cee4debc6fea88df30b4027f7ca250edf347fbc1ad"
-    sha256 ventura: "0012115ea253583b5046b244379bfceef31b96edc5d5c0f12fa78a8757ef826b"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build

--- a/Formula/gz-launch8.rb
+++ b/Formula/gz-launch8.rb
@@ -4,15 +4,9 @@ class GzLaunch8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-8.0.0.tar.bz2"
   sha256 "474e6dfeb2f1faed59f644d87decad6db53bec6046aea4b302907ff88985ebba"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "da9f1318db31dd4ccc628dcfba88e0a27adf2bd1c6000fc0938b4c82d08d330b"
-    sha256 ventura: "130fb2fcd4bbc83ee05eee896c23b2c28562febf540716105251ebb5751ef0b5"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build

--- a/Formula/gz-msgs10.rb
+++ b/Formula/gz-msgs10.rb
@@ -4,15 +4,9 @@ class GzMsgs10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/gz-msgs-10.3.1.tar.bz2"
   sha256 "b5df1050dc01e74bb996a9d66955ae4f18d058af4e5d5d52341f7d515849db24"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs10"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "2e3c1b945e6620cda02fa1e0ec5e57ec7c151f5e49024bf2b1567a5c6849a121"
-    sha256 ventura: "e710e26cce1466981d767ff10436f67c37a504f3a8380ff9355ea8f5ecc9567b"
-  end
 
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]

--- a/Formula/gz-msgs11.rb
+++ b/Formula/gz-msgs11.rb
@@ -4,15 +4,9 @@ class GzMsgs11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/gz-msgs-11.0.1.tar.bz2"
   sha256 "4154cea1cf4e8c2b9b40962e44d6ab46b4f767ffab3809e4b6b4022904524fcb"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs11"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "a2359a03076b220fad5f6a111cd68444dafc7ba79caca34a4fce8e1a5d5c899c"
-    sha256 ventura: "7f5ff49a02069b08305c387a2d49946645b7d9a4856ea4b23ee5b9704e9b1379"
-  end
 
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]

--- a/Formula/gz-sensors8.rb
+++ b/Formula/gz-sensors8.rb
@@ -4,15 +4,9 @@ class GzSensors8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-8.2.1.tar.bz2"
   sha256 "a651f8970e07055d7abdc32734e638ebf5904a99ab87b6ad1091ab65974cf6a9"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "f117d734e323bfdf387a54acec80da312b79b180a4321e47d42d039b91f39e31"
-    sha256 cellar: :any, ventura: "0444d7b0aec5a4b2be84ede5ad174e79d29e5e362a5d9f0e0d2a1c96e4bda1bb"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-sensors9.rb
+++ b/Formula/gz-sensors9.rb
@@ -4,15 +4,9 @@ class GzSensors9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-9.0.0.tar.bz2"
   sha256 "f6f3b1bf67ce81a5f3f99feffe44a4de5a7e170ace401b2272d9d5e1814521ec"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "bfbe09b3d0a0f7dc07b91d5e097aa5fde16e7d7ca0c1ba43534dc91e85df112e"
-    sha256 cellar: :any, ventura: "bb62719fa97a922a8758e3589f6ab0cf93aaa8ea3cc9b731f6effe4e5c14ed3e"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-sim8.rb
+++ b/Formula/gz-sim8.rb
@@ -4,15 +4,9 @@ class GzSim8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-8.7.0.tar.bz2"
   sha256 "4375643526a0009723b67ee74127432f94f730f67d6098d548e7e731d1e2e7e6"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "daa1d31119542b15c2d93605c870f7c530b42040e22bbdd54f70c81044b91256"
-    sha256 ventura: "8a0fca80dc3bf32929f830956faf0a7966ca78f2a51753e53babf9e5fbbfa46c"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build

--- a/Formula/gz-sim9.rb
+++ b/Formula/gz-sim9.rb
@@ -4,15 +4,9 @@ class GzSim9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-9.0.0.tar.bz2"
   sha256 "62effba56ffbfdb2db67b6ccca17527df0ede7fa83469df72c2f043f6cc96ea8"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "c83c8f2e8fd7b39bf8fdafcd4ad5c9db8d1ea8e20de143a1fbc15a9703abd0d8"
-    sha256 ventura: "1cc054b0c1ee3f0fe4ee880fd9d6bdccbe0ab8ee81f1eedf63a14e12c01f8983"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build

--- a/Formula/gz-transport13.rb
+++ b/Formula/gz-transport13.rb
@@ -4,15 +4,9 @@ class GzTransport13 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/gz-transport-13.4.0.tar.bz2"
   sha256 "bec7a13e2f40df963afcf8dc87a9c2e34369daec80f36636965c92d4c8bf5a46"
   license "Apache-2.0"
-  revision 14
+  revision 15
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport13"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "3da3aaa18cecb71ab21fc98080d28b8994851a667b4b6099d7227f4212870429"
-    sha256 ventura: "3859255e08d3d7e844db460bf1acccdf0b873ee3dcfddf82f760694ddc1d91ee"
-  end
 
   depends_on "doxygen" => [:build, :optional]
   depends_on "pybind11" => :build

--- a/Formula/gz-transport14.rb
+++ b/Formula/gz-transport14.rb
@@ -4,15 +4,9 @@ class GzTransport14 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/gz-transport-14.0.0.tar.bz2"
   sha256 "88cbcef69f16ea5124ff41766cc59c0277bfc3ae57c405f3fbae1dbee874a1c0"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport14"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "2afc4e134d4c3270e7fe068b0ea7f71fb7906e311db0d0346b76467d39c06f55"
-    sha256 ventura: "9610c941e00e8db3c3ae60368ac4eefb1f069d24e7108c6a89d015b331eecb1e"
-  end
 
   depends_on "doxygen" => [:build, :optional]
   depends_on "pybind11" => :build

--- a/Formula/ignition-fuel-tools4.rb
+++ b/Formula/ignition-fuel-tools4.rb
@@ -4,15 +4,9 @@ class IgnitionFuelTools4 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-fuel-tools/releases/ignition-fuel-tools4-4.9.1.tar.bz2"
   sha256 "35b8cdceae46f50360081eb1b310366ae085a8c64d88fee7175f2b0582e454a2"
   license "Apache-2.0"
-  revision 30
+  revision 31
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools4"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "d1ca437809022a1b0f4c8083da2165b0578e4d9685abb87d85a4fe22a0a9055c"
-    sha256 cellar: :any, ventura: "a4227dfae4b81840baaf0f7fb2789de7d4b1dd60541fb8fb204fcfaab06c3a8d"
-  end
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -4,15 +4,9 @@ class IgnitionFuelTools7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/ignition-fuel_tools-7.3.1.tar.bz2"
   sha256 "b8224c574406147ae008ed9a0ac459f1e2582f6aaef7ba44e1fd1c5ac97b6de8"
   license "Apache-2.0"
-  revision 10
+  revision 11
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "b9cd2e2bc2f3549a3c15fde84544e2c8ef92e39899c59c21248fec46113c32f6"
-    sha256 cellar: :any, ventura: "6529a717379f9082b31b424fd54518c057a61e6d51e308296a32818688ba457f"
-  end
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-gazebo3.rb
+++ b/Formula/ignition-gazebo3.rb
@@ -4,14 +4,9 @@ class IgnitionGazebo3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/ignition-gazebo-3.15.2.tar.bz2"
   sha256 "4d111085e1a6a41015fee61e06adbd4c43604b6aeb7a4cc9ad1c7a57b4af09e2"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo3"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "0f84876d0c1ca10dfdf3a611737bdbc9dacae336ab6e943aaa660730c376e1b2"
-    sha256 ventura: "b114f0e46e1a48e6ace9bae40754ccef7c60465f05c7578aee22fef90dbcca74"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -4,15 +4,9 @@ class IgnitionGazebo6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gazebo/releases/ignition-gazebo6-6.16.0.tar.bz2"
   sha256 "1e61148e8b49a5a20f4cac1e116ce5c4d8de3718a1d26e41a1cec394ce5ea9e4"
   license "Apache-2.0"
-  revision 28
+  revision 29
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "0a0ae62d8ac5df9fb2da1cf4775f6bc5a7367ea3945b79a93f821c89dcbceca3"
-    sha256 ventura: "84c2f29644ee2640ece04f702fda6f7bb839b11fb1eba9f4acbad6d15d4ac090"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build

--- a/Formula/ignition-gui3.rb
+++ b/Formula/ignition-gui3.rb
@@ -4,14 +4,9 @@ class IgnitionGui3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/ignition-gui-3.12.1.tar.bz2"
   sha256 "47221dba126197f1c40bb4b32e82833db6a46637ede89e84c7849116a9c87aff"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui3"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "2cbeaff05d4de31bb86f4636f461e532b7a0a526978e2944d07d5f678ba45f05"
-    sha256 ventura: "0b8b27ac257f200043cb96042d62e11cfbb0ad6f2d87baefde2f4d65a2599ceb"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -4,15 +4,9 @@ class IgnitionGui6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gui/releases/ignition-gui6-6.8.0.tar.bz2"
   sha256 "dd4f26100f4d1343f068ba36f2b8394a0cddb337efde7b4a21c1b0f66ce496c9"
   license "Apache-2.0"
-  revision 46
+  revision 47
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "de8dd730bd0f1d7702d21998a89e7c34d0dd8cd812b9f75119a4166acba611a2"
-    sha256 ventura: "16b47a24840f48be43dd5fd38c64cde4d59b3bbf64f7743d7ef3d0e039ccee24"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/ignition-launch2.rb
+++ b/Formula/ignition-launch2.rb
@@ -4,15 +4,9 @@ class IgnitionLaunch2 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-launch/releases/ignition-launch2-2.3.1.tar.bz2"
   sha256 "984e2a5df03ca220960470b6b59728edf3cd570314fbad6435b67cb26c9b7e4e"
   license "Apache-2.0"
-  revision 30
+  revision 31
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "ign-launch2"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "be96be92995becc8b41f451105767246ab620ae584161903f8b45b824a83497c"
-    sha256 ventura: "adb56f633fe642139531e95f560237fd63d34fee22feb0f204a31781bd740f9a"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-launch5.rb
+++ b/Formula/ignition-launch5.rb
@@ -4,15 +4,9 @@ class IgnitionLaunch5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-launch/releases/ignition-launch5-5.3.0.tar.bz2"
   sha256 "84d356b9c85609da1bb7feda2f90ae6d1a1fd2d6713b284799d5605de42e2613"
   license "Apache-2.0"
-  revision 44
+  revision 45
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "ign-launch5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "a3944b56a9259666ff25ec102516d0e0030594c9cc54d62a235381f848fb0eab"
-    sha256 ventura: "0c0625509b0d471f3ecb8250b5e0dd2dbef0b27ff6bfec5e5fc058f5482562c0"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build

--- a/Formula/ignition-msgs5.rb
+++ b/Formula/ignition-msgs5.rb
@@ -4,15 +4,9 @@ class IgnitionMsgs5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs5-5.11.0.tar.bz2"
   sha256 "59a03770c27b4cdb6d0b0f3de9f10f1c748a47b45376a297e1f30900edb893fd"
   license "Apache-2.0"
-  revision 44
+  revision 45
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "27f832858d6ef865aa1db5c470878eddecb6fb23545734ec6b93e92d55ccef8e"
-    sha256 cellar: :any, ventura: "2df3a74702a300574b261845592d8c91a6e8c95ca03f7a6d52b7ffb97d8b073c"
-  end
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-msgs8.rb
+++ b/Formula/ignition-msgs8.rb
@@ -4,15 +4,9 @@ class IgnitionMsgs8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs8-8.7.0.tar.bz2"
   sha256 "b17a8e16fe56a84891bd0654a2ac09427e9a567b9cd2255bb2cfa830f8e1af45"
   license "Apache-2.0"
-  revision 43
+  revision 44
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "2e59845e3776c6f2689a50e3b4e0c7a923db6e0ff39335196e1092699ad84bc0"
-    sha256 cellar: :any, ventura: "3d8c0704f2fb31ff278a229d39ae14f80d6a6b00578a08c347be326dc45f5017"
-  end
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-sensors3.rb
+++ b/Formula/ignition-sensors3.rb
@@ -4,15 +4,9 @@ class IgnitionSensors3 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-sensors/releases/ignition-sensors3-3.6.0.tar.bz2"
   sha256 "b64b187333907a9e866307ccc76649672e0df9b6bdfb4a390929ebbcaa83ce64"
   license "Apache-2.0"
-  revision 30
+  revision 31
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors3"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "6634e11ca4905b9e33716bb5dab7b9411fba19f3d17dd98225f90b9052eae344"
-    sha256 ventura: "f1e74c7e2f3835f819800cb1edad0038cfde2d0b73d188a8ebfffd3a0f3d4e1b"
-  end
 
   deprecate! date: "2024-12-31", because: "is past end-of-life date"
 

--- a/Formula/ignition-sensors6.rb
+++ b/Formula/ignition-sensors6.rb
@@ -4,15 +4,9 @@ class IgnitionSensors6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/ignition-sensors-6.8.1.tar.bz2"
   sha256 "abc96be3bd018cae94c83981d173af0f67ce2980ef7a1374b34bd5b63f9a7235"
   license "Apache-2.0"
-  revision 6
+  revision 7
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "a9931455b85d4a01f715bb3a7b1f4aab315b8777bb93ceab50ae228391600fd1"
-    sha256 cellar: :any, ventura: "ec5cb67125012228d3b6fae3f6501f7f041d64ff5b931f2a7fe8f2bef69ddf0f"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -4,16 +4,10 @@ class IgnitionTransport11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases/ignition-transport11-11.4.1.tar.bz2"
   sha256 "f18501cbd5c78b584b3db1960a3049d6ae416bab7f0289af64eadda13d1c5da5"
   license "Apache-2.0"
-  revision 36
+  revision 37
   version_scheme 1
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport11"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "bfd2a03a55e9b40861f06caf028ad4ebdcf443579f33f6c263cb8aea61b18065"
-    sha256 ventura: "23de9755757f10a76e0022ab34ddf6648c33e0ecf1464e3ef09191b62699c1b7"
-  end
 
   depends_on "doxygen" => [:build, :optional]
 

--- a/Formula/ignition-transport8.rb
+++ b/Formula/ignition-transport8.rb
@@ -4,15 +4,9 @@ class IgnitionTransport8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases/ignition-transport8-8.5.0.tar.bz2"
   sha256 "5edd15699e35ade5ad2f814af1f5e96a866f7908e16b55333abb23978f44d4c6"
   license "Apache-2.0"
-  revision 28
+  revision 29
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "4a6948db155729b45b7d4047c6b20b6b0e92eb874aa36b92d48b2ddef2624e14"
-    sha256 ventura: "bf375e3a9b84d2b340a066409a6527896f6b55624140f6dae30614b140e662de"
-  end
 
   depends_on "doxygen" => [:build, :optional]
 


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/2920.

Implemented using:

~~~
for m in gz-msgs11 gz-msgs10 gz-msgs8 gz-msgs5
do
    brew bump-revision --remove-bottle-block --message="broken bottle" $m
    for f in $(.github/ci/bottled_dependents.sh $m)
    do
        brew bump-revision --remove-bottle-block --message="broken bottle" $f
    done
done
~~~