### PR TITLE
gz-utils3: depend on cli11

### DIFF
--- a/Formula/gz-utils3.rb
+++ b/Formula/gz-utils3.rb
@@ -14,6 +14,7 @@ class GzUtils3 < Formula
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
+  depends_on "cli11"
   depends_on "gz-cmake4"
   depends_on "spdlog"
 


### PR DESCRIPTION
Needed by https://github.com/gazebosim/gz-utils/pull/167.