### PR TITLE
Harmonic: rebuild bottles broken by protobuf 29.2

### DIFF
--- a/Formula/gz-fuel-tools9.rb
+++ b/Formula/gz-fuel-tools9.rb
@@ -8,6 +8,12 @@ class GzFuelTools9 < Formula
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, sonoma:  "5b4e12a8b88082fbd8fe2d44aa1fac24e591d85f85658ca056b236887a55a142"
+    sha256 cellar: :any, ventura: "adf3bc5ea6dda128c034ce6b2f97462359fc61daa5a02b50a038750edb9937cb"
+  end
+
   depends_on "abseil"
   depends_on "cmake"
   depends_on "gz-cmake3"

--- a/Formula/gz-fuel-tools9.rb
+++ b/Formula/gz-fuel-tools9.rb
@@ -4,7 +4,7 @@ class GzFuelTools9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-9.1.0.tar.bz2"
   sha256 "6335f8c6906f052527c97fb1991afffcfe9991122bce3a7c7ffc02df7c8e4d8d"
   license "Apache-2.0"
-  revision 11
+  revision 12
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools9"
 

--- a/Formula/gz-gui8.rb
+++ b/Formula/gz-gui8.rb
@@ -4,7 +4,7 @@ class GzGui8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-8.3.0.tar.bz2"
   sha256 "ba772f4a1cf59d2b29fbb24bb13c618f52c3dc345f363b0a8d2f46d19bea0eb9"
   license "Apache-2.0"
-  revision 15
+  revision 16
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui8"
 

--- a/Formula/gz-gui8.rb
+++ b/Formula/gz-gui8.rb
@@ -8,6 +8,12 @@ class GzGui8 < Formula
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui8"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "24e730e07d3ce362973b0c414e7a54c2d1f413380a305bfe411c9a707c3b0b10"
+    sha256 ventura: "ab0d9a0b7f1f14861773d37a6cf78a30666a782b99de2be344f6dd5fb7f3f5d8"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
   depends_on "abseil"

--- a/Formula/gz-launch7.rb
+++ b/Formula/gz-launch7.rb
@@ -4,7 +4,7 @@ class GzLaunch7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-7.1.0.tar.bz2"
   sha256 "320606c71b6a2cbbcab683cd8569af9145ece157d5ebd23bc80218e8d148cd09"
   license "Apache-2.0"
-  revision 18
+  revision 19
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch7"
 

--- a/Formula/gz-launch7.rb
+++ b/Formula/gz-launch7.rb
@@ -8,6 +8,12 @@ class GzLaunch7 < Formula
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch7"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "e63e3e48ca4e4fbfe5eb59968b0e42fdb168c8b92eb8fdf8861d02234cc78400"
+    sha256 ventura: "40131892f400a5eb390ad747c9625f3b902cd217acf1873826e72b1c029bcc8b"
+  end
+
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
 

--- a/Formula/gz-msgs10.rb
+++ b/Formula/gz-msgs10.rb
@@ -4,7 +4,7 @@ class GzMsgs10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/gz-msgs-10.3.1.tar.bz2"
   sha256 "b5df1050dc01e74bb996a9d66955ae4f18d058af4e5d5d52341f7d515849db24"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs10"
 

--- a/Formula/gz-msgs10.rb
+++ b/Formula/gz-msgs10.rb
@@ -8,6 +8,12 @@ class GzMsgs10 < Formula
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "a2444db415901d5be83314f18a6061fc13de282ed1ef11342597c8827b913414"
+    sha256 ventura: "8cd6c0e7cf25c91415362d1df606ce4eb064ac4d65548f00052f7195eb52385f"
+  end
+
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
   depends_on "abseil"

--- a/Formula/gz-sensors8.rb
+++ b/Formula/gz-sensors8.rb
@@ -8,6 +8,12 @@ class GzSensors8 < Formula
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors8"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, sonoma:  "fd3e5e0cdc412d6e7d99ba794f9ed569d802efab2318aab5402ad404bebce6de"
+    sha256 cellar: :any, ventura: "1f852ab1ef3caf58e72bf39626a1a2440252c7641e086ddd364b6bb5ab2834d9"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
 

--- a/Formula/gz-sensors8.rb
+++ b/Formula/gz-sensors8.rb
@@ -4,7 +4,7 @@ class GzSensors8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-8.2.1.tar.bz2"
   sha256 "a651f8970e07055d7abdc32734e638ebf5904a99ab87b6ad1091ab65974cf6a9"
   license "Apache-2.0"
-  revision 6
+  revision 7
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors8"
 

--- a/Formula/gz-sim8.rb
+++ b/Formula/gz-sim8.rb
@@ -8,6 +8,12 @@ class GzSim8 < Formula
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim8"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "4f19ed89aae2d4619836cd9552a34a9c1362c1b0ffd681285c1aafc480d2aa9c"
+    sha256 ventura: "c482ad1d339ecdd6a69acd1fbec03a26713d3fd98c9402939a7db9c546f8f941"
+  end
+
   depends_on "cmake" => :build
   depends_on "pybind11" => :build
   depends_on "python@3.13" => [:build, :test]

--- a/Formula/gz-sim8.rb
+++ b/Formula/gz-sim8.rb
@@ -4,7 +4,7 @@ class GzSim8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-8.7.0.tar.bz2"
   sha256 "4375643526a0009723b67ee74127432f94f730f67d6098d548e7e731d1e2e7e6"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim8"
 

--- a/Formula/gz-transport13.rb
+++ b/Formula/gz-transport13.rb
@@ -8,6 +8,12 @@ class GzTransport13 < Formula
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport13"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "e8224be719ec0ac858a611889bd936b92a2bad2cb90cc234b82e8be9144f41b8"
+    sha256 ventura: "23ba73bea5fc648e6a3618ce3db5286ce593aefe5dfdb57cc15e7eff0e277e55"
+  end
+
   depends_on "doxygen" => [:build, :optional]
   depends_on "pybind11" => :build
   depends_on "python@3.12" => [:build, :test]

--- a/Formula/gz-transport13.rb
+++ b/Formula/gz-transport13.rb
@@ -4,7 +4,7 @@ class GzTransport13 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/gz-transport-13.4.0.tar.bz2"
   sha256 "bec7a13e2f40df963afcf8dc87a9c2e34369daec80f36636965c92d4c8bf5a46"
   license "Apache-2.0"
-  revision 15
+  revision 16
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport13"
 


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/2920.

Implemented with:

~~~
for f in $(.github/ci/unbottled_dependencies.sh gz-harmonic)
do
    brew bump-revision --message="rebuild" $f
done
~~~