### PR TITLE
gz-gui10 and gz-sim10: Add Qt6 dependency

### DIFF
--- a/Formula/gz-gui10.rb
+++ b/Formula/gz-gui10.rb
@@ -20,7 +20,7 @@ class GzGui10 < Formula
   depends_on "gz-utils3"
   depends_on macos: :mojave # c++17
   depends_on "protobuf"
-  depends_on "qt@5"
+  depends_on "qt@6"
   depends_on "tinyxml2"
 
   def install

--- a/Formula/gz-gui10.rb
+++ b/Formula/gz-gui10.rb
@@ -20,6 +20,7 @@ class GzGui10 < Formula
   depends_on "gz-utils3"
   depends_on macos: :mojave # c++17
   depends_on "protobuf"
+  depends_on "qt@5"
   depends_on "qt@6"
   depends_on "tinyxml2"
 

--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -31,6 +31,7 @@ class GzSim10 < Formula
   depends_on macos: :mojave # c++17
   depends_on "pkgconf"
   depends_on "protobuf"
+  depends_on "qt@5"
   depends_on "qt@6"
   depends_on "ruby"
   depends_on "sdformat15"

--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -31,7 +31,7 @@ class GzSim10 < Formula
   depends_on macos: :mojave # c++17
   depends_on "pkgconf"
   depends_on "protobuf"
-  depends_on "qt@5"
+  depends_on "qt@6"
   depends_on "ruby"
   depends_on "sdformat15"
   depends_on "tinyxml2"


### PR DESCRIPTION
Adds Qt6 dependency alongside of Qt5. Once the switch is made in the source repos (gz-sim, gz-gui), we can remove Qt5. 

Tested with https://github.com/gazebosim/gz-gui/pull/673

https://build.osrfoundation.org/job/gz_gui-ci-pr_any-homebrew-amd64/202/

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_gui-ci-pr_any-homebrew-amd64&build=202)](https://build.osrfoundation.org/job/gz_gui-ci-pr_any-homebrew-amd64/202/) 
