### PR TITLE
Fortress: rebuild bottles broken by protobuf 29.2

### DIFF
--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -8,6 +8,12 @@ class IgnitionFuelTools7 < Formula
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools7"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, sonoma:  "75e64c17e688761e2f9624af5753e89efc15a6963accc2bdfcb0bd3e166c5b36"
+    sha256 cellar: :any, ventura: "a8246223910495ef1e0961ae60a10efdb7dce3106c20d7de7acef15d230ac04d"
+  end
+
   depends_on "cmake"
   depends_on "ignition-cmake2"
   depends_on "ignition-common4"

--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -4,7 +4,7 @@ class IgnitionFuelTools7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/ignition-fuel_tools-7.3.1.tar.bz2"
   sha256 "b8224c574406147ae008ed9a0ac459f1e2582f6aaef7ba44e1fd1c5ac97b6de8"
   license "Apache-2.0"
-  revision 11
+  revision 12
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools7"
 

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -8,6 +8,12 @@ class IgnitionGazebo6 < Formula
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo6"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "3f4d585e76136f21a2899fbdecbfc72d21149829d44a6377a5021688eaef0b77"
+    sha256 ventura: "06fa09d806717e0e8365225f82559b4d9b5bae493a08f5e23460424cf714509b"
+  end
+
   depends_on "cmake" => :build
   depends_on "pybind11" => :build
   depends_on "gz-plugin2" => :test

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -4,7 +4,7 @@ class IgnitionGazebo6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gazebo/releases/ignition-gazebo6-6.16.0.tar.bz2"
   sha256 "1e61148e8b49a5a20f4cac1e116ce5c4d8de3718a1d26e41a1cec394ce5ea9e4"
   license "Apache-2.0"
-  revision 29
+  revision 30
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo6"
 

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -4,7 +4,7 @@ class IgnitionGui6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gui/releases/ignition-gui6-6.8.0.tar.bz2"
   sha256 "dd4f26100f4d1343f068ba36f2b8394a0cddb337efde7b4a21c1b0f66ce496c9"
   license "Apache-2.0"
-  revision 47
+  revision 48
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui6"
 

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -8,6 +8,12 @@ class IgnitionGui6 < Formula
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui6"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "0b82cf31d934fa9d6f87929c4b0ccddeb605e982ee684bf0ba8ace17bbf28617"
+    sha256 ventura: "14188edbe611782ed539ae71c3f6e5e37b386452a9b65c20317ce413170677f4"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
 

--- a/Formula/ignition-launch5.rb
+++ b/Formula/ignition-launch5.rb
@@ -8,6 +8,12 @@ class IgnitionLaunch5 < Formula
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "ign-launch5"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "3e9728b4ea1afd651f59cfebb644086d850005063a7521525e260384a382742d"
+    sha256 ventura: "2c441df4c45e6a0dbfe6e674c529e77470cba1eb849a20a0bfd7a3c0e983aea1"
+  end
+
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
 

--- a/Formula/ignition-launch5.rb
+++ b/Formula/ignition-launch5.rb
@@ -4,7 +4,7 @@ class IgnitionLaunch5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-launch/releases/ignition-launch5-5.3.0.tar.bz2"
   sha256 "84d356b9c85609da1bb7feda2f90ae6d1a1fd2d6713b284799d5605de42e2613"
   license "Apache-2.0"
-  revision 45
+  revision 46
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "ign-launch5"
 

--- a/Formula/ignition-msgs8.rb
+++ b/Formula/ignition-msgs8.rb
@@ -8,6 +8,12 @@ class IgnitionMsgs8 < Formula
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs8"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, sonoma:  "c3c1b3f32d28b0e0adbb9a6308af34d38a7dff0f64d166e77d914f8f896755aa"
+    sha256 cellar: :any, ventura: "c1a0ec97cc6cea3dfb2a702a5a9ee47c9e3deaa4aeef9c1e296afc1249fba784"
+  end
+
   depends_on "cmake"
   depends_on "ignition-cmake2"
   depends_on "ignition-math6"

--- a/Formula/ignition-msgs8.rb
+++ b/Formula/ignition-msgs8.rb
@@ -4,7 +4,7 @@ class IgnitionMsgs8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs8-8.7.0.tar.bz2"
   sha256 "b17a8e16fe56a84891bd0654a2ac09427e9a567b9cd2255bb2cfa830f8e1af45"
   license "Apache-2.0"
-  revision 44
+  revision 45
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs8"
 

--- a/Formula/ignition-sensors6.rb
+++ b/Formula/ignition-sensors6.rb
@@ -4,7 +4,7 @@ class IgnitionSensors6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/ignition-sensors-6.8.1.tar.bz2"
   sha256 "abc96be3bd018cae94c83981d173af0f67ce2980ef7a1374b34bd5b63f9a7235"
   license "Apache-2.0"
-  revision 7
+  revision 8
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors6"
 

--- a/Formula/ignition-sensors6.rb
+++ b/Formula/ignition-sensors6.rb
@@ -8,6 +8,12 @@ class IgnitionSensors6 < Formula
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors6"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, sonoma:  "79b67ec46f572eaf307f13f798be29e8416bf4aac89d41a7294ba5d84433e6f0"
+    sha256 cellar: :any, ventura: "ab4c2939cb94d15e7f5f7ab411c160da9e47c20b4e784e5470ef7e8cac01cc58"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
 

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -9,6 +9,12 @@ class IgnitionTransport11 < Formula
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport11"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "45701f706264c01a3f6807d8358b35a724dc23debc3e8e7ed957b35a82d2da20"
+    sha256 ventura: "a1ee7fc50c6dfe10bd0472311e0d94bd09d739df5281d6b180579ff97e407e61"
+  end
+
   depends_on "doxygen" => [:build, :optional]
 
   depends_on "cmake"

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -4,7 +4,7 @@ class IgnitionTransport11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases/ignition-transport11-11.4.1.tar.bz2"
   sha256 "f18501cbd5c78b584b3db1960a3049d6ae416bab7f0289af64eadda13d1c5da5"
   license "Apache-2.0"
-  revision 37
+  revision 38
   version_scheme 1
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport11"


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/2920.

Implemented with:

~~~
for f in $(.github/ci/unbottled_dependencies.sh gz-fortress)
do
    brew bump-revision --message="rebuild" $f
done
~~~