### PR TITLE
gz-cmake5: Use stable branch in url

### DIFF
--- a/Formula/gz-cmake5.rb
+++ b/Formula/gz-cmake5.rb
@@ -1,7 +1,7 @@
 class GzCmake5 < Formula
   desc "CMake helper functions for building robotic applications"
   homepage "https://gazebosim.org"
-  url "https://github.com/gazebosim/gz-cmake.git", branch: "main"
+  url "https://github.com/gazebosim/gz-cmake.git", branch: "gz-cmake5"
   version "4.999.999-0-20250424"
   license "Apache-2.0"
 


### PR DESCRIPTION
Part of https://github.com/gazebosim/gz-jetty/issues/19