### PR TITLE
gz-sim10: depend on libwebsockets

### DIFF
--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -27,6 +27,7 @@ class GzSim10 < Formula
   depends_on "gz-tools2"
   depends_on "gz-transport14"
   depends_on "gz-utils3"
+  depends_on "libwebsockets"
   depends_on macos: :mojave # c++17
   depends_on "pkgconf"
   depends_on "protobuf"
@@ -34,7 +35,6 @@ class GzSim10 < Formula
   depends_on "ruby"
   depends_on "sdformat15"
   depends_on "tinyxml2"
-  depends_on "libwebsockets"
 
   def pythons
     deps.map(&:to_formula)

--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -34,6 +34,7 @@ class GzSim10 < Formula
   depends_on "ruby"
   depends_on "sdformat15"
   depends_on "tinyxml2"
+  depends_on "libwebsockets"
 
   def pythons
     deps.map(&:to_formula)


### PR DESCRIPTION
Related issue: https://github.com/gazebosim/gz-launch/issues/288
Needed by: https://github.com/gazebosim/gz-sim/pull/2792

The websocket server is being ported from gz-launch to gz-sim. This adds `libwebsockets` dependency to gz-sim10 for Jetty. Note: I don't see this in the gz-launch9 formula as I think it's only an optional dependency there. 