### PR TITLE
Remove supported broken bottles by the urfdom5 release

### DIFF
--- a/Formula/gz-launch7.rb
+++ b/Formula/gz-launch7.rb
@@ -4,15 +4,9 @@ class GzLaunch7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-7.1.1.tar.bz2"
   sha256 "e29f8b4663474cfed1364c45afa3aee8b44d816ffe1679c26c699f7c805cdffd"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "43274b4e2c69d1042351a744b9ab460c32743ccfb0c32d0dd89deee7fc54ba70"
-    sha256 ventura: "6f5dca228be92475eb03427709e9c55448eeeb3ccb73dd9ec1074c16efef00af"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build

--- a/Formula/gz-launch8.rb
+++ b/Formula/gz-launch8.rb
@@ -4,15 +4,9 @@ class GzLaunch8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-8.0.1.tar.bz2"
   sha256 "ce89cfe1554bf64ea63bbbcd7ce9624dd488a72a688cd620f97cabab776245a7"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "6e3951ab477ab442b972003d4501cc2c6d1da3a22819f4b7eac5a2ab76259f28"
-    sha256 ventura: "cf95cf13720b7db899d138339adec2289be0cbfb28992b8272a1dd088dbf9c7f"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build

--- a/Formula/gz-physics7.rb
+++ b/Formula/gz-physics7.rb
@@ -4,15 +4,9 @@ class GzPhysics7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-7.5.0.tar.bz2"
   sha256 "3c44365182f8d43ae54c7b8cec65b80daab95defb8057dbd7da6e0c1fc44dbf6"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "611599d72af9aa2ba1402c5280479affddff36f26b77ec4007e0acd555c6f499"
-    sha256 ventura: "82c58fe632de94bfc91bc9ef8494eb1c58a48fc39605294b67f5971695b100f5"
-  end
 
   depends_on "cmake" => [:build, :test]
 

--- a/Formula/gz-physics8.rb
+++ b/Formula/gz-physics8.rb
@@ -4,14 +4,9 @@ class GzPhysics8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-8.2.0.tar.bz2"
   sha256 "309739fc5c9f5c6fd3e2408184ceb916297f3b506f8b4a0cb4475f261add7ebd"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "2e3cb5c1dcf7992783e37514769cfef7d613b5f6be7ec43de3cb44b66739e6ff"
-    sha256 ventura: "4232c3dbf802a0d1a910a57f9ae65c5e72cc20e61c2365616f53fe460488b5ab"
-  end
 
   depends_on "cmake" => [:build, :test]
 

--- a/Formula/gz-sensors8.rb
+++ b/Formula/gz-sensors8.rb
@@ -4,15 +4,9 @@ class GzSensors8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-8.2.2.tar.bz2"
   sha256 "9ddc16d5cab0a86f27771732f5cfcfde1efe7611f27da61176ea122273806c42"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "786d47b4c30e66984383afecc2b32fc2b7b906bef5ada015c30ebd8c13b2a118"
-    sha256 cellar: :any, ventura: "1b73cd85cc6e4931991de4fdacd097e365cba9071a985361d4e2ede44dc9f26f"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-sensors9.rb
+++ b/Formula/gz-sensors9.rb
@@ -4,14 +4,9 @@ class GzSensors9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-9.2.0.tar.bz2"
   sha256 "af2ec9a453a830338e80e94954160030e81b3ff8f60853e7c5730cdd2950be85"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "2634c5f9cf86fe34d9a248d22dbcc5bbc816c6aab3ce4d099cb63e40912de04a"
-    sha256 cellar: :any, ventura: "60b7147f0e312b60bb96999057be2edd49f2122d98229afb253446092ca80f7d"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-sim8.rb
+++ b/Formula/gz-sim8.rb
@@ -4,15 +4,9 @@ class GzSim8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-8.9.0.tar.bz2"
   sha256 "c55aa45a4f12ddad7115455722afd2fe9bb7fef7cc3fa119a2a24ea77e58dedf"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "71bdcb04aba0c9f19928c0044a7905ee8be64ec3052ffaaf1cc159dab27f85f6"
-    sha256 ventura: "eee69e6dc7799cdf4e554241c60556417e4ff720e586f07264999d742a1732f3"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build

--- a/Formula/gz-sim9.rb
+++ b/Formula/gz-sim9.rb
@@ -4,14 +4,9 @@ class GzSim9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-9.2.0.tar.bz2"
   sha256 "31ffa9b70e717adf0219122ec9ff70482995038c280a01faf4341a5f6f014dc7"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "dc49612a4ba61dc1c7983c4589b0d031031ebda2f8d1641c014b64ead26e8aba"
-    sha256 ventura: "75d6f1663613b015292057290760628d87a0efde8a3c5aacf957c24507d986bc"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -4,15 +4,9 @@ class IgnitionGazebo6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/ignition-gazebo-6.17.0.tar.bz2"
   sha256 "3a51ba77e5cbbc3d0b6b3dd44d66bfd3076bed228c8c9face9678f1bd7a51ced"
   license "Apache-2.0"
-  revision 6
+  revision 7
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "146b6454c19eb0ef8402d757d9c73f511bb3e6b50556b53f3c68d0cce41fb91d"
-    sha256 ventura: "244d6e700470fef66d0eb4f0bebce037817a599b18a0e571ccb814009855d319"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build

--- a/Formula/ignition-launch5.rb
+++ b/Formula/ignition-launch5.rb
@@ -4,15 +4,9 @@ class IgnitionLaunch5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-launch/releases/ignition-launch5-5.3.0.tar.bz2"
   sha256 "84d356b9c85609da1bb7feda2f90ae6d1a1fd2d6713b284799d5605de42e2613"
   license "Apache-2.0"
-  revision 54
+  revision 55
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "ign-launch5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "fdf37d79cb861fb7dbfcc34c1c77575d8f54e9b395f6f2f8c6183b6df6106e66"
-    sha256 ventura: "35d0e637444e425865ec4280cf38bd5f12e7cc480c1d4f58cd1ff6e54b7151a9"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build

--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -4,15 +4,9 @@ class IgnitionPhysics5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-physics/releases/ignition-physics5-5.3.2.tar.bz2"
   sha256 "4262512fbb6952712234c5cbeed69cdabca338931bb6c587a1ef7d487a5f262b"
   license "Apache-2.0"
-  revision 22
+  revision 23
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "ign-physics5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "8aa820099f28a1d02705b2d0a15f472a5f42c309e1eaf10f7607c48d932484c9"
-    sha256 cellar: :any, ventura: "f450b7c7eb89a9621aeb6d723a27fc2e22bbcb3e73abaf6a8d6ff63a00ef8207"
-  end
 
   depends_on "cmake" => :build
 

--- a/Formula/ignition-sensors6.rb
+++ b/Formula/ignition-sensors6.rb
@@ -4,15 +4,9 @@ class IgnitionSensors6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/ignition-sensors-6.8.1.tar.bz2"
   sha256 "abc96be3bd018cae94c83981d173af0f67ce2980ef7a1374b34bd5b63f9a7235"
   license "Apache-2.0"
-  revision 16
+  revision 17
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "a178968b28c4857e4b908e192acd1d6263d005540423b9ea9c4efba66a6c2441"
-    sha256 cellar: :any, ventura: "dc52ded5db87890a97d6369ccfe6360537d362669382266c0969cc8b945e87a0"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/sdformat12.rb
+++ b/Formula/sdformat12.rb
@@ -4,15 +4,9 @@ class Sdformat12 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-12.8.0.tar.bz2"
   sha256 "5c0d6579738ff14f849f8d6e101468a8f0abc43000b2b8040170fe082a630489"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   head "https://github.com/gazebosim/sdformat.git", branch: "sdf12"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "41ab8e4734c3fa71a74ce5fc520318391b8dc6a01be324fb8928f07d52e44496"
-    sha256 ventura: "3890c7c8941c57a3d4e3a68fabc75c624be9f9e36fdc9633c21ffc4038759fc5"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/sdformat14.rb
+++ b/Formula/sdformat14.rb
@@ -4,15 +4,9 @@ class Sdformat14 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-14.7.0.tar.bz2"
   sha256 "1ce4d8fe1de6223940a09005cda5b04c1064dd6c622d58dfa6fbc73da0311fa4"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   head "https://github.com/gazebosim/sdformat.git", branch: "main"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "f9b7ae01fe6141e4324bac6cdad52b4c3de9525a58b64e1c92a76b606d9d8ccb"
-    sha256 ventura: "381a5e61a69323f33445279b83811e07056a1a287cfb665aec61a842af1f13c2"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/sdformat15.rb
+++ b/Formula/sdformat15.rb
@@ -4,15 +4,9 @@ class Sdformat15 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-15.3.0.tar.bz2"
   sha256 "4855c95dcc53652e564f1c71d47d7e7ee73218efd8a99f2fa98207d175ee7c61"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/sdformat.git", branch: "sdf15"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "642eb6ea1a7eb99e705169366cacac94d8ca80c4876b9779589728808bebfefd"
-    sha256 ventura: "c81e9d2f4a39bc187b85efe9bec0e9abd16079166247829bc47d4e3c3da4b75c"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]


### PR DESCRIPTION
Part of 3078. I've included what I think are the formulas corresponding to our support distributions.

I've used https://github.com/gazebo-tooling/gazebodistro/pull/208/files to generate the list of packages, mostly doing:
```bash
> cd /home/jrivero/code/gazebodistro && python3 tools/get_package_version.py \
   --collection-files collection-fortress.yaml collection-harmonic.yaml collection-ionic.yaml collection-jetty.yaml \
   --libs sdformat gz-sim gz-sensors gz-launch sdformat gz-physics
# Output
 gz-launch7 gz-launch8 gz-launch9 gz-physics7 gz-physics8 gz-sensors10 gz-sensors8 gz-sensors9 gz-sim10 gz-sim8 gz-sim9 ignition-gazebo6 ignition-launch5 ignition-physics5 ignition-sensors6 sdformat12 sdformat14 sdformat15
```

There were some warnings about some Formulas that does not have a bottle block probably coming from Jetty.