### PR TITLE
Ionic: rebuild bottles broken by protobuf 29.3

### DIFF
--- a/Formula/gz-fuel-tools10.rb
+++ b/Formula/gz-fuel-tools10.rb
@@ -4,7 +4,7 @@ class GzFuelTools10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-10.0.0.tar.bz2"
   sha256 "dce4fb51a6af8d15d3ebdd98ecff4baf47c02ffb4d6aed48b284a7ce9188778e"
   license "Apache-2.0"
-  revision 11
+  revision 12
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools10"
 

--- a/Formula/gz-fuel-tools10.rb
+++ b/Formula/gz-fuel-tools10.rb
@@ -8,6 +8,12 @@ class GzFuelTools10 < Formula
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, sonoma:  "61014b208d7d623d628d0947bafca44f8a2b025705c6e1767535e4eac5256898"
+    sha256 cellar: :any, ventura: "a19ad49db346a229d9d3368b53b8570dbffaff7c3a52498c1b109598a8cfb4ef"
+  end
+
   depends_on "abseil"
   depends_on "cmake"
   depends_on "gz-cmake4"

--- a/Formula/gz-gui9.rb
+++ b/Formula/gz-gui9.rb
@@ -8,6 +8,12 @@ class GzGui9 < Formula
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "bb13f7e66e0b7484df7f5e0d1c480fb67093ef63f78767d4610caba456f202f7"
+    sha256 ventura: "0521d34bc7b9c938551e43de1eae9190096f8d8be2af0bbeec289848e91f4baf"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
   depends_on "abseil"

--- a/Formula/gz-gui9.rb
+++ b/Formula/gz-gui9.rb
@@ -4,7 +4,7 @@ class GzGui9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-9.0.0.tar.bz2"
   sha256 "2534cc688197c973029a43723de50c12a560320106d6b70a27aa4173c0a2d832"
   license "Apache-2.0"
-  revision 11
+  revision 12
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui9"
 

--- a/Formula/gz-launch8.rb
+++ b/Formula/gz-launch8.rb
@@ -8,6 +8,12 @@ class GzLaunch8 < Formula
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch8"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "20a6d63f2ea8e1fb30ef805af826c7994fec99169d7b0a38adc0b771412756ce"
+    sha256 ventura: "abb6a1856fcdcf31dfa7507ddeee435dbb15e5907af91570b987e97516976ad0"
+  end
+
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
 

--- a/Formula/gz-launch8.rb
+++ b/Formula/gz-launch8.rb
@@ -4,7 +4,7 @@ class GzLaunch8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-8.0.0.tar.bz2"
   sha256 "474e6dfeb2f1faed59f644d87decad6db53bec6046aea4b302907ff88985ebba"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch8"
 

--- a/Formula/gz-msgs11.rb
+++ b/Formula/gz-msgs11.rb
@@ -4,7 +4,7 @@ class GzMsgs11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/gz-msgs-11.0.1.tar.bz2"
   sha256 "4154cea1cf4e8c2b9b40962e44d6ab46b4f767ffab3809e4b6b4022904524fcb"
   license "Apache-2.0"
-  revision 11
+  revision 12
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs11"
 

--- a/Formula/gz-msgs11.rb
+++ b/Formula/gz-msgs11.rb
@@ -8,6 +8,12 @@ class GzMsgs11 < Formula
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs11"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "8cf3605b67bd8b93f9802d2b690524f20db36f93daa648959a01bc8419d70b2d"
+    sha256 ventura: "55586632db71c7b62f0a2dd5d80b1b384e49b52a26393ccc0e3bd58ba7c31d20"
+  end
+
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
   depends_on "abseil"

--- a/Formula/gz-sensors9.rb
+++ b/Formula/gz-sensors9.rb
@@ -4,7 +4,7 @@ class GzSensors9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-9.0.0.tar.bz2"
   sha256 "f6f3b1bf67ce81a5f3f99feffe44a4de5a7e170ace401b2272d9d5e1814521ec"
   license "Apache-2.0"
-  revision 11
+  revision 12
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors9"
 

--- a/Formula/gz-sensors9.rb
+++ b/Formula/gz-sensors9.rb
@@ -8,6 +8,12 @@ class GzSensors9 < Formula
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, sonoma:  "eb5b84cc61b019156900793a5455424b73a4ed26a10c988137eb42863734bfb7"
+    sha256 cellar: :any, ventura: "bf3ebfa0181ea8b4f85c6dd02cc907b13acfb16a20b9a7269c5c1248a508a081"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
 

--- a/Formula/gz-sim9.rb
+++ b/Formula/gz-sim9.rb
@@ -4,7 +4,7 @@ class GzSim9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-9.0.0.tar.bz2"
   sha256 "62effba56ffbfdb2db67b6ccca17527df0ede7fa83469df72c2f043f6cc96ea8"
   license "Apache-2.0"
-  revision 7
+  revision 8
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim9"
 

--- a/Formula/gz-sim9.rb
+++ b/Formula/gz-sim9.rb
@@ -8,6 +8,12 @@ class GzSim9 < Formula
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "e962efd3a22c023c90f791f38012a1e0a6dce24d11af36abf9b718e089282366"
+    sha256 ventura: "a4dff5008bee1dd12dd88b42fa0b727dec2f9f6ee88a223cbf76d88836c39383"
+  end
+
   depends_on "cmake" => :build
   depends_on "pybind11" => :build
   depends_on "python@3.13" => [:build, :test]

--- a/Formula/gz-transport14.rb
+++ b/Formula/gz-transport14.rb
@@ -4,7 +4,7 @@ class GzTransport14 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/gz-transport-14.0.0.tar.bz2"
   sha256 "88cbcef69f16ea5124ff41766cc59c0277bfc3ae57c405f3fbae1dbee874a1c0"
   license "Apache-2.0"
-  revision 11
+  revision 12
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport14"
 

--- a/Formula/gz-transport14.rb
+++ b/Formula/gz-transport14.rb
@@ -8,6 +8,12 @@ class GzTransport14 < Formula
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport14"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "db55737c33186e6a5cd49ea4d7c6a0fbb9f8a401020a73593ea5b5367dcb4f4a"
+    sha256 ventura: "d801bf32cb2508fb1b56fedc8e76b8f764ef8730a6640f8d20f7341ae636e016"
+  end
+
   depends_on "doxygen" => [:build, :optional]
   depends_on "pybind11" => :build
   depends_on "python@3.12" => [:build, :test]


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/2929.

Implemented with:

~~~
for f in $(.github/ci/unbottled_dependencies.sh gz-ionic)
do
    brew bump-revision --message="rebuild" $f
done
~~~