### PR TITLE
gz-launch9: use stable branch in url

### DIFF
--- a/Formula/gz-launch9.rb
+++ b/Formula/gz-launch9.rb
@@ -1,7 +1,7 @@
 class GzLaunch9 < Formula
   desc "Launch libraries for robotics applications"
   homepage "https://github.com/gazebosim/gz-launch"
-  url "https://github.com/gazebosim/gz-launch.git", branch: "main"
+  url "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch9"
   version "8.999.999-0-20250516"
   license "Apache-2.0"
 


### PR DESCRIPTION
Part of https://github.com/gazebosim/gz-jetty/issues/18