### PR TITLE
gz-fuel-tools11: Bump gz-cmake and others in jetty

### DIFF
--- a/Aliases/gz-fuel-tools11
+++ b/Aliases/gz-fuel-tools11
@@ -1,1 +1,0 @@
-../Formula/gz-fuel-tools10.rb

--- a/Formula/gz-fuel-tools11.rb
+++ b/Formula/gz-fuel-tools11.rb
@@ -1,0 +1,70 @@
+class GzFuelTools11 < Formula
+  desc "Tools for using Fuel API to download robot models"
+  homepage "https://gazebosim.org"
+  url "https://github.com/gazebosim/gz-fuel-tools.git", branch: "main"
+  version "10.999.999-0-20250502"
+  license "Apache-2.0"
+
+  head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools11"
+
+  depends_on "abseil"
+  depends_on "cmake"
+  depends_on "gz-cmake5"
+  depends_on "gz-common7"
+  depends_on "gz-math9"
+  depends_on "gz-msgs12"
+  depends_on "gz-utils4"
+  depends_on "jsoncpp"
+  depends_on "libyaml"
+  depends_on "libzip"
+  depends_on macos: :high_sierra # c++17
+  depends_on "pkgconf"
+  depends_on "protobuf"
+  depends_on "tinyxml2"
+
+  def install
+    cmake_args = std_cmake_args
+    cmake_args << "-DBUILD_TESTING=Off"
+    cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+
+    mkdir "build" do
+      system "cmake", "..", *cmake_args
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS
+      #include <gz/fuel_tools.hh>
+      int main() {
+        gz::fuel_tools::ServerConfig srv;
+        return 0;
+      }
+    EOS
+    (testpath/"CMakeLists.txt").write <<-EOS
+      cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
+      find_package(gz-fuel_tools QUIET REQUIRED)
+      add_executable(test_cmake test.cpp)
+      target_link_libraries(test_cmake gz-fuel_tools::gz-fuel_tools)
+    EOS
+    # test building with pkg-config
+    system "pkg-config", "gz-fuel_tools"
+    cflags = `pkg-config --cflags gz-fuel_tools`.split
+    system ENV.cc, "test.cpp",
+                   *cflags,
+                   "-L#{lib}",
+                   "-lgz-fuel_tools",
+                   "-lc++",
+                   "-o", "test"
+    system "./test"
+    # test building with cmake
+    mkdir "build" do
+      system "cmake", ".."
+      system "make"
+      system "./test_cmake"
+    end
+    # check for Xcode frameworks in bottle
+    cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
+    system cmd_not_grep_xcode
+  end
+end


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1309.