### PR TITLE
gz-physics9: use stable branch in url

### DIFF
--- a/Formula/gz-physics9.rb
+++ b/Formula/gz-physics9.rb
@@ -1,7 +1,7 @@
 class GzPhysics9 < Formula
   desc "Physics library for robotics applications"
   homepage "https://github.com/gazebosim/gz-physics"
-  url "https://github.com/gazebosim/gz-physics.git", branch: "main"
+  url "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics9"
   version "8.999.999-0-20250501"
   license "Apache-2.0"
 


### PR DESCRIPTION
Part of https://github.com/gazebosim/gz-jetty/issues/29.