### PR TITLE
gz-launch9: Bump gz-transport and others in jetty

### DIFF
--- a/Aliases/gz-sensors10
+++ b/Aliases/gz-sensors10
@@ -1,1 +1,0 @@
-../Formula/gz-sensors9.rb

--- a/Formula/gz-gui10.rb
+++ b/Formula/gz-gui10.rb
@@ -2,7 +2,7 @@ class GzGui10 < Formula
   desc "Common libraries for robotics applications. GUI Library"
   homepage "https://github.com/gazebosim/gz-gui"
   url "https://github.com/gazebosim/gz-gui.git", branch: "main"
-  version "9.999.999-0-20250117"
+  version "9.999.999-0-20250412"
   license "Apache-2.0"
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui10"
@@ -16,7 +16,7 @@ class GzGui10 < Formula
   depends_on "gz-msgs11"
   depends_on "gz-plugin3"
   depends_on "gz-rendering9"
-  depends_on "gz-transport14"
+  depends_on "gz-transport15"
   depends_on "gz-utils3"
   depends_on macos: :mojave # c++17
   depends_on "protobuf"

--- a/Formula/gz-launch9.rb
+++ b/Formula/gz-launch9.rb
@@ -2,7 +2,7 @@ class GzLaunch9 < Formula
   desc "Launch libraries for robotics applications"
   homepage "https://github.com/gazebosim/gz-launch"
   url "https://github.com/gazebosim/gz-launch.git", branch: "main"
-  version "8.999.999-0-20250117"
+  version "8.999.999-0-20250415"
   license "Apache-2.0"
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch9"
@@ -23,7 +23,7 @@ class GzLaunch9 < Formula
   depends_on "gz-rendering9"
   depends_on "gz-sim10"
   depends_on "gz-tools2"
-  depends_on "gz-transport14"
+  depends_on "gz-transport15"
   depends_on "gz-utils3"
   depends_on "protobuf"
   depends_on "qt@5"

--- a/Formula/gz-sensors10.rb
+++ b/Formula/gz-sensors10.rb
@@ -1,0 +1,73 @@
+class GzSensors10 < Formula
+  desc "Sensors library for robotics applications"
+  homepage "https://github.com/gazebosim/gz-sensors"
+  url "https://github.com/gazebosim/gz-sensors.git", branch: "main"
+  version "9.999.999-0-20250412"
+  license "Apache-2.0"
+
+  head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors10"
+
+  depends_on "cmake" => [:build, :test]
+  depends_on "pkgconf" => [:build, :test]
+
+  depends_on "abseil"
+  depends_on "gz-cmake4"
+  depends_on "gz-common6"
+  depends_on "gz-math8"
+  depends_on "gz-msgs11"
+  depends_on "gz-rendering9"
+  depends_on "gz-transport15"
+  depends_on "gz-utils3"
+  depends_on "protobuf"
+  depends_on "sdformat15"
+  depends_on "tinyxml2"
+
+  def install
+    cmake_args = std_cmake_args
+    cmake_args << "-DBUILD_TESTING=OFF"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+
+    mkdir "build" do
+      system "cmake", "..", *cmake_args
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS
+      #include <gz/sensors/Noise.hh>
+
+      int main()
+      {
+        gz::sensors::Noise noise(gz::sensors::NoiseType::NONE);
+
+        return 0;
+      }
+    EOS
+    (testpath/"CMakeLists.txt").write <<-EOS
+      cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
+      find_package(gz-sensors QUIET REQUIRED)
+      add_executable(test_cmake test.cpp)
+      target_link_libraries(test_cmake gz-sensors::gz-sensors)
+    EOS
+    # test building with pkg-config
+    system "pkg-config", "gz-sensors"
+    cflags   = `pkg-config --cflags gz-sensors`.split
+    ldflags  = `pkg-config --libs gz-sensors`.split
+    system ENV.cc, "test.cpp",
+                   *cflags,
+                   *ldflags,
+                   "-lc++",
+                   "-o", "test"
+    system "./test"
+    # test building with cmake
+    mkdir "build" do
+      system "cmake", ".."
+      system "make"
+      system "./test_cmake"
+    end
+    # check for Xcode frameworks in bottle
+    cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
+    system cmd_not_grep_xcode
+  end
+end

--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -2,7 +2,7 @@ class GzSim10 < Formula
   desc "Gazebo Sim robot simulator"
   homepage "https://github.com/gazebosim/gz-sim"
   url "https://github.com/gazebosim/gz-sim.git", branch: "main"
-  version "9.999.999-0-20250117"
+  version "9.999.999-0-20250415"
   license "Apache-2.0"
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim10"
@@ -23,9 +23,9 @@ class GzSim10 < Formula
   depends_on "gz-physics8"
   depends_on "gz-plugin3"
   depends_on "gz-rendering9"
-  depends_on "gz-sensors9"
+  depends_on "gz-sensors10"
   depends_on "gz-tools2"
-  depends_on "gz-transport14"
+  depends_on "gz-transport15"
   depends_on "gz-utils3"
   depends_on "libwebsockets"
   depends_on macos: :mojave # c++17


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1292.