### PR TITLE
Fix brew style warnings in gz-<collection>.rb files

### DIFF
--- a/Formula/gz-garden.rb
+++ b/Formula/gz-garden.rb
@@ -41,6 +41,6 @@ class GzGarden < Formula
   end
 
   test do
-    assert_predicate share/"gz/gz-garden/gazebodistro/collection-garden.yaml", :exist?
+    assert_path_exists share/"gz/gz-garden/gazebodistro/collection-garden.yaml"
   end
 end

--- a/Formula/gz-harmonic.rb
+++ b/Formula/gz-harmonic.rb
@@ -38,6 +38,6 @@ class GzHarmonic < Formula
   end
 
   test do
-    assert_predicate share/"gz/gz-harmonic/gazebodistro/collection-harmonic.yaml", :exist?
+    assert_path_exists share/"gz/gz-harmonic/gazebodistro/collection-harmonic.yaml"
   end
 end

--- a/Formula/gz-ionic.rb
+++ b/Formula/gz-ionic.rb
@@ -38,6 +38,6 @@ class GzIonic < Formula
   end
 
   test do
-    assert_predicate share/"gz/gz-ionic/release_notes.md", :exist?
+    assert_path_exists share/"gz/gz-ionic/release_notes.md"
   end
 end

--- a/Formula/gz-jetty.rb
+++ b/Formula/gz-jetty.rb
@@ -37,6 +37,6 @@ class GzJetty < Formula
   end
 
   test do
-    assert_predicate share/"gz/gz-jetty/release_notes.md", :exist?
+    assert_path_exists share/"gz/gz-jetty/release_notes.md"
   end
 end


### PR DESCRIPTION
Fix brew test-bot warnings such as:

```
  Taps/osrf/homebrew-simulation/Formula/gz-garden.rb:44:5: C: [Correctable] FormulaAudit/AssertStatements: Use assert_path_exists <path_to_file> instead of assert_predicate share/"gz/gz-garden/gazebodistro/collection-garden.yaml", :exist?
      assert_predicate share/"gz/gz-garden/gazebodistro/collection-garden.yaml", :exist?
```