### PR TITLE
Remove bottles broken by gdal 3.11.0

### DIFF
--- a/Formula/gz-common5.rb
+++ b/Formula/gz-common5.rb
@@ -4,15 +4,9 @@ class GzCommon5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-common/releases/gz-common-5.7.1.tar.bz2"
   sha256 "802a0a95bf52e10ec02b7531db1d577e2f477e5d326f0998f0b6ba323eb0396b"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-common.git", branch: "gz-common5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "e95a309f68e8b7441992a5f24444a0a9206669caea16b1fe43dea6d2656b6952"
-    sha256 cellar: :any, ventura: "11ff0ba33310ee8ada4c7404abcd397a866cb89763ecc11b200f05320daf02fc"
-  end
 
   depends_on "assimp"
   depends_on "cmake"

--- a/Formula/gz-common6.rb
+++ b/Formula/gz-common6.rb
@@ -4,15 +4,9 @@ class GzCommon6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-common/releases/gz-common-6.0.2.tar.bz2"
   sha256 "d87f805c5b79b06d610c50f4ed3123afcc6018d2e12759a18ca4131f7d4a6921"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-common.git", branch: "gz-common6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "ddfe4c2fd8ab2422f468f69aaf9e68e3557aa0525e09726810a72d6b88249927"
-    sha256 cellar: :any, ventura: "1a64b1c11ff5c8ff917a028dd08db4de381d0a28af584647394cff977b6bb826"
-  end
 
   depends_on "assimp"
   depends_on "cmake"

--- a/Formula/gz-fuel-tools10.rb
+++ b/Formula/gz-fuel-tools10.rb
@@ -4,15 +4,9 @@ class GzFuelTools10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-10.0.1.tar.bz2"
   sha256 "ca858f88bbfdebbe0a6b8ea94be3668e62862039397c6e08d41d646435d57fdc"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools10"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "b3d728d60207af8792202b7fecd31d9cc2213ef79826cca8fef785293dcb155b"
-    sha256 cellar: :any, ventura: "a218ea449be7ea476b5d4f6b95e0aaf4865eb78b06b00c8b12d61ab4919972ae"
-  end
 
   depends_on "abseil"
   depends_on "cmake"

--- a/Formula/gz-fuel-tools9.rb
+++ b/Formula/gz-fuel-tools9.rb
@@ -4,15 +4,9 @@ class GzFuelTools9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-9.1.1.tar.bz2"
   sha256 "3189166d4b0078c0b9d98de178e5496a1cc28b88fbd1124603376181b5a053f5"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "3c4807e0ede06d8f47ad15b508d8b029ad59e283ce79b0daf09ec8fa69d7b795"
-    sha256 cellar: :any, ventura: "f413c3a2dc8f2df64ff41c8dc86299e53c722e4593ea92385143664e76dc5e33"
-  end
 
   depends_on "abseil"
   depends_on "cmake"

--- a/Formula/gz-gui8.rb
+++ b/Formula/gz-gui8.rb
@@ -4,15 +4,9 @@ class GzGui8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-8.4.0.tar.bz2"
   sha256 "1731b01a134afb11b1b3e049fc65e74fa7b5c50532406d3d68366d54016d5498"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "23ad8222f1b7c209298077ef76ba6cf89196f3f2fe79b0def3b6fd75b14544f6"
-    sha256 ventura: "53ee3d31dd4ceaac4094ac28a14a509e12a051479623b8d21d7f9595295e1b16"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-gui9.rb
+++ b/Formula/gz-gui9.rb
@@ -4,15 +4,9 @@ class GzGui9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-9.0.1.tar.bz2"
   sha256 "873d9950b1aa577b5b7f864caa4c3f759e29d5b67b81c4d69ab7d37043c4f96d"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "6cd4a2cf86dfd39dcfbd7e40dd14bd453260d43768956a64b40adce663cbc9de"
-    sha256 ventura: "f86ef2d2cb36b13f5291aad91bce589039af986babe997a6e7a81394848d4b47"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-launch7.rb
+++ b/Formula/gz-launch7.rb
@@ -4,15 +4,9 @@ class GzLaunch7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-7.1.1.tar.bz2"
   sha256 "e29f8b4663474cfed1364c45afa3aee8b44d816ffe1679c26c699f7c805cdffd"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "0f3fa069d9536aef45be3e56c7f0601268ba43fca533430ea14dc7c53890f879"
-    sha256 ventura: "8b4d35ee0f16c438cdedf497b78747f29e3236ff591b5807c90eb4eea40abea6"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build

--- a/Formula/gz-launch8.rb
+++ b/Formula/gz-launch8.rb
@@ -4,15 +4,9 @@ class GzLaunch8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-8.0.1.tar.bz2"
   sha256 "ce89cfe1554bf64ea63bbbcd7ce9624dd488a72a688cd620f97cabab776245a7"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "0a946804893e2a197bb5dde61d23685f1ff43471e2ae265a61725dc7896aac22"
-    sha256 ventura: "4ad6911fd55a9ded207768d543057be1f10b4a64e4d16cffcacc97a93021ca3c"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build

--- a/Formula/gz-physics7.rb
+++ b/Formula/gz-physics7.rb
@@ -4,15 +4,9 @@ class GzPhysics7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-7.5.0.tar.bz2"
   sha256 "3c44365182f8d43ae54c7b8cec65b80daab95defb8057dbd7da6e0c1fc44dbf6"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "b9ade6c4b90392a17b3e2b557d103e4def7969605d73877a035f818d587ac142"
-    sha256 ventura: "64e3398c042ba95a5cc29dcc5118286a1bedcb84a97110a53b073202de9b330d"
-  end
 
   depends_on "cmake" => [:build, :test]
 

--- a/Formula/gz-physics8.rb
+++ b/Formula/gz-physics8.rb
@@ -4,15 +4,9 @@ class GzPhysics8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-8.1.0.tar.bz2"
   sha256 "4dc187a27b5c2b34a22ff911ae770a551a49468ca53bdd24316f57e6e18e6490"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "1967f733587729852a3d96ff661c353d6054668109220ebc9bde6425ebd499eb"
-    sha256 ventura: "e8ff13b93fefab8664886f2a2d0cfaf9333de2ee817a3e504d32ab7724805953"
-  end
 
   depends_on "cmake" => [:build, :test]
 

--- a/Formula/gz-rendering8.rb
+++ b/Formula/gz-rendering8.rb
@@ -4,15 +4,9 @@ class GzRendering8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-rendering/releases/gz-rendering-8.2.2.tar.bz2"
   sha256 "5029db79e098ca23b95bf186c046f8996a7b0f4490e2f9e95da7aaa8eb37d130"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "e6b5978c7557be90e00b2165828b80d26d7f64cceeef58843d1b4cddae33005f"
-    sha256 ventura: "ebaaf5702d914159a566134efcf98425013cedc07a3826561aba8ae42aa6eb3c"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-rendering9.rb
+++ b/Formula/gz-rendering9.rb
@@ -4,15 +4,9 @@ class GzRendering9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-rendering/releases/gz-rendering-9.1.0.tar.bz2"
   sha256 "bf0542abbc6f30ca9f2889f4a16ceb7255327d440f545e83fa229f92cbbc5ea8"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "fbaaa15af7c61c29a59b1fe8046d97a8c2ec0749b5099fdb76be57e2778215de"
-    sha256 ventura: "cf2f1882b41275a90f9817cbe6938055c87965b117103e029dc3bab6bdb20a11"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-sensors8.rb
+++ b/Formula/gz-sensors8.rb
@@ -4,15 +4,9 @@ class GzSensors8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-8.2.2.tar.bz2"
   sha256 "9ddc16d5cab0a86f27771732f5cfcfde1efe7611f27da61176ea122273806c42"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "d0dcd7e7161c065be00891c2ae97436c1bb680d7650df19512fbd2a70bf5e34a"
-    sha256 cellar: :any, ventura: "bc612d39335d0634e61782a3aea46a7cc0cc85e8ee05a6f1b18cd5871a92ca96"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-sensors9.rb
+++ b/Formula/gz-sensors9.rb
@@ -4,15 +4,9 @@ class GzSensors9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-9.1.0.tar.bz2"
   sha256 "3d1aaf20fd987efc1fc29f343cc42c96e07f57e060849c779b22bb32724ded35"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "fd4319e1b80be5bac5389a2687250816852d6ba15e0b81aeabc79181e01c7f71"
-    sha256 cellar: :any, ventura: "2c79af383af5d8afa55532db166bbfa9a9867668e661748ea04fb4d085e008fe"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-sim8.rb
+++ b/Formula/gz-sim8.rb
@@ -4,15 +4,9 @@ class GzSim8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-8.9.0.tar.bz2"
   sha256 "c55aa45a4f12ddad7115455722afd2fe9bb7fef7cc3fa119a2a24ea77e58dedf"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "3af8567c85e71754863ed673a814ed36b1c504b0e85db99ade566be5c7939db8"
-    sha256 ventura: "c398d2842c6dbd81ea718e8b9557e35c2dc12b387ad31d024a1383bc90b5c817"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build

--- a/Formula/gz-sim9.rb
+++ b/Formula/gz-sim9.rb
@@ -4,15 +4,9 @@ class GzSim9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-9.1.0.tar.bz2"
   sha256 "7866afccfae26d345d696f22d9b9952f821d2e9f7418be2616b2bcc99bbfdea9"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "cf318f8b9fa7f072b239e9669c394a35b18dbbd2851b5d94df40a1417440d51c"
-    sha256 ventura: "24211355a038befd0f291d241f2b60a51101e2066c852f6ab436ff38911f5d20"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build


### PR DESCRIPTION
Part of #3038.

Implemented with:

~~~
for m in gz-common5 gz-common6
do
    brew bump-revision --remove-bottle-block --message="broken bottle" $m
    for f in $(.github/ci/bottled_dependents.sh $m)
    do
        brew bump-revision --remove-bottle-block --message="broken bottle" $f
    done
done
~~~