### PR TITLE
Remove bottles broken by tinyxml2 10.1.0

### DIFF
--- a/Formula/gz-common5.rb
+++ b/Formula/gz-common5.rb
@@ -4,14 +4,9 @@ class GzCommon5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-common/releases/gz-common-5.7.1.tar.bz2"
   sha256 "802a0a95bf52e10ec02b7531db1d577e2f477e5d326f0998f0b6ba323eb0396b"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-common.git", branch: "gz-common5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "437af0f2e7c6be2de4f4f2e4e655e00cb6838a81ff64d41ef2f1f190616bb84d"
-    sha256 cellar: :any, ventura: "4c6b7bb1f641ed3956a111e338bb8baa9db61a3c65ba9a3f1651c170469333d1"
-  end
 
   depends_on "assimp"
   depends_on "cmake"

--- a/Formula/gz-common6.rb
+++ b/Formula/gz-common6.rb
@@ -4,14 +4,9 @@ class GzCommon6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-common/releases/gz-common-6.0.2.tar.bz2"
   sha256 "d87f805c5b79b06d610c50f4ed3123afcc6018d2e12759a18ca4131f7d4a6921"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-common.git", branch: "gz-common6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "2e5a156acee13dcc126eae587cb265884b3653b427d1e9a6400cbb0f59fbbd7a"
-    sha256 cellar: :any, ventura: "d44ceb8526526a061c4207a12f0c7ac8aa9ab757fdc0aeb9538ff17b09a289d7"
-  end
 
   depends_on "assimp"
   depends_on "cmake"

--- a/Formula/gz-fuel-tools10.rb
+++ b/Formula/gz-fuel-tools10.rb
@@ -4,14 +4,9 @@ class GzFuelTools10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-10.0.1.tar.bz2"
   sha256 "ca858f88bbfdebbe0a6b8ea94be3668e62862039397c6e08d41d646435d57fdc"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools10"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "a9e1f2c2541e480d8f20d900999659da8efe2d6e6dc52ddea5590a465faaa66d"
-    sha256 cellar: :any, ventura: "815a30fbbae2b0a7c5830a737d41ad42f64c3aa4e19b4dde71cbd8323b0a322a"
-  end
 
   depends_on "abseil"
   depends_on "cmake"

--- a/Formula/gz-fuel-tools9.rb
+++ b/Formula/gz-fuel-tools9.rb
@@ -4,14 +4,9 @@ class GzFuelTools9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-9.1.1.tar.bz2"
   sha256 "3189166d4b0078c0b9d98de178e5496a1cc28b88fbd1124603376181b5a053f5"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "f2c7114692ce1d04d7d16669963624cc4bb00a1e31936d51a47ba41deb2737fd"
-    sha256 cellar: :any, ventura: "0ba1ef9cd6a9e25cd21a0f81441e8379be725b8aa5aef572c1ef779d84c3f41c"
-  end
 
   depends_on "abseil"
   depends_on "cmake"

--- a/Formula/gz-gui8.rb
+++ b/Formula/gz-gui8.rb
@@ -4,14 +4,9 @@ class GzGui8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-8.4.0.tar.bz2"
   sha256 "1731b01a134afb11b1b3e049fc65e74fa7b5c50532406d3d68366d54016d5498"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "7ec3b63121e3c2ce93b38746729dc0831b465a54df918b854822050beeb48de5"
-    sha256 ventura: "01506c5cd11502f655615b5de32355592188f4d58cb9b09caf82e16da34ebf68"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-gui9.rb
+++ b/Formula/gz-gui9.rb
@@ -4,14 +4,9 @@ class GzGui9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-9.0.1.tar.bz2"
   sha256 "873d9950b1aa577b5b7f864caa4c3f759e29d5b67b81c4d69ab7d37043c4f96d"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "1137d0d38c39f788764c2f85214f485c0173ae60e2a7b213317466b9ff659b5f"
-    sha256 ventura: "df7995df3e66d5326c608d3f518e48013e63447cfa15d754f955d4be4a1fe71f"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-launch7.rb
+++ b/Formula/gz-launch7.rb
@@ -4,14 +4,9 @@ class GzLaunch7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-7.1.1.tar.bz2"
   sha256 "e29f8b4663474cfed1364c45afa3aee8b44d816ffe1679c26c699f7c805cdffd"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "a1f57fb358d60006a10dca042cb1241993478bef8e24f98f04082a6844602e6c"
-    sha256 ventura: "4ff1b2180d50b5d2c9656a40744f30f24048c80385dbc4d20c77ad7f948b4f75"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build

--- a/Formula/gz-launch8.rb
+++ b/Formula/gz-launch8.rb
@@ -4,14 +4,9 @@ class GzLaunch8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-8.0.1.tar.bz2"
   sha256 "ce89cfe1554bf64ea63bbbcd7ce9624dd488a72a688cd620f97cabab776245a7"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "2175e45f529b20fe5f15ff2d1e7d0a9ea504e260ddd8cf750a194b5229125fde"
-    sha256 ventura: "bba95c4023af150756d3272b7209931e393db9e85f12b5b43a6310adfab6118a"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build

--- a/Formula/gz-msgs10.rb
+++ b/Formula/gz-msgs10.rb
@@ -4,14 +4,9 @@ class GzMsgs10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/gz-msgs-10.3.2.tar.bz2"
   sha256 "0dd9c19dee7aec7fc0f7bdd03ee2ae44ab1068dac2fc1ae8cc3ecc1b6df8472a"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs10"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "43dae8e2fe9db3052628c71967fa5d90e801cfac7d948590de7fc56e4b7ae657"
-    sha256 ventura: "bcc49f7d6f4e6b4f754149148c7235a1b7c241002f2f31d9c62035f10211dc85"
-  end
 
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]

--- a/Formula/gz-msgs11.rb
+++ b/Formula/gz-msgs11.rb
@@ -4,14 +4,9 @@ class GzMsgs11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/gz-msgs-11.0.2.tar.bz2"
   sha256 "6a7ccdb49d9320ba94c4ee25641ff27ca0aa78b230a8933b0d3f1d4b1b2bda05"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs11"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "b8d438fbd663f920d5b3c8a7a5ecaa9dcc873d6224c0ddeafdbae57822dee343"
-    sha256 ventura: "80114d86a5d61b638db49729a03f480d72a3548beab52f6013f66131984deb7a"
-  end
 
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]

--- a/Formula/gz-physics7.rb
+++ b/Formula/gz-physics7.rb
@@ -4,14 +4,9 @@ class GzPhysics7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-7.5.0.tar.bz2"
   sha256 "3c44365182f8d43ae54c7b8cec65b80daab95defb8057dbd7da6e0c1fc44dbf6"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "5c43cdb193347945e2a13244f578fd4aa4c2f65d94042de9d9083eb0dc333d41"
-    sha256 ventura: "99857120177e9db85c71d9d6237f303c7790c0206a4a924430090982e3378af8"
-  end
 
   depends_on "cmake" => [:build, :test]
 

--- a/Formula/gz-physics8.rb
+++ b/Formula/gz-physics8.rb
@@ -4,14 +4,9 @@ class GzPhysics8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-8.1.0.tar.bz2"
   sha256 "4dc187a27b5c2b34a22ff911ae770a551a49468ca53bdd24316f57e6e18e6490"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "191d81374e8726f7d5aadf5c48346e83d0329168d3467fa5add431785b63f4d5"
-    sha256 ventura: "9491c6ef4351e22c58eee8730d6341548c2c7609db2797bbf8db25798ecd6060"
-  end
 
   depends_on "cmake" => [:build, :test]
 

--- a/Formula/gz-sensors8.rb
+++ b/Formula/gz-sensors8.rb
@@ -4,14 +4,9 @@ class GzSensors8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-8.2.2.tar.bz2"
   sha256 "9ddc16d5cab0a86f27771732f5cfcfde1efe7611f27da61176ea122273806c42"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "ab1862372bf304693645fb71dd9c87599f837746a08cf07ac20d0537d915b501"
-    sha256 cellar: :any, ventura: "059a89f79e2328884f2bfdedccb2e409433f2dd02f03d27afdd31147b9bf6a4b"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-sensors9.rb
+++ b/Formula/gz-sensors9.rb
@@ -4,14 +4,9 @@ class GzSensors9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-9.1.0.tar.bz2"
   sha256 "3d1aaf20fd987efc1fc29f343cc42c96e07f57e060849c779b22bb32724ded35"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "8de205646db731e930f6837354f989cce9505205486c2989f9ad8c205e05a1f1"
-    sha256 cellar: :any, ventura: "7286428b0c28748a0538f8cf3d8580c7c43f7e4d43035d201a13957472e7065c"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-sim8.rb
+++ b/Formula/gz-sim8.rb
@@ -4,14 +4,9 @@ class GzSim8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-8.9.0.tar.bz2"
   sha256 "c55aa45a4f12ddad7115455722afd2fe9bb7fef7cc3fa119a2a24ea77e58dedf"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "40e7c74adda608678e7804c9cf49b8f4b18390821d25363d7b75c28f9bffd208"
-    sha256 ventura: "6220e2426908a854c7d071a880467d42a5dffc306112f9406bfcad7362352407"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build

--- a/Formula/gz-sim9.rb
+++ b/Formula/gz-sim9.rb
@@ -4,14 +4,9 @@ class GzSim9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-9.1.0.tar.bz2"
   sha256 "7866afccfae26d345d696f22d9b9952f821d2e9f7418be2616b2bcc99bbfdea9"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "01b8d6aaaea3bd8228f96186bd7bfe08227981c4f51bca09c32e44b607687047"
-    sha256 ventura: "a0a84df7ed32018aa32c77ccc13367d47d32f755d655e69efaa27e6dfb2bc82a"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build

--- a/Formula/gz-transport13.rb
+++ b/Formula/gz-transport13.rb
@@ -4,14 +4,9 @@ class GzTransport13 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/gz-transport-13.4.1.tar.bz2"
   sha256 "1e7051de16c8e0cadf5b357d32193ffdb3eb33775126d1f89bef29bfd02e11b8"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport13"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "793539d672f055940f970113c60985f1bbc78dddbadf0db9bd9a93e3238b9cdc"
-    sha256 ventura: "68a8929b9f8c972b47f2c92475773efa8bd48832417fbbd77963c3a5f1e0e8f0"
-  end
 
   depends_on "doxygen" => [:build, :optional]
   depends_on "pybind11" => :build

--- a/Formula/gz-transport14.rb
+++ b/Formula/gz-transport14.rb
@@ -4,14 +4,9 @@ class GzTransport14 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/gz-transport-14.0.1.tar.bz2"
   sha256 "74f6f082be147c12a327abd3480fd8b423d6af6867e75fdf596452a03ad9350b"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport14"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "d153ab95ff6c9d12a3ad01ea0ec8776f6b71c6e9fe27f8d68607043a0694ff25"
-    sha256 ventura: "4812bdb90e327e865af726c8ba0a8bef98a6b93b00141e6e3ceda6bba895f2c4"
-  end
 
   depends_on "doxygen" => [:build, :optional]
   depends_on "pybind11" => :build

--- a/Formula/ignition-common4.rb
+++ b/Formula/ignition-common4.rb
@@ -4,16 +4,9 @@ class IgnitionCommon4 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-common/releases/ignition-common4-4.7.0.tar.bz2"
   sha256 "ec9bb68be9f6323f3a3a12b23259c567f9a2478951719573e1b7c906bd7e68cb"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-common.git", branch: "ign-common4"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:   "15888c5b1ec5bec43cd96acc1d13ae845e4d0a608bb849ab0691dc32e7772978"
-    sha256 cellar: :any, ventura:  "b043f1aa21eb01cffe1e255a3dfae775696d37c14fb817148c42bd4e5de5d47e"
-    sha256 cellar: :any, monterey: "9af9629eb96798da3114b2a77950c797747c3984c20d6336654429f7991fc93b"
-  end
 
   depends_on "cmake"
   depends_on "ffmpeg"

--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -4,15 +4,9 @@ class IgnitionFuelTools7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/ignition-fuel_tools-7.3.1.tar.bz2"
   sha256 "b8224c574406147ae008ed9a0ac459f1e2582f6aaef7ba44e1fd1c5ac97b6de8"
   license "Apache-2.0"
-  revision 14
+  revision 15
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "ac38029c65d592848f6b1ae768cdb970e31c4497fe2521739df7107393d67301"
-    sha256 cellar: :any, ventura: "0d77f5b55d6b5f111eb40823d77307094e0e84fda775869eb154e1efe93d5745"
-  end
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -4,15 +4,9 @@ class IgnitionGui6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gui/releases/ignition-gui6-6.8.0.tar.bz2"
   sha256 "dd4f26100f4d1343f068ba36f2b8394a0cddb337efde7b4a21c1b0f66ce496c9"
   license "Apache-2.0"
-  revision 50
+  revision 51
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "a67e61825abea2811c48dcf1d1f835d0b67e169ea99603d0e4a13e1ed2dfecdd"
-    sha256 ventura: "cc18cf10ddbbb7cc2a8400cc40ec7d778f4d9a7b988ccedd58df9224e3c43872"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/ignition-msgs8.rb
+++ b/Formula/ignition-msgs8.rb
@@ -4,15 +4,9 @@ class IgnitionMsgs8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs8-8.7.0.tar.bz2"
   sha256 "b17a8e16fe56a84891bd0654a2ac09427e9a567b9cd2255bb2cfa830f8e1af45"
   license "Apache-2.0"
-  revision 47
+  revision 48
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "19438b60d9fff0eb135d17b131fa591edf5417d87925707f994e64b56d1f2d1b"
-    sha256 cellar: :any, ventura: "a4b37b746f2d1b9f17509e2fc1d3b5fb676c98ce23e54732c4508380acd0166d"
-  end
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -4,15 +4,9 @@ class IgnitionPhysics5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics5-5.3.2.tar.bz2"
   sha256 "4262512fbb6952712234c5cbeed69cdabca338931bb6c587a1ef7d487a5f262b"
   license "Apache-2.0"
-  revision 16
+  revision 17
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "ign-physics5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "4652c7734355008350ddc51956d9b38655e3a854f8a0b84c7ac92b4b7adf273e"
-    sha256 cellar: :any, ventura: "2bf8dcf7740d1a12ba427f5d249594d8dac0d2641f483e1da4411d26820a59ac"
-  end
 
   depends_on "cmake" => :build
 

--- a/Formula/ignition-sensors6.rb
+++ b/Formula/ignition-sensors6.rb
@@ -4,15 +4,9 @@ class IgnitionSensors6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/ignition-sensors-6.8.1.tar.bz2"
   sha256 "abc96be3bd018cae94c83981d173af0f67ce2980ef7a1374b34bd5b63f9a7235"
   license "Apache-2.0"
-  revision 10
+  revision 11
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "bf4765fd96ba53b95abef4d843e928c32f0f0a7e29af71cb60937068451891ae"
-    sha256 cellar: :any, ventura: "27e357cb1cb81ab5f8fed932d2b3359c7f54b0e6872a13d2680bf63f241b1a05"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -4,16 +4,10 @@ class IgnitionTransport11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases/ignition-transport11-11.4.1.tar.bz2"
   sha256 "f18501cbd5c78b584b3db1960a3049d6ae416bab7f0289af64eadda13d1c5da5"
   license "Apache-2.0"
-  revision 40
+  revision 41
   version_scheme 1
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport11"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "782bc93ba35a19d178e144ce14a833f63990f15aeebdf223e518c8f8a0dd37f7"
-    sha256 ventura: "274f2a00ef3dbf594a48e4b2c41408ec4b4b97bc1fa602a1724f8be710e713e4"
-  end
 
   depends_on "doxygen" => [:build, :optional]
 

--- a/Formula/ignition-transport8.rb
+++ b/Formula/ignition-transport8.rb
@@ -4,14 +4,9 @@ class IgnitionTransport8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/ignition-transport-8.5.1.tar.bz2"
   sha256 "e1c67ceda0f98c8ad9167372c3c72b4cdb2329930487121afcc82a5a52e24cb2"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "81dee0982e36cc6edac107c043ea829920572b74ee1d9c43a98ea6f0e4a0a080"
-    sha256 ventura: "242adf28ebabf39d00f69eab1830f804190b045747a28d3a72efd6ba67d661b4"
-  end
 
   depends_on "doxygen" => [:build, :optional]
 

--- a/Formula/sdformat12.rb
+++ b/Formula/sdformat12.rb
@@ -4,15 +4,9 @@ class Sdformat12 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-12.8.0.tar.bz2"
   sha256 "5c0d6579738ff14f849f8d6e101468a8f0abc43000b2b8040170fe082a630489"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/sdformat.git", branch: "sdf12"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:   "d7036d483f69fc6c0906bd16afc8c5f29c749f7d4d2c23356e713365664b0bd5"
-    sha256 ventura:  "1b44fc8926077bfefcbcd5b6e94ef226f88d0bd728ed699643ac7e90a084336e"
-    sha256 monterey: "b88d9dc541ff92956c80c495176154bd1e6cb1dcf447987b372bf5b4820493f5"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/sdformat14.rb
+++ b/Formula/sdformat14.rb
@@ -4,14 +4,9 @@ class Sdformat14 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-14.7.0.tar.bz2"
   sha256 "1ce4d8fe1de6223940a09005cda5b04c1064dd6c622d58dfa6fbc73da0311fa4"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/sdformat.git", branch: "main"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "3eb51fbbab3e5e2a11f33e774e6aa6cc300309936c3a2b809eef399c98bcfc41"
-    sha256 ventura: "e998cd80e454fb87670407cef5b3bb8455111ceac1c5abc942399bb217f3c75c"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/sdformat15.rb
+++ b/Formula/sdformat15.rb
@@ -4,14 +4,9 @@ class Sdformat15 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-15.2.0.tar.bz2"
   sha256 "7242c58349ac1f1607722a6b6f25b692d37f0fe9b4c3f2e197db4fa90c096d76"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/sdformat.git", branch: "sdf15"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "fb53bf7bffbcf66adc1cb1bc09bf08c9c9b6d30ff5a3c87e1bde0556616cf397"
-    sha256 ventura: "39a132e9aa7b09d953cb4e164cb12528d88fce9079488ba6af9df35f791919bf"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/2992.

Generated with:

~~~
for f in $(.github/ci/bottled_dependents.sh tinyxml2)
do
  brew bump-revision --remove-bottle-block --message="broken bottle" $f
done
~~~