### PR TITLE
gz-gui9: patch for protobuf 30

### DIFF
--- a/Formula/gz-gui9.rb
+++ b/Formula/gz-gui9.rb
@@ -8,6 +8,12 @@ class GzGui9 < Formula
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 sonoma:  "389e4ba5206eba1f657b225c40e988192835d7a5bcb4881972bbea86e3b2cc74"
+    sha256 ventura: "56287ad736b5128798ea63306d1dedb3131fe585ead1c98077bacfc43eeaeee7"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
   depends_on "abseil"

--- a/Formula/gz-gui9.rb
+++ b/Formula/gz-gui9.rb
@@ -4,7 +4,7 @@ class GzGui9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-9.0.1.tar.bz2"
   sha256 "873d9950b1aa577b5b7f864caa4c3f759e29d5b67b81c4d69ab7d37043c4f96d"
   license "Apache-2.0"
-  revision 11
+  revision 12
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui9"
 
@@ -23,6 +23,12 @@ class GzGui9 < Formula
   depends_on "protobuf"
   depends_on "qt@5"
   depends_on "tinyxml2"
+
+  patch do
+    # Fix for compatibility with protobuf 30
+    url "https://github.com/gazebosim/gz-gui/commit/e1eb227411f605577c4eb6de2f4df627d72d1ade.patch?full_index=1"
+    sha256 "6134cf08e128909430e2a0ed1e09c1092fe13b9ec9a345d2a24fed7eeee00e52"
+  end
 
   def install
     rpaths = [


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/3094, applies patch from https://github.com/gazebosim/gz-gui/pull/677 / https://github.com/gazebosim/gz-gui/commit/e1eb227411f605577c4eb6de2f4df627d72d1ade.