### PR TITLE
Deprecate old versioned formulae on 2025-09-30

### DIFF
--- a/Formula/boost@1.85.0.rb
+++ b/Formula/boost@1.85.0.rb
@@ -13,6 +13,8 @@ class BoostAT1850 < Formula
 
   keg_only :versioned_formula
 
+  deprecate! date: "2025-09-30", because: "not used by supported package"
+
   depends_on "icu4c@76"
   depends_on "xz"
   depends_on "zstd"

--- a/Formula/bullet@2.87.rb
+++ b/Formula/bullet@2.87.rb
@@ -14,6 +14,8 @@ class BulletAT287 < Formula
   deprecated_option "build-demo" => "with-demo"
   deprecated_option "double-precision" => "with-double-precision"
 
+  deprecate! date: "2025-09-30", because: "not used by supported package"
+
   depends_on "cmake" => :build
 
   def install

--- a/Formula/ogre1.9-with-boost1.85.rb
+++ b/Formula/ogre1.9-with-boost1.85.rb
@@ -18,6 +18,8 @@ class Ogre19WithBoost185 < Formula
 
   option "with-cg"
 
+  deprecate! date: "2025-09-30", because: "not used by supported package"
+
   depends_on "cmake" => :build
   depends_on "boost@1.85.0"
   depends_on "doxygen"

--- a/Formula/tinyxml1.rb
+++ b/Formula/tinyxml1.rb
@@ -12,6 +12,8 @@ class Tinyxml1 < Formula
     sha256 cellar: :any, monterey: "99460c19db8e2b1e8512362b4bf504e62f5f9449e6fa8d8b4abdefdb89ca5db3"
   end
 
+  deprecate! date: "2025-09-30", because: "not used by supported package"
+
   depends_on "cmake" => :build
 
   conflicts_with "tinyxml", because: "differing version of same formula"


### PR DESCRIPTION
These formulae are not used by any currently supported formulae, so deprecate them in a little over 1 month.