### PR TITLE
Remove bottles broken by pybind11

### DIFF
--- a/Formula/gz-common5.rb
+++ b/Formula/gz-common5.rb
@@ -4,15 +4,9 @@ class GzCommon5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-common/releases/gz-common-5.7.1.tar.bz2"
   sha256 "802a0a95bf52e10ec02b7531db1d577e2f477e5d326f0998f0b6ba323eb0396b"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-common.git", branch: "gz-common5"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "4764b8025492a411f82344f5ea390742fa8eb9015fe9a0f33a5f4ee97f826129"
-    sha256 cellar: :any, ventura: "7cebff2b0a1ab203c481c1d87265568ebd25094dd43d5a0d825c37dc3c461c8c"
-  end
 
   depends_on "assimp"
   depends_on "cmake"

--- a/Formula/gz-common6.rb
+++ b/Formula/gz-common6.rb
@@ -4,15 +4,9 @@ class GzCommon6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-common/releases/gz-common-6.1.0.tar.bz2"
   sha256 "e79eacbce58f6d0bc5d34f58ed363c44cf89f61562b0a7d4ea1b586441e10b65"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-common.git", branch: "gz-common6"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "beccbb8adabaf27a197ba2ed19c05e083c2a3f41c53b0a5bde5dce6074f440fc"
-    sha256 cellar: :any, ventura: "635e1dd347148ce267f52fc2d9cb20cebd0a68ed6dcf1ff0a4985ca272c6ddaf"
-  end
 
   depends_on "assimp"
   depends_on "cmake"

--- a/Formula/gz-fuel-tools10.rb
+++ b/Formula/gz-fuel-tools10.rb
@@ -4,15 +4,9 @@ class GzFuelTools10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-10.1.0.tar.bz2"
   sha256 "37ae351be9a9b281d078e36068422dd096f59f46c72c4ef490800dfeb7653e1d"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools10"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "8798ada00c0ced964100232bcfd6bf921533a7355193d6837964a9381b10169e"
-    sha256 cellar: :any, ventura: "2b04625f82bb8272c9b3ef4e4493a07be3fda32ff923232183307c7c3be7e02a"
-  end
 
   depends_on "abseil"
   depends_on "cmake"

--- a/Formula/gz-fuel-tools9.rb
+++ b/Formula/gz-fuel-tools9.rb
@@ -4,15 +4,9 @@ class GzFuelTools9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-9.1.1.tar.bz2"
   sha256 "3189166d4b0078c0b9d98de178e5496a1cc28b88fbd1124603376181b5a053f5"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "949bfb1bec170fa064f9de6e2c858d8d6eec338cbb6c2a3bab5c1e90a08e7dc9"
-    sha256 cellar: :any, ventura: "349035968d33baed2f7afbea60ef51c84b05220a67a3c91b7178ab2d16530012"
-  end
 
   depends_on "abseil"
   depends_on "cmake"

--- a/Formula/gz-gui8.rb
+++ b/Formula/gz-gui8.rb
@@ -4,15 +4,9 @@ class GzGui8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-8.4.0.tar.bz2"
   sha256 "1731b01a134afb11b1b3e049fc65e74fa7b5c50532406d3d68366d54016d5498"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "b7efa242f740fddec888e22cee656fe9370496ed4cee3c80ee722cfa01259a0a"
-    sha256 ventura: "35abcb9c77f3eb86222c7168da5facf6d071823f6c5cd1573a8d919c3595e946"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-gui9.rb
+++ b/Formula/gz-gui9.rb
@@ -4,15 +4,9 @@ class GzGui9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-9.0.1.tar.bz2"
   sha256 "873d9950b1aa577b5b7f864caa4c3f759e29d5b67b81c4d69ab7d37043c4f96d"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "3c351a1bc5d526f7d32e69ed158feaa3e457719c188929db118a39491e044c46"
-    sha256 ventura: "9855a7db58b93c6e5967dc25ef58954cdb9e2b015cd20e5f2aa486df77b6de75"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-math7.rb
+++ b/Formula/gz-math7.rb
@@ -4,14 +4,9 @@ class GzMath7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-math/releases/gz-math-7.5.2.tar.bz2"
   sha256 "2451435f601f1adc8fdb3580e3b55bba951822dd85dcddcc8bae4fe132587803"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-math.git", branch: "gz-math7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "0fa6e82a5357dc759b6a04f945ef33131cc1362570fc852d3de50292dac50877"
-    sha256 cellar: :any, ventura: "627e2fd4005571a016896ad36953613006b8f00c96bb16254e97a0123c9f88bc"
-  end
 
   depends_on "cmake" => :build
   depends_on "doxygen" => :build

--- a/Formula/gz-math8.rb
+++ b/Formula/gz-math8.rb
@@ -4,14 +4,9 @@ class GzMath8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-math/releases/gz-math-8.2.0.tar.bz2"
   sha256 "2275a93f10dc95acebcdcb2678757f0daf64bca02ddb086ca372f2bdd5580b4e"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-math.git", branch: "gz-math8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, sonoma:  "df7090eddeb24f798a4be62af4be546eda1e3aa4bef59d034f8572a85956933e"
-    sha256 cellar: :any, ventura: "ab75242370e68f55408ceea1cda7c1f4ba2d775091775b5658beeb09ca3b9a26"
-  end
 
   depends_on "cmake" => :build
   depends_on "doxygen" => :build

--- a/Formula/gz-msgs10.rb
+++ b/Formula/gz-msgs10.rb
@@ -4,15 +4,9 @@ class GzMsgs10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/gz-msgs-10.3.2.tar.bz2"
   sha256 "0dd9c19dee7aec7fc0f7bdd03ee2ae44ab1068dac2fc1ae8cc3ecc1b6df8472a"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs10"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "ca8e2bfae4016bfb77b239fce87607582feb040d6f8160786cd10c67def6ec3a"
-    sha256 ventura: "2de77377228625f8c4e8e11c03da770f276918a040fa2af0d7c07fa1c3d49ada"
-  end
 
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]

--- a/Formula/gz-msgs11.rb
+++ b/Formula/gz-msgs11.rb
@@ -4,15 +4,9 @@ class GzMsgs11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/gz-msgs-11.1.0.tar.bz2"
   sha256 "2343f0975d00fb21dd87de15603161981c920e0e4b33e735863a259f488f36d0"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs11"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "828e0981c1a3ce8a8f4dbe9950963f4b438f6f89aaa2159884144b76484132bb"
-    sha256 ventura: "1d5cd76380c43227445afdbb3e125a877dc51d6e22bffadff8d416d18c1a1243"
-  end
 
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]

--- a/Formula/gz-rendering8.rb
+++ b/Formula/gz-rendering8.rb
@@ -4,15 +4,9 @@ class GzRendering8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-rendering/releases/gz-rendering-8.2.2.tar.bz2"
   sha256 "5029db79e098ca23b95bf186c046f8996a7b0f4490e2f9e95da7aaa8eb37d130"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "2925f393af42d6d4a09b934e4717a1e00e8b0ea1ea77ad59079c1de151bc34f6"
-    sha256 ventura: "79e718943b488fdbb42c2c28f3ae6f3dc5ebf9b87ccf463673b277e4690e6fd4"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-rendering9.rb
+++ b/Formula/gz-rendering9.rb
@@ -4,15 +4,9 @@ class GzRendering9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-rendering/releases/gz-rendering-9.2.0.tar.bz2"
   sha256 "3f2f28ea5188aa2c7794cd0d3726ebbcf9e443faad7003886a92f862eb51b3da"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "2bc2afa1fa13a6148f6079ac51dc0d399c026f3cdc7b50fef6cd502fb0905bc1"
-    sha256 ventura: "9dc4dd71283c072f9aeab29d9e4499be3c2150670d15b58c590b9c9dbcb6f30c"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-transport13.rb
+++ b/Formula/gz-transport13.rb
@@ -4,15 +4,9 @@ class GzTransport13 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/gz-transport-13.4.1.tar.bz2"
   sha256 "1e7051de16c8e0cadf5b357d32193ffdb3eb33775126d1f89bef29bfd02e11b8"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport13"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "98176964f425055e50c9ce1d94f09d398de59baaa680831c8b62adaba4c1586f"
-    sha256 ventura: "05a84c9c71d0cfd1a1fd545cdb942f21a92bdd164b9065dc0f7008e50f71bf8d"
-  end
 
   depends_on "doxygen" => [:build, :optional]
   depends_on "pybind11" => :build

--- a/Formula/gz-transport14.rb
+++ b/Formula/gz-transport14.rb
@@ -4,14 +4,9 @@ class GzTransport14 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/gz-transport-14.1.0.tar.bz2"
   sha256 "9731f850ea060edecd399c3d8566a4bf998d85ee64fae236db09a542738ed18d"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport14"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "3e4857437a2b9f98dd23709fc5b531397440c76de7a0925f892a023bc3c4670d"
-    sha256 ventura: "72400526d197e6ad42baeb5d8d3482f7458d3c58d437bdd8ca8927f79975a574"
-  end
 
   depends_on "doxygen" => [:build, :optional]
   depends_on "pybind11" => :build

--- a/Formula/sdformat14.rb
+++ b/Formula/sdformat14.rb
@@ -105,7 +105,8 @@ class Sdformat14 < Formula
     system cmd_not_grep_xcode
     # check python import
     pythons.each do |python|
-      system python.opt_libexec/"bin/python", "-c", "import sdformat14"
+      system python.opt_libexec/"bin/python", "-c",
+        "import sdformat14; sdformat14.Box().size()"
     end
   end
 end

--- a/Formula/sdformat14.rb
+++ b/Formula/sdformat14.rb
@@ -4,14 +4,9 @@ class Sdformat14 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-14.8.0.tar.bz2"
   sha256 "47272ae4fba00b094da1f5eed32a3adb7417da14dfeaf9b1af758e52829ad75b"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/sdformat.git", branch: "main"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 sonoma:  "66f4cb7ca5064edfee2f037c74610422657b0d75f9224fcc2efca94b02fdf511"
-    sha256 ventura: "c2e4f549cc5be1c074e154edb42ba8e1d3a3c23b77b27923ebe91887a3d39169"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/sdformat15.rb
+++ b/Formula/sdformat15.rb
@@ -105,7 +105,8 @@ class Sdformat15 < Formula
     system cmd_not_grep_xcode
     # check python import
     pythons.each do |python|
-      system python.opt_libexec/"bin/python", "-c", "import sdformat15"
+      system python.opt_libexec/"bin/python", "-c",
+        "import sdformat15; sdformat15.Box().size()"
     end
   end
 end

--- a/Formula/sdformat16.rb
+++ b/Formula/sdformat16.rb
@@ -104,7 +104,8 @@ class Sdformat16 < Formula
     system cmd_not_grep_xcode
     # check python import
     pythons.each do |python|
-      system python.opt_libexec/"bin/python", "-c", "import sdformat"
+      system python.opt_libexec/"bin/python", "-c",
+        "import sdformat; sdformat.Box().size()"
     end
   end
 end


### PR DESCRIPTION
I noticed some python tests failing in sdformat:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci-sdf15-homebrew-amd64&build=102)](https://build.osrfoundation.org/job/sdformat-ci-sdf15-homebrew-amd64/102/) https://build.osrfoundation.org/job/sdformat-ci-sdf15-homebrew-amd64/102/testReport/

I believe this was caused by the upgrade to pybind11 3.0 in https://github.com/Homebrew/homebrew-core/pull/229675.

I've updated the sdformat tests in https://github.com/osrf/homebrew-simulation/commit/c04896739a786fab541b6cd3695c005292497f88 to call an API that returns a math type, which reproduces the test failures seen in the CI job linked above. I've also removed the broken gz-math7 and gz-math8 bottles and any downstream bottles.