### PR TITLE
fix: resolve deprecation warning

### DIFF
--- a/Formula/simbody.rb
+++ b/Formula/simbody.rb
@@ -36,7 +36,7 @@ class Simbody < Formula
 
     inreplace Dir[lib/"cmake/simbody/SimbodyTargets-*.cmake"],
         %r{/Applications/+Xcode.app/[^;]*/System/Library},
-        "/System/Library", false
+        "/System/Library", audit_result: false
   end
 
   test do


### PR DESCRIPTION
### Overview:

- Resolve warning here:
```Warning: Calling inreplace(paths, before, after, false) is deprecated! Use inreplace(paths, before, after, audit_result: false) instead.
Please report this issue to the osrf/homebrew-simulation tap (not Homebrew/brew or Homebrew/homebrew-core), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/osrf/homebrew-simulation/Formula/simbody.rb:3```