### PR TITLE
gz-sim10: Use stable branch in the url

### DIFF
--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -1,7 +1,7 @@
 class GzSim10 < Formula
   desc "Gazebo Sim robot simulator"
   homepage "https://github.com/gazebosim/gz-sim"
-  url "https://github.com/gazebosim/gz-sim.git", branch: "main"
+  url "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim10"
   version "9.999.999-0-20250516"
   license "Apache-2.0"
 


### PR DESCRIPTION
Part of https://github.com/gazebosim/gz-jetty/issues/33

Note @scpeters : I accidentally pushed to master and reverted.