### PR TITLE
gz-transport15: new formula

### DIFF
--- a/Aliases/gz-transport15
+++ b/Aliases/gz-transport15
@@ -1,1 +1,0 @@
-../Formula/gz-transport14.rb

--- a/Formula/gz-transport15.rb
+++ b/Formula/gz-transport15.rb
@@ -12,11 +12,13 @@ class GzTransport15 < Formula
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
 
+  depends_on "abseil"
   depends_on "cmake"
   depends_on "cppzmq"
   depends_on "eclipse-zenoh/homebrew-zenoh/libzenohc"
   depends_on "eclipse-zenoh/homebrew-zenoh/libzenohcpp"
   depends_on "gz-cmake4"
+  depends_on "gz-math8"
   depends_on "gz-msgs11"
   depends_on "gz-tools2"
   depends_on "gz-utils3"
@@ -25,6 +27,7 @@ class GzTransport15 < Formula
   depends_on "pkgconf"
   depends_on "protobuf"
   depends_on "sqlite"
+  depends_on "tinyxml2"
   depends_on "zeromq"
 
   def pythons

--- a/Formula/gz-transport15.rb
+++ b/Formula/gz-transport15.rb
@@ -12,13 +12,11 @@ class GzTransport15 < Formula
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
 
-  depends_on "abseil"
   depends_on "cmake"
   depends_on "cppzmq"
   depends_on "eclipse-zenoh/homebrew-zenoh/libzenohc"
   depends_on "eclipse-zenoh/homebrew-zenoh/libzenohcpp"
   depends_on "gz-cmake4"
-  depends_on "gz-math8"
   depends_on "gz-msgs11"
   depends_on "gz-tools2"
   depends_on "gz-utils3"
@@ -27,7 +25,6 @@ class GzTransport15 < Formula
   depends_on "pkgconf"
   depends_on "protobuf"
   depends_on "sqlite"
-  depends_on "tinyxml2"
   depends_on "zeromq"
 
   def pythons

--- a/Formula/gz-transport15.rb
+++ b/Formula/gz-transport15.rb
@@ -82,16 +82,16 @@ class GzTransport15 < Formula
     EOS
     (testpath/"CMakeLists.txt").write <<-EOS
       cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
-      find_package(gz-transport15 QUIET REQUIRED)
+      find_package(gz-transport QUIET REQUIRED)
       add_executable(test_cmake test.cpp)
-      target_link_libraries(test_cmake gz-transport15::gz-transport15)
+      target_link_libraries(test_cmake gz-transport::gz-transport)
     EOS
-    system "pkg-config", "gz-transport15"
-    cflags = `pkg-config --cflags gz-transport15`.split
+    system "pkg-config", "gz-transport"
+    cflags = `pkg-config --cflags gz-transport`.split
     system ENV.cc, "test.cpp",
                    *cflags,
                    "-L#{lib}",
-                   "-lgz-transport15",
+                   "-lgz-transport",
                    "-lc++",
                    "-o", "test"
     ENV["GZ_PARTITION"] = rand((1 << 32) - 1).to_s
@@ -106,7 +106,7 @@ class GzTransport15 < Formula
     system cmd_not_grep_xcode
     # check python import
     pythons.each do |python|
-      system python.opt_libexec/"bin/python", "-c", "import gz.transport15"
+      system python.opt_libexec/"bin/python", "-c", "import gz.transport"
     end
   end
 end

--- a/Formula/gz-transport15.rb
+++ b/Formula/gz-transport15.rb
@@ -15,6 +15,8 @@ class GzTransport15 < Formula
   depends_on "abseil"
   depends_on "cmake"
   depends_on "cppzmq"
+  depends_on "eclipse-zenoh/homebrew-zenoh/libzenohc"
+  depends_on "eclipse-zenoh/homebrew-zenoh/libzenohcpp"
   depends_on "gz-cmake4"
   depends_on "gz-math8"
   depends_on "gz-msgs11"
@@ -27,8 +29,6 @@ class GzTransport15 < Formula
   depends_on "sqlite"
   depends_on "tinyxml2"
   depends_on "zeromq"
-  depends_on "eclipse-zenoh/homebrew-zenoh/libzenohcpp"
-  depends_on "eclipse-zenoh/homebrew-zenoh/libzenohc"
 
   def pythons
     deps.map(&:to_formula)

--- a/Formula/gz-transport15.rb
+++ b/Formula/gz-transport15.rb
@@ -1,0 +1,112 @@
+class GzTransport15 < Formula
+  desc "Transport middleware for robotics"
+  homepage "https://gazebosim.org"
+  url "https://github.com/gazebosim/gz-transport.git", branch: "main"
+  version "14.999.999-0-20250407"
+  license "Apache-2.0"
+
+  head "https://github.com/gazebosim/gz-transport.git", branch: "main"
+
+  depends_on "doxygen" => [:build, :optional]
+  depends_on "pybind11" => :build
+  depends_on "python@3.12" => [:build, :test]
+  depends_on "python@3.13" => [:build, :test]
+
+  depends_on "abseil"
+  depends_on "cmake"
+  depends_on "cppzmq"
+  depends_on "gz-cmake4"
+  depends_on "gz-math8"
+  depends_on "gz-msgs11"
+  depends_on "gz-tools2"
+  depends_on "gz-utils3"
+  depends_on macos: :mojave # c++17
+  depends_on "ossp-uuid"
+  depends_on "pkgconf"
+  depends_on "protobuf"
+  depends_on "sqlite"
+  depends_on "tinyxml2"
+  depends_on "zeromq"
+  depends_on "eclipse-zenoh/homebrew-zenoh/libzenohcpp"
+  depends_on "eclipse-zenoh/homebrew-zenoh/libzenohc"
+
+  def pythons
+    deps.map(&:to_formula)
+        .select { |f| f.name.match?(/^python@3\.\d+$/) }
+  end
+
+  def python_cmake_arg(python = Formula["python@3.13"])
+    "-DPython3_EXECUTABLE=#{python.opt_libexec}/bin/python"
+  end
+
+  def install
+    rpaths = [
+      rpath,
+      rpath(source: libexec/"gz/transport15", target: lib),
+    ]
+    cmake_args = std_cmake_args
+    cmake_args << "-DBUILD_TESTING=OFF"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpaths.join(";")}"
+
+    # first build without python bindings
+    mkdir "build" do
+      system "cmake", "..", *cmake_args, "-DSKIP_PYBIND11=ON"
+      system "make", "install"
+    end
+
+    # now build only the python bindings
+    pythons.each do |python|
+      # remove @ from formula name
+      python_name = python.name.tr("@", "")
+      mkdir "build_#{python_name}" do
+        system "cmake", "../python", *cmake_args, python_cmake_arg(python)
+        system "make", "install"
+        (lib/"#{python_name}/site-packages").install Dir[lib/"python/*"]
+        rmdir prefix/"lib/python"
+      end
+    end
+  end
+
+  test do
+    # test CLI executables
+    system libexec/"gz/transport15/gz-transport-service"
+    system libexec/"gz/transport15/gz-transport-topic"
+    # build against API
+    (testpath/"test.cpp").write <<-EOS
+      #include <iostream>
+      #include <gz/transport.hh>
+      int main() {
+        gz::transport::NodeOptions options;
+        return 0;
+      }
+    EOS
+    (testpath/"CMakeLists.txt").write <<-EOS
+      cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
+      find_package(gz-transport15 QUIET REQUIRED)
+      add_executable(test_cmake test.cpp)
+      target_link_libraries(test_cmake gz-transport15::gz-transport15)
+    EOS
+    system "pkg-config", "gz-transport15"
+    cflags = `pkg-config --cflags gz-transport15`.split
+    system ENV.cc, "test.cpp",
+                   *cflags,
+                   "-L#{lib}",
+                   "-lgz-transport15",
+                   "-lc++",
+                   "-o", "test"
+    ENV["GZ_PARTITION"] = rand((1 << 32) - 1).to_s
+    system "./test"
+    mkdir "build" do
+      system "cmake", ".."
+      system "make"
+      system "./test_cmake"
+    end
+    # check for Xcode frameworks in bottle
+    cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
+    system cmd_not_grep_xcode
+    # check python import
+    pythons.each do |python|
+      system python.opt_libexec/"bin/python", "-c", "import gz.transport15"
+    end
+  end
+end

--- a/Formula/gz-transport15.rb
+++ b/Formula/gz-transport15.rb
@@ -15,8 +15,6 @@ class GzTransport15 < Formula
   depends_on "abseil"
   depends_on "cmake"
   depends_on "cppzmq"
-  depends_on "eclipse-zenoh/homebrew-zenoh/libzenohc"
-  depends_on "eclipse-zenoh/homebrew-zenoh/libzenohcpp"
   depends_on "gz-cmake4"
   depends_on "gz-math8"
   depends_on "gz-msgs11"


### PR DESCRIPTION
Removed alias to gz-transport14 and added a new gz-transport15.rb formula

~~Added 2 new dependencies related to zenoh that comes from a thirdparty tap:~~


  ~~depends_on "eclipse-zenoh/homebrew-zenoh/libzenohcpp"~~
  ~~depends_on "eclipse-zenoh/homebrew-zenoh/libzenohc"~~


~~Related gz-transport PR: https://github.com/gazebosim/gz-transport/pull/600~~