### PR TITLE
gz-launch9: Update to Qt6

### DIFF
--- a/Formula/gz-launch9.rb
+++ b/Formula/gz-launch9.rb
@@ -26,7 +26,7 @@ class GzLaunch9 < Formula
   depends_on "gz-transport15"
   depends_on "gz-utils3"
   depends_on "protobuf"
-  depends_on "qt@5"
+  depends_on "qt@6"
   depends_on "sdformat15"
   depends_on "tinyxml2"
 


### PR DESCRIPTION
I removed the search for Qt packages in source code: https://github.com/gazebosim/gz-launch/pull/297 but given that homebrew bottle building may need transitive dependencies, I updated it to Qt6 here instead of removing the dependency.