### PR TITLE
gazebo11: use boost 1.85

### DIFF
--- a/Formula/boost@1.85.0.rb
+++ b/Formula/boost@1.85.0.rb
@@ -1,0 +1,121 @@
+class BoostAT1850 < Formula
+  desc "Collection of portable C++ source libraries"
+  homepage "https://www.boost.org/"
+  url "https://github.com/boostorg/boost/releases/download/boost-1.85.0/boost-1.85.0-b2-nodocs.tar.xz"
+  sha256 "09f0628bded81d20b0145b30925d7d7492fd99583671586525d5d66d4c28266a"
+  license "BSL-1.0"
+
+  keg_only :versioned_formula
+
+  depends_on "icu4c@76"
+  depends_on "xz"
+  depends_on "zstd"
+
+  uses_from_macos "bzip2"
+  uses_from_macos "zlib"
+
+  def install
+    # Force boost to compile with the desired compiler
+    open("user-config.jam", "a") do |file|
+      if OS.mac?
+        file.write "using darwin : : #{ENV.cxx} ;\n"
+      else
+        file.write "using gcc : : #{ENV.cxx} ;\n"
+      end
+    end
+
+    # libdir should be set by --prefix but isn't
+    icu4c = deps.find { |dep| dep.name.match?(/^icu4c(@\d+)?$/) }
+                .to_formula
+    bootstrap_args = %W[
+      --prefix=#{prefix}
+      --libdir=#{lib}
+      --with-icu=#{icu4c.opt_prefix}
+    ]
+
+    # Handle libraries that will not be built.
+    without_libraries = ["python", "mpi"]
+
+    # Boost.Log cannot be built using Apple GCC at the moment. Disabled
+    # on such systems.
+    without_libraries << "log" if ENV.compiler == :gcc
+
+    bootstrap_args << "--without-libraries=#{without_libraries.join(",")}"
+
+    # layout should be synchronized with boost-python and boost-mpi
+    args = %W[
+      --prefix=#{prefix}
+      --libdir=#{lib}
+      -d2
+      -j#{ENV.make_jobs}
+      --layout=tagged-1.66
+      --user-config=user-config.jam
+      install
+      threading=multi,single
+      link=shared,static
+    ]
+
+    # Boost is using "clang++ -x c" to select C compiler which breaks C++
+    # handling in superenv. Using "cxxflags" and "linkflags" still works.
+    # C++17 is due to `icu4c`.
+    args << "cxxflags=-std=c++17"
+    args << "cxxflags=-stdlib=libc++" << "linkflags=-stdlib=libc++" if ENV.compiler == :clang
+
+    system "./bootstrap.sh", *bootstrap_args
+    system "./b2", "headers"
+    system "./b2", *args
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~CPP
+      #include <boost/algorithm/string.hpp>
+      #include <boost/iostreams/device/array.hpp>
+      #include <boost/iostreams/device/back_inserter.hpp>
+      #include <boost/iostreams/filter/zstd.hpp>
+      #include <boost/iostreams/filtering_stream.hpp>
+      #include <boost/iostreams/stream.hpp>
+
+      #include <string>
+      #include <iostream>
+      #include <vector>
+      #include <assert.h>
+
+      using namespace boost::algorithm;
+      using namespace boost::iostreams;
+      using namespace std;
+
+      int main()
+      {
+        string str("a,b");
+        vector<string> strVec;
+        split(strVec, str, is_any_of(","));
+        assert(strVec.size()==2);
+        assert(strVec[0]=="a");
+        assert(strVec[1]=="b");
+
+        // Test boost::iostreams::zstd_compressor() linking
+        std::vector<char> v;
+        back_insert_device<std::vector<char>> snk{v};
+        filtering_ostream os;
+        os.push(zstd_compressor());
+        os.push(snk);
+        os << "Boost" << std::flush;
+        os.pop();
+
+        array_source src{v.data(), v.size()};
+        filtering_istream is;
+        is.push(zstd_decompressor());
+        is.push(src);
+        std::string s;
+        is >> s;
+
+        assert(s == "Boost");
+
+        return 0;
+      }
+    CPP
+    system ENV.cxx, "test.cpp", "-std=c++14", "-o", "test", "-I#{include}",
+                    "-L#{lib}", "-lboost_iostreams", "-L#{Formula["zstd"].opt_lib}", "-lzstd"
+    system "./test"
+  end
+end

--- a/Formula/boost@1.85.0.rb
+++ b/Formula/boost@1.85.0.rb
@@ -7,8 +7,8 @@ class BoostAT1850 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "fb79af23638d60be500f32f88cf179626a1284c30b1a6b1c802fe3c8c7faf7dd"
-    sha256 cellar: :any, ventura: "d30d0028956faa275279b6f83e36844d8f6cea128c75114bd204ea162ce4acae"
+    sha256 cellar: :any, sonoma:  "5a624e8d2320a4c44eb1f85ad45c5578e1eb9753d546ad3a40b6d74074955cb6"
+    sha256 cellar: :any, ventura: "720375f0e2aca06242502973008cf8145088ed036fd46308f6b0ecc4c0f22023"
   end
 
   keg_only :versioned_formula

--- a/Formula/boost@1.85.0.rb
+++ b/Formula/boost@1.85.0.rb
@@ -5,6 +5,12 @@ class BoostAT1850 < Formula
   sha256 "09f0628bded81d20b0145b30925d7d7492fd99583671586525d5d66d4c28266a"
   license "BSL-1.0"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, sonoma:  "fb79af23638d60be500f32f88cf179626a1284c30b1a6b1c802fe3c8c7faf7dd"
+    sha256 cellar: :any, ventura: "d30d0028956faa275279b6f83e36844d8f6cea128c75114bd204ea162ce4acae"
+  end
+
   keg_only :versioned_formula
 
   depends_on "icu4c@76"

--- a/Formula/gazebo11.rb
+++ b/Formula/gazebo11.rb
@@ -96,6 +96,8 @@ class Gazebo11 < Formula
     #                "-o", "test"
     # system "./test"
     ENV.append_path "CMAKE_PREFIX_PATH", Formula["boost@1.85.0"].opt_prefix
+    ENV.append_path "CMAKE_PREFIX_PATH", Formula["ogre1.9-with-boost1.85"].opt_prefix
+    ENV.append_path "PKG_CONFIG_PATH", Formula["ogre1.9-with-boost1.85"].opt_lib/"pkgconfig"
     mkdir "build" do
       system "cmake", ".."
       system "make"

--- a/Formula/gazebo11.rb
+++ b/Formula/gazebo11.rb
@@ -4,14 +4,14 @@ class Gazebo11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/gazebo-11.15.0.tar.bz2"
   sha256 "8998ef927b424ac24ae6eaea4e69b0d0640877059cba8680d20cd526e6333262"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   head "https://github.com/osrf/gazebo.git", branch: "gazebo11"
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
 
-  depends_on "boost"
+  depends_on "boost@1.85.0"
   depends_on "bullet"
   depends_on "dartsim"
   depends_on "doxygen"
@@ -25,7 +25,7 @@ class Gazebo11 < Formula
   depends_on "ignition-msgs5"
   depends_on "ignition-transport8"
   depends_on "libtar"
-  depends_on "ogre1.9"
+  depends_on "ogre1.9-with-boost1.85"
   depends_on "protobuf"
   depends_on "qt@5"
   depends_on "qwt-qt5"
@@ -95,6 +95,7 @@ class Gazebo11 < Formula
     #                "-lc++",
     #                "-o", "test"
     # system "./test"
+    ENV.append_path "CMAKE_PREFIX_PATH", Formula["boost@1.85.0"].opt_prefix
     mkdir "build" do
       system "cmake", ".."
       system "make"

--- a/Formula/gazebo11.rb
+++ b/Formula/gazebo11.rb
@@ -8,6 +8,12 @@ class Gazebo11 < Formula
 
   head "https://github.com/osrf/gazebo.git", branch: "gazebo11"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "074e08d3b0e44475ffb0f159cdf599c30ee6b37b6a8e2bb0dbada457d73a3581"
+    sha256 ventura: "d4376884717e4f5e49e453f00ff13b1e10c3322ed9a94e5dde5de008567538ef"
+  end
+
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
 

--- a/Formula/ogre1.9-with-boost1.85.rb
+++ b/Formula/ogre1.9-with-boost1.85.rb
@@ -10,8 +10,8 @@ class Ogre19WithBoost185 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "9a27d938d945cb9a8cf9ff1f47f4b6fa6cdfadee5200f36d4d12124a5e11fec7"
-    sha256 ventura: "d25af9f42bb8745756cbf14a05e860c2f0e86bd6b7ba7c81ebabeffaad1e71d7"
+    sha256 sonoma:  "9768c5821e9f23faa57d6b36a23615ae499f8968cc8699f90f04a75ae256191e"
+    sha256 ventura: "7b9651c2799df5159b6f571e66f42c011f01814c783976b27d02b22b30c6e59e"
   end
 
   keg_only "it conflicts with ogre1.9"

--- a/Formula/ogre1.9-with-boost1.85.rb
+++ b/Formula/ogre1.9-with-boost1.85.rb
@@ -8,6 +8,12 @@ class Ogre19WithBoost185 < Formula
 
   head "https://github.com/OGRECave/ogre.git", branch: "master"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "9a27d938d945cb9a8cf9ff1f47f4b6fa6cdfadee5200f36d4d12124a5e11fec7"
+    sha256 ventura: "d25af9f42bb8745756cbf14a05e860c2f0e86bd6b7ba7c81ebabeffaad1e71d7"
+  end
+
   keg_only "it conflicts with ogre1.9"
 
   option "with-cg"

--- a/Formula/ogre1.9-with-boost1.85.rb
+++ b/Formula/ogre1.9-with-boost1.85.rb
@@ -1,0 +1,162 @@
+class Ogre19WithBoost185 < Formula
+  desc "Scene-oriented 3D engine written in c++"
+  homepage "https://www.ogre3d.org/"
+  url "https://osrf-distributions.s3.amazonaws.com/ogre/releases/sinbad-ogre-108ab0bcc696.tar.bz2"
+  version "1.9-20160714-108ab0bcc69603dba32c0ffd4bbbc39051f421c9"
+  sha256 "3ca667b959905b290d782d7f0808e35d075c85db809d3239018e4e10e89b1721"
+  license "MIT"
+
+  head "https://github.com/OGRECave/ogre.git", branch: "master"
+
+  keg_only "it conflicts with ogre1.9"
+
+  option "with-cg"
+
+  depends_on "cmake" => :build
+  depends_on "boost@1.85.0"
+  depends_on "doxygen"
+  depends_on "freeimage"
+  depends_on "freetype"
+  depends_on "libx11"
+  depends_on "libzzip"
+  depends_on "tbb"
+
+  patch do
+    url "https://gist.githubusercontent.com/marvinosswald/0e981e918aeee4403e9a0790c6f32cdd/raw/5d295499255867064ace8c4c41b2f31fd48d4576/gistfile1.txt"
+    sha256 "62d33adbb3d46f9354ba9486226ee88649d7d7af0e26354f69c5cc777dd2ef86"
+  end
+
+  patch do
+    url "https://gist.github.com/NikolausDemmel/2b11d1b49b35cd27a102/raw/bf4a4d16020821218f73db0d56aa111ab2fde679/fix-1.9-HEAD.diff"
+    sha256 "15ecd1f12266918650ea789e2f96da4b0ef1a96076d7a671d3c56d98e2459712"
+  end
+
+  patch do
+    # retain osx cocoa window
+    url "https://gist.githubusercontent.com/NikolausDemmel/927bd7bb3f14c1788599/raw/c9a5ba88b758e80d3f46511629c4e8026b92c462/ogre1.9.patch"
+    sha256 "e82d842138f7f5ff4637ed313d1140c3b868c8425d4cdba7a71e0a9d7f7e0fd6"
+  end
+
+  patch do
+    # disable building samples if ois is not available
+    url "https://gist.githubusercontent.com/iche033/68349eebfc436e484b70e6e3508ae27b/raw/d96227cd79ed1d63f051689a18c95a1c174a4efa/ogre-1.9-ois.patch"
+    sha256 "7ad630740217ccb9f48898507e9c6713dcd37a677a9669cdc16ef39afbf68826"
+  end
+
+  patch do
+    # link against AGL framework
+    url "https://gist.githubusercontent.com/iche033/b73766fac9ab3d628a79b5ed986677cd/raw/878d0902704c7fb51511163052c95294361f1dbe/ogre-1.9-agl.patch"
+    sha256 "8122c7eb52faae0fdedb70278d24e2581c88d1181de4d6e94d27bc1b3e596181"
+  end
+
+  patch do
+    # backport cocoa window fix to support contents scaling factor (for retina displays)
+    url "https://gist.githubusercontent.com/iche033/e0080a592c890cc9a4fce31f6863a5ed/raw/875ae8ad1d9f0eaa271fd44eab8e0979bac74119/ogre-1.9-cocoa_window_scale.patch"
+    sha256 "c20c288530ea4d11b37f9c8b30cb43c89722c85eac0af3b6520cd89c37014e5b"
+  end
+
+  patch do
+    # add libc++ flag
+    url "https://gist.githubusercontent.com/iche033/e2b152d9df080b21f71ba3b65aa39922/raw/5397fa149c7570c17f2d78421d44b12dfa175387/ogre-1.9-cxx_flags.patch"
+    sha256 "7dc77285029c34b4a6adb52b0d4b9c40578526a5e9764d0a7091c6a4cb63fa78"
+  end
+
+  patch do
+    # fix FindOGRE.cmake for non-framework builds
+    url "https://gist.githubusercontent.com/iche033/2b5e2ba31436881f1db29f9b60c7a5b2/raw/b6ab953ebd82127ad1177744f367a36e059312a9/ogre-1.9-findogre.patch"
+    sha256 "7ca6f549fbdff7b7fc334f06da4547e071ec0e3f2733897fc6ef0d2bfa1716a3"
+  end
+
+  patch do
+    # fix for boost 1.65
+    url "https://github.com/OGRECave/ogre/commit/cade48b4c2215dd77ea74b7aa219a22c2a5d6654.patch?full_index=1"
+    sha256 "d30c9a941b436c920cdb7a56e870e6a07921d1188ba3e0d8934323fdd28fc7c2"
+  end
+
+  patch do
+    # fix for boost 1.67
+    url "https://github.com/OGRECave/ogre/commit/2371c8d001725190a9cda62dc5df282cde78f951.patch?full_index=1"
+    sha256 "28d418f7c978bedcf26c7a53c0f621fd5d9a2f27e5b838ea03af00e062f65470"
+  end
+
+  # fix for finding ZZip
+  patch do
+    url "https://github.com/scpeters/ogre/commit/8fcfe0885e6bd98d971250d4a3fb9a23e3743dfd.patch?full_index=1"
+    sha256 "3a69a4ed9e86887d3a23b0882c9868e994ab710205bb2e4b87204a8c89f1a3c5"
+  end
+
+  # fix for m1 cpu arch
+  patch do
+    url "https://github.com/scpeters/ogre/commit/c39b6df49618773357da0b54437f351b57168d12.patch?full_index=1"
+    sha256 "fa8dc20d5978d1ff1402a4df890a6fa0ca1fec6ec73f00154f7484820516b071"
+  end
+
+  def install
+    cmake_args = [
+      "-DCMAKE_CXX_STANDARD='14'",
+      "-DOGRE_BUILD_DOCS:BOOL=FALSE",
+      "-DOGRE_BUILD_LIBS_AS_FRAMEWORKS=OFF",
+      "-DOGRE_BUILD_SAMPLES:BOOL=FALSE",
+      "-DOGRE_FULL_RPATH:BOOL=FALSE",
+      "-DOGRE_INSTALL_DOCS:BOOL=FALSE",
+      "-DOGRE_INSTALL_SAMPLES:BOOL=FALSE",
+      "-DOGRE_INSTALL_SAMPLES_SOURCE:BOOL=FALSE",
+    ]
+    cmake_args << "-DOGRE_BUILD_PLUGIN_CG=OFF" if build.without? "cg"
+    cmake_args.concat(std_cmake_args)
+    cmake_args << ".."
+
+    mkdir "build" do
+      system "cmake", *cmake_args
+      system "make", "install"
+    end
+
+    # Put these cmake files where Debian puts them
+    (share/"OGRE/cmake/modules").install Dir[prefix/"CMake/*.cmake"]
+    rmdir prefix/"CMake"
+
+    # This is necessary because earlier versions of Ogre seem to have created
+    # the plugins with "lib" prefix and software like "rviz" now has Mac
+    # specific code that looks for the plugins with "lib" prefix. Hence we add
+    # symlinks with the "lib" prefix manually, but their use is deprecated.
+    Dir.glob(lib/"OGRE/*.dylib") do |path|
+      filename = File.basename(path)
+      symlink path, lib/"OGRE/lib#{filename}"
+    end
+  end
+
+  test do
+    (testpath/"test.mesh.xml").write <<-EOS
+      <mesh>
+        <submeshes>
+          <submesh material="BaseWhite" usesharedvertices="false" use32bitindexes="false" operationtype="triangle_list">
+            <faces count="1">
+              <face v1="0" v2="1" v3="2" />
+            </faces>
+            <geometry vertexcount="3">
+              <vertexbuffer positions="true" normals="false" texture_coords="0">
+                <vertex>
+                  <position x="-50" y="-50" z="50" />
+                </vertex>
+                <vertex>
+                  <position x="-50" y="-50" z="-50" />
+                </vertex>
+                <vertex>
+                  <position x="50" y="-50" z="-50" />
+                </vertex>
+              </vertexbuffer>
+            </geometry>
+          </submesh>
+        </submeshes>
+        <submeshnames>
+          <submeshname name="submesh0" index="0" />
+        </submeshnames>
+      </mesh>
+    EOS
+    system "#{bin}/OgreXMLConverter", "test.mesh.xml"
+    system "du", "-h", "./test.mesh"
+    # check for Xcode frameworks in bottle
+    cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
+    system cmd_not_grep_xcode
+  end
+end


### PR DESCRIPTION
This is a workaround for #2916 and https://github.com/gazebosim/gazebo-classic/issues/3414 that uses forked versions of `boost` and `ogre1.9`:

* `boost@1.85.0` (derived using `brew extract bost@1.85 osrf/simulation`)
* `ogre1.9-with-boost1.85` (copied from `ogre1.9`)

If we find a fix for https://github.com/gazebosim/gazebo-classic/issues/3414, we can revert to using the system version of `boost`.

Note that `boost@1.85.0` and `ogre1.9-with-boost1.85` are keg-only, which means they are not sym-linked to `HOMEBREW_PREFIX`, so compiling gazebo11 from source or compiling custom plugins will require setting additional environment variables, similar to the approach for `qt@5` in the [build-from-source documentation](https://gazebosim.org/docs/latest/install_osx_src/#install-dependencies).