### PR TITLE
ogre2.1: add deprecation date

### DIFF
--- a/Formula/ogre2.1.rb
+++ b/Formula/ogre2.1.rb
@@ -20,6 +20,8 @@ class Ogre21 < Formula
     sha256 cellar: :any, mojave:   "f0b505985d282e7dd8b1aecc7daf51ff15c8fbb58b4b30c556fbc139ec878075"
   end
 
+  deprecate! date: "2024-12-31", because: "is past end-of-life date"
+
   depends_on "cmake" => :build
   depends_on "pkgconf" => :test
 


### PR DESCRIPTION
Part of gazebo-tooling/release-tools#1252. Follow-up to #2950.