### PR TITLE
ignition-transport8: add deprecation date

### DIFF
--- a/Formula/ignition-transport8.rb
+++ b/Formula/ignition-transport8.rb
@@ -8,6 +8,8 @@ class IgnitionTransport8 < Formula
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport8"
 
+  deprecate! date: "2025-01-31", because: "is past end-of-life date"
+
   depends_on "doxygen" => [:build, :optional]
 
   depends_on "cmake"


### PR DESCRIPTION
Part of gazebo-tooling/release-tools#1252. This was accidentally missed in #2950.