### PR TITLE
Remove bottles broken by tinyxml2 11.0

### DIFF
--- a/Formula/gz-common5.rb
+++ b/Formula/gz-common5.rb
@@ -4,15 +4,9 @@ class GzCommon5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-common/releases/gz-common-5.7.1.tar.bz2"
   sha256 "802a0a95bf52e10ec02b7531db1d577e2f477e5d326f0998f0b6ba323eb0396b"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-common.git", branch: "gz-common5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "6a4b7ef3834ab6d065e9933af25a1fcd34f5d05cfc7bd229a0fd51b4c6ea4506"
-    sha256 cellar: :any, ventura: "fcf2b1f21339ddbbd0b0908ce61b1b1b1a2e7ed933245a285963ed11c047ccdc"
-  end
 
   depends_on "assimp"
   depends_on "cmake"

--- a/Formula/gz-common6.rb
+++ b/Formula/gz-common6.rb
@@ -4,15 +4,9 @@ class GzCommon6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-common/releases/gz-common-6.0.2.tar.bz2"
   sha256 "d87f805c5b79b06d610c50f4ed3123afcc6018d2e12759a18ca4131f7d4a6921"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-common.git", branch: "gz-common6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "eefe5ec105c19573fd595ad5b01d38f7e6f8c88a25b7ee1247ad720b05b154b3"
-    sha256 cellar: :any, ventura: "dadc80ae1d36b27cdb6ad36d6557ee1ded1f39dcc4ab672d56cc146244bad460"
-  end
 
   depends_on "assimp"
   depends_on "cmake"

--- a/Formula/gz-fuel-tools10.rb
+++ b/Formula/gz-fuel-tools10.rb
@@ -4,15 +4,9 @@ class GzFuelTools10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-10.0.1.tar.bz2"
   sha256 "ca858f88bbfdebbe0a6b8ea94be3668e62862039397c6e08d41d646435d57fdc"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools10"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "5f9fbd00ac309db0286414085a3882dfde7f464a4ba44dc64f598d3c9838d0eb"
-    sha256 cellar: :any, ventura: "83a417cbe4337147bf815921b12a1a7207410ebd30ae441e3e0aa47ec1028b3a"
-  end
 
   depends_on "abseil"
   depends_on "cmake"

--- a/Formula/gz-fuel-tools9.rb
+++ b/Formula/gz-fuel-tools9.rb
@@ -4,15 +4,9 @@ class GzFuelTools9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-9.1.1.tar.bz2"
   sha256 "3189166d4b0078c0b9d98de178e5496a1cc28b88fbd1124603376181b5a053f5"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "6e670f10588d487ccd0fba3dcedaf2f6c051ed2495836e03893b6e26ad0e77c5"
-    sha256 cellar: :any, ventura: "60d95e1a2bd7e5fbb1f6bc22061413ce4683fb4b70abb711866a851e6be54aca"
-  end
 
   depends_on "abseil"
   depends_on "cmake"

--- a/Formula/gz-gui8.rb
+++ b/Formula/gz-gui8.rb
@@ -4,15 +4,9 @@ class GzGui8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-8.4.0.tar.bz2"
   sha256 "1731b01a134afb11b1b3e049fc65e74fa7b5c50532406d3d68366d54016d5498"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "bc65bd08222864d7eadf1756f8aae31ec40b73c6f471b66656775243fc232e10"
-    sha256 ventura: "5c1221ff442beecd702e4542b6cc4b8514dce606feefd4a7873b62a83e019900"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-gui9.rb
+++ b/Formula/gz-gui9.rb
@@ -4,15 +4,9 @@ class GzGui9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-9.0.1.tar.bz2"
   sha256 "873d9950b1aa577b5b7f864caa4c3f759e29d5b67b81c4d69ab7d37043c4f96d"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "f736d12f18a3fd4bb4bb511ec02a7aefc5f7817858bc5fab05a8f89a47a7c13a"
-    sha256 ventura: "62dc55325984b186c98650ad2432ee35716333edd2a621e23472d474d2180bc4"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-launch7.rb
+++ b/Formula/gz-launch7.rb
@@ -4,15 +4,9 @@ class GzLaunch7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-7.1.1.tar.bz2"
   sha256 "e29f8b4663474cfed1364c45afa3aee8b44d816ffe1679c26c699f7c805cdffd"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "92de00112e348d6acb39a1279127aac9ae6ba394c09d76e7fe208913b8c0622d"
-    sha256 ventura: "246c80133c9fe57266bcd25f02a99d59eea8c5fd3b3690c854fc482fc18474dd"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build

--- a/Formula/gz-launch8.rb
+++ b/Formula/gz-launch8.rb
@@ -4,15 +4,9 @@ class GzLaunch8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-8.0.1.tar.bz2"
   sha256 "ce89cfe1554bf64ea63bbbcd7ce9624dd488a72a688cd620f97cabab776245a7"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "61f0a8c4039bb8e01bd8e017a6971061481f982663bd508a1784cf694a3cc9b6"
-    sha256 ventura: "9bf7bb1eba827112282871242b7ef2fdea24af46f0a209c56075bcffb7f6dd6c"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build

--- a/Formula/gz-msgs10.rb
+++ b/Formula/gz-msgs10.rb
@@ -4,15 +4,9 @@ class GzMsgs10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/gz-msgs-10.3.2.tar.bz2"
   sha256 "0dd9c19dee7aec7fc0f7bdd03ee2ae44ab1068dac2fc1ae8cc3ecc1b6df8472a"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs10"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "107f10b00c69fbf0054ef789a4ef2a0d227152a3a8e8e75799b98884a2544ba1"
-    sha256 ventura: "dbd8c598fb0b94284d6842fa03a6332adda6c0d674176555b5f3a07f42635cda"
-  end
 
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]

--- a/Formula/gz-msgs11.rb
+++ b/Formula/gz-msgs11.rb
@@ -4,15 +4,9 @@ class GzMsgs11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/gz-msgs-11.0.2.tar.bz2"
   sha256 "6a7ccdb49d9320ba94c4ee25641ff27ca0aa78b230a8933b0d3f1d4b1b2bda05"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs11"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "7904dd2c14e6bbb3302dcd098d32e81bfe183acb6b13eea398bd6d59c2599d61"
-    sha256 ventura: "f3293a6190bd1d145b070c317e20589a30530bf114ac3332b447b8342aa9a54c"
-  end
 
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]

--- a/Formula/gz-physics7.rb
+++ b/Formula/gz-physics7.rb
@@ -4,15 +4,9 @@ class GzPhysics7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-7.5.0.tar.bz2"
   sha256 "3c44365182f8d43ae54c7b8cec65b80daab95defb8057dbd7da6e0c1fc44dbf6"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "582e103981594fccbda34445cf26e5a3b10f580faa234a16b2fb0dabaddd41a6"
-    sha256 ventura: "882c254d59014692289ee5906703d8acd54c2052b5889341e0e808c1b01b9e9b"
-  end
 
   depends_on "cmake" => [:build, :test]
 

--- a/Formula/gz-physics8.rb
+++ b/Formula/gz-physics8.rb
@@ -4,15 +4,9 @@ class GzPhysics8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-8.1.0.tar.bz2"
   sha256 "4dc187a27b5c2b34a22ff911ae770a551a49468ca53bdd24316f57e6e18e6490"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "6c8930d439a674b76cdc9b6ad7bf1b25e34383cf2ef18dbe55cbe0d77cff6e36"
-    sha256 ventura: "5d5a5e6115ac004c3d6581d6bdf080a1732ba498a6798e80b90247e451d39f88"
-  end
 
   depends_on "cmake" => [:build, :test]
 

--- a/Formula/gz-sensors8.rb
+++ b/Formula/gz-sensors8.rb
@@ -4,15 +4,9 @@ class GzSensors8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-8.2.2.tar.bz2"
   sha256 "9ddc16d5cab0a86f27771732f5cfcfde1efe7611f27da61176ea122273806c42"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "f1ea865ec082b493f11e055c0858f8f741eb5cafe36a95f5ad581a9fc1e1399e"
-    sha256 cellar: :any, ventura: "2224450863feafebb3631ab785cc022de9041bbf76ab23d27444475335f9a514"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-sensors9.rb
+++ b/Formula/gz-sensors9.rb
@@ -4,15 +4,9 @@ class GzSensors9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-9.1.0.tar.bz2"
   sha256 "3d1aaf20fd987efc1fc29f343cc42c96e07f57e060849c779b22bb32724ded35"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "d13c3542bec58d4d8248f2f15b6e85c915fe9804ad45f97b322932b2f8dfea12"
-    sha256 cellar: :any, ventura: "0efca662251158467c5aff2498859cca25640e13fdf7ae1d16e34acebddaf7ea"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-sim8.rb
+++ b/Formula/gz-sim8.rb
@@ -4,15 +4,9 @@ class GzSim8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-8.9.0.tar.bz2"
   sha256 "c55aa45a4f12ddad7115455722afd2fe9bb7fef7cc3fa119a2a24ea77e58dedf"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "161441fdb8b37b22da5a2f64de072c7a50472b131b86eb8c4fb47f3f941bd99b"
-    sha256 ventura: "aeea4a7b4bbabfe6068e16593931ec0167a5a5313131456c585b05681a0ea0ff"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build

--- a/Formula/gz-sim9.rb
+++ b/Formula/gz-sim9.rb
@@ -4,15 +4,9 @@ class GzSim9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-9.1.0.tar.bz2"
   sha256 "7866afccfae26d345d696f22d9b9952f821d2e9f7418be2616b2bcc99bbfdea9"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "f2f4afde107fe9b683e88b4a8944917d350899be4e4066fcbd4712182205aefe"
-    sha256 ventura: "84190adf13564721579a1648bf6aa1a15eace8d3b0836e06868fa65293b15541"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build

--- a/Formula/gz-transport13.rb
+++ b/Formula/gz-transport13.rb
@@ -4,15 +4,9 @@ class GzTransport13 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/gz-transport-13.4.1.tar.bz2"
   sha256 "1e7051de16c8e0cadf5b357d32193ffdb3eb33775126d1f89bef29bfd02e11b8"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport13"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "b3c85f39d5d71ba45891219c6cddeccbac1a5fb71e044138c462ec34ec06c432"
-    sha256 ventura: "2afe8cab38921b30d9e61363f320c31bf08a4f95f388810da28fa7eb5a238627"
-  end
 
   depends_on "doxygen" => [:build, :optional]
   depends_on "pybind11" => :build

--- a/Formula/gz-transport14.rb
+++ b/Formula/gz-transport14.rb
@@ -4,15 +4,9 @@ class GzTransport14 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/gz-transport-14.0.1.tar.bz2"
   sha256 "74f6f082be147c12a327abd3480fd8b423d6af6867e75fdf596452a03ad9350b"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport14"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "8ccbae04798676a79a315d07f198a607e6d320e48d60bee07abc771d89fd5223"
-    sha256 ventura: "616a2c77d750967123f11719daaaea1064cc908ced18a335a1808501c6cbcecf"
-  end
 
   depends_on "doxygen" => [:build, :optional]
   depends_on "pybind11" => :build

--- a/Formula/ignition-common4.rb
+++ b/Formula/ignition-common4.rb
@@ -4,15 +4,9 @@ class IgnitionCommon4 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-common/releases/ignition-common4-4.7.0.tar.bz2"
   sha256 "ec9bb68be9f6323f3a3a12b23259c567f9a2478951719573e1b7c906bd7e68cb"
   license "Apache-2.0"
-  revision 6
+  revision 7
 
   head "https://github.com/gazebosim/gz-common.git", branch: "ign-common4"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "e36f98109631d6f6ff04cf70fb425140b398938335634c52ab7b9c8a08d6dfff"
-    sha256 cellar: :any, ventura: "1b5a99730f78cc7bd39b59360e920b31ac128b32f3dbcc26a8cc0288edeb0402"
-  end
 
   depends_on "cmake"
   depends_on "ffmpeg"

--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -4,15 +4,9 @@ class IgnitionFuelTools7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/ignition-fuel_tools-7.3.1.tar.bz2"
   sha256 "b8224c574406147ae008ed9a0ac459f1e2582f6aaef7ba44e1fd1c5ac97b6de8"
   license "Apache-2.0"
-  revision 16
+  revision 17
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "62deb3b5e9878414807eaf0572e1be7978846fda11085fb5e141624599c474e3"
-    sha256 cellar: :any, ventura: "b149be82d04699e5e597e6f671b8ca33dc7b3b038d78c55c4459b0161bd914da"
-  end
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -4,15 +4,9 @@ class IgnitionGazebo6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/ignition-gazebo-6.17.0.tar.bz2"
   sha256 "3a51ba77e5cbbc3d0b6b3dd44d66bfd3076bed228c8c9face9678f1bd7a51ced"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "dd4df5aa358d3c54fe69891a3e89fe9d61c747697dab76dc804349e6d804f986"
-    sha256 ventura: "6dc0f739685a67370275784b3969ac49875fba236d00b47b237653ac4fad6862"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -4,15 +4,9 @@ class IgnitionGui6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-gui/releases/ignition-gui6-6.8.0.tar.bz2"
   sha256 "dd4f26100f4d1343f068ba36f2b8394a0cddb337efde7b4a21c1b0f66ce496c9"
   license "Apache-2.0"
-  revision 52
+  revision 53
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "346c5d472ca04a16cbfb092a416f02506d39c0af376e623b186fd5ddca4bd0c7"
-    sha256 ventura: "f16f8c8572c932d8b39cd374d3f08bfe215377e4cc576434a97e4c753790b081"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/ignition-launch5.rb
+++ b/Formula/ignition-launch5.rb
@@ -4,15 +4,9 @@ class IgnitionLaunch5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-launch/releases/ignition-launch5-5.3.0.tar.bz2"
   sha256 "84d356b9c85609da1bb7feda2f90ae6d1a1fd2d6713b284799d5605de42e2613"
   license "Apache-2.0"
-  revision 50
+  revision 51
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "ign-launch5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "98b8a9f11a8bb9f2fcdda10be510bc07a3fa68bf1ebb60729e30176ac860b63a"
-    sha256 ventura: "bcf097724aafe42147de800191da10b64bf39683501506270f64dcefc59f6380"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build

--- a/Formula/ignition-msgs8.rb
+++ b/Formula/ignition-msgs8.rb
@@ -4,15 +4,9 @@ class IgnitionMsgs8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs8-8.7.0.tar.bz2"
   sha256 "b17a8e16fe56a84891bd0654a2ac09427e9a567b9cd2255bb2cfa830f8e1af45"
   license "Apache-2.0"
-  revision 49
+  revision 50
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "b1cb82c0533fb1362a4be307df90bd6c661066f4652d3c7ec0c6783dc3b14aaf"
-    sha256 cellar: :any, ventura: "6479566514b250973272350fea63fc187262bf71190d133d07800f8a32013ebc"
-  end
 
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -4,15 +4,9 @@ class IgnitionPhysics5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics5-5.3.2.tar.bz2"
   sha256 "4262512fbb6952712234c5cbeed69cdabca338931bb6c587a1ef7d487a5f262b"
   license "Apache-2.0"
-  revision 18
+  revision 19
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "ign-physics5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "7429e390f582fe6d48d89a4df64acecf495a8a24daa03f13dcf1b39d5d091091"
-    sha256 cellar: :any, ventura: "25f57f0bc3fa96283dde7889842aaeb8ae89d10da205ee2d666e4d950c598025"
-  end
 
   depends_on "cmake" => :build
 

--- a/Formula/ignition-sensors6.rb
+++ b/Formula/ignition-sensors6.rb
@@ -4,15 +4,9 @@ class IgnitionSensors6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/ignition-sensors-6.8.1.tar.bz2"
   sha256 "abc96be3bd018cae94c83981d173af0f67ce2980ef7a1374b34bd5b63f9a7235"
   license "Apache-2.0"
-  revision 12
+  revision 13
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "e7c416875a9514620701e45046e5be71129d141188c62778607289171aecbfe8"
-    sha256 cellar: :any, ventura: "78214d4281078219620984cbc03e5ae3ec327b36d7c766a81ca932bd79e6692a"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -4,16 +4,10 @@ class IgnitionTransport11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-transport/releases/ignition-transport11-11.4.1.tar.bz2"
   sha256 "f18501cbd5c78b584b3db1960a3049d6ae416bab7f0289af64eadda13d1c5da5"
   license "Apache-2.0"
-  revision 42
+  revision 43
   version_scheme 1
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport11"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "0afee44e829e3ab683692aacbc252495103134d28b330a7aff71b0f8b6285da5"
-    sha256 ventura: "74fb2f80a9ada296a289c6e8e3a8ac29fccc7c0a739b7527a3304c941e7519b9"
-  end
 
   depends_on "doxygen" => [:build, :optional]
 

--- a/Formula/sdformat12.rb
+++ b/Formula/sdformat12.rb
@@ -4,15 +4,9 @@ class Sdformat12 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-12.8.0.tar.bz2"
   sha256 "5c0d6579738ff14f849f8d6e101468a8f0abc43000b2b8040170fe082a630489"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/sdformat.git", branch: "sdf12"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "12b8a1dff29d908adbfcaea0984929fd0b61d7ad9e280200e1c0ee85a1b05242"
-    sha256 ventura: "8926100961139c2bfd2454b2a778c349aa37283e2e39ff7611daea7bbaeb5cb7"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/sdformat14.rb
+++ b/Formula/sdformat14.rb
@@ -4,15 +4,9 @@ class Sdformat14 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-14.7.0.tar.bz2"
   sha256 "1ce4d8fe1de6223940a09005cda5b04c1064dd6c622d58dfa6fbc73da0311fa4"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/sdformat.git", branch: "main"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "b104c20d21e4e90b63bbfc3c72d3852a81599c2f12c1e68cbf8e1c8211900e29"
-    sha256 ventura: "661874a93df2c2d0e1cec67b4223b89c019dc9f2bc0c9a377cd4761d9d5f99cb"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/sdformat15.rb
+++ b/Formula/sdformat15.rb
@@ -4,15 +4,9 @@ class Sdformat15 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-15.2.0.tar.bz2"
   sha256 "7242c58349ac1f1607722a6b6f25b692d37f0fe9b4c3f2e197db4fa90c096d76"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/sdformat.git", branch: "sdf15"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "c9172cfd0d46fd07c45e820e6c4d7c21dfd188a2c9c4b21bc637b869cab1fcd0"
-    sha256 ventura: "028529d36204b5cddab74767ea59272d1745f8d7c4bdcff2107bc609f241edfd"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/2998.

Generated with:

~~~
for f in $(.github/ci/bottled_dependents.sh tinyxml2)
do
  brew bump-revision --remove-bottle-block --message="broken bottle" $f
done
~~~