### PR TITLE
Remove depends_on macos statements

### DIFF
--- a/Formula/gz-common5.rb
+++ b/Formula/gz-common5.rb
@@ -24,7 +24,6 @@ class GzCommon5 < Formula
   depends_on "gz-cmake3"
   depends_on "gz-math7"
   depends_on "gz-utils2"
-  depends_on macos: :high_sierra # c++17
   depends_on "ossp-uuid"
   depends_on "pkgconf"
   depends_on "tinyxml2"

--- a/Formula/gz-common6.rb
+++ b/Formula/gz-common6.rb
@@ -23,7 +23,6 @@ class GzCommon6 < Formula
   depends_on "gz-cmake4"
   depends_on "gz-math8"
   depends_on "gz-utils3"
-  depends_on macos: :high_sierra # c++17
   depends_on "ossp-uuid"
   depends_on "pkgconf"
   depends_on "spdlog"

--- a/Formula/gz-common7.rb
+++ b/Formula/gz-common7.rb
@@ -15,7 +15,6 @@ class GzCommon7 < Formula
   depends_on "gz-cmake5"
   depends_on "gz-math9"
   depends_on "gz-utils4"
-  depends_on macos: :high_sierra # c++17
   depends_on "ossp-uuid"
   depends_on "pkgconf"
   depends_on "spdlog"

--- a/Formula/gz-fuel-tools10.rb
+++ b/Formula/gz-fuel-tools10.rb
@@ -18,7 +18,6 @@ class GzFuelTools10 < Formula
   depends_on "jsoncpp"
   depends_on "libyaml"
   depends_on "libzip"
-  depends_on macos: :high_sierra # c++17
   depends_on "pkgconf"
   depends_on "protobuf"
   depends_on "tinyxml2"

--- a/Formula/gz-fuel-tools11.rb
+++ b/Formula/gz-fuel-tools11.rb
@@ -17,7 +17,6 @@ class GzFuelTools11 < Formula
   depends_on "jsoncpp"
   depends_on "libyaml"
   depends_on "libzip"
-  depends_on macos: :high_sierra # c++17
   depends_on "pkgconf"
   depends_on "protobuf"
   depends_on "tinyxml2"

--- a/Formula/gz-fuel-tools8.rb
+++ b/Formula/gz-fuel-tools8.rb
@@ -28,7 +28,6 @@ class GzFuelTools8 < Formula
   depends_on "jsoncpp"
   depends_on "libyaml"
   depends_on "libzip"
-  depends_on macos: :high_sierra # c++17
   depends_on "pkgconf"
   depends_on "protobuf"
   depends_on "tinyxml2"

--- a/Formula/gz-fuel-tools9.rb
+++ b/Formula/gz-fuel-tools9.rb
@@ -18,7 +18,6 @@ class GzFuelTools9 < Formula
   depends_on "jsoncpp"
   depends_on "libyaml"
   depends_on "libzip"
-  depends_on macos: :high_sierra # c++17
   depends_on "pkgconf"
   depends_on "protobuf"
   depends_on "tinyxml2"

--- a/Formula/gz-garden.rb
+++ b/Formula/gz-garden.rb
@@ -31,7 +31,6 @@ class GzGarden < Formula
   depends_on "gz-tools2"
   depends_on "gz-transport12"
   depends_on "gz-utils2"
-  depends_on macos: :mojave # c++17
   depends_on "pkgconf"
   depends_on "sdformat13"
 

--- a/Formula/gz-gui10.rb
+++ b/Formula/gz-gui10.rb
@@ -18,7 +18,6 @@ class GzGui10 < Formula
   depends_on "gz-rendering10"
   depends_on "gz-transport15"
   depends_on "gz-utils4"
-  depends_on macos: :mojave # c++17
   depends_on "protobuf"
   depends_on "qt@6"
   depends_on "tinyxml2"

--- a/Formula/gz-gui7.rb
+++ b/Formula/gz-gui7.rb
@@ -29,7 +29,6 @@ class GzGui7 < Formula
   depends_on "gz-rendering7"
   depends_on "gz-transport12"
   depends_on "gz-utils2"
-  depends_on macos: :mojave # c++17
   depends_on "protobuf"
   depends_on "qt@5"
   depends_on "tinyxml2"

--- a/Formula/gz-gui8.rb
+++ b/Formula/gz-gui8.rb
@@ -19,7 +19,6 @@ class GzGui8 < Formula
   depends_on "gz-rendering8"
   depends_on "gz-transport13"
   depends_on "gz-utils2"
-  depends_on macos: :mojave # c++17
   depends_on "protobuf"
   depends_on "qt@5"
   depends_on "tinyxml2"

--- a/Formula/gz-gui9.rb
+++ b/Formula/gz-gui9.rb
@@ -19,7 +19,6 @@ class GzGui9 < Formula
   depends_on "gz-rendering9"
   depends_on "gz-transport14"
   depends_on "gz-utils3"
-  depends_on macos: :mojave # c++17
   depends_on "protobuf"
   depends_on "qt@5"
   depends_on "tinyxml2"

--- a/Formula/gz-msgs10.rb
+++ b/Formula/gz-msgs10.rb
@@ -16,7 +16,6 @@ class GzMsgs10 < Formula
   depends_on "gz-math7"
   depends_on "gz-tools2"
   depends_on "gz-utils2"
-  depends_on macos: :high_sierra # c++17
   depends_on "pkgconf"
   depends_on "protobuf"
   depends_on "tinyxml2"

--- a/Formula/gz-msgs11.rb
+++ b/Formula/gz-msgs11.rb
@@ -16,7 +16,6 @@ class GzMsgs11 < Formula
   depends_on "gz-math8"
   depends_on "gz-tools2"
   depends_on "gz-utils3"
-  depends_on macos: :high_sierra # c++17
   depends_on "pkgconf"
   depends_on "protobuf"
   depends_on "tinyxml2"

--- a/Formula/gz-msgs12.rb
+++ b/Formula/gz-msgs12.rb
@@ -15,7 +15,6 @@ class GzMsgs12 < Formula
   depends_on "gz-math9"
   depends_on "gz-tools2"
   depends_on "gz-utils4"
-  depends_on macos: :high_sierra # c++17
   depends_on "pkgconf"
   depends_on "protobuf"
   depends_on "tinyxml2"

--- a/Formula/gz-msgs9.rb
+++ b/Formula/gz-msgs9.rb
@@ -18,7 +18,6 @@ class GzMsgs9 < Formula
   depends_on "gz-math7"
   depends_on "gz-tools2"
   depends_on "gz-utils2"
-  depends_on macos: :high_sierra # c++17
   depends_on "pkgconf"
   depends_on "protobuf"
   depends_on "tinyxml2"

--- a/Formula/gz-physics6.rb
+++ b/Formula/gz-physics6.rb
@@ -29,7 +29,6 @@ class GzPhysics6 < Formula
   depends_on "gz-math7"
   depends_on "gz-plugin2"
   depends_on "gz-utils2"
-  depends_on macos: :mojave # c++17
   depends_on "pkgconf"
   depends_on "sdformat13"
   depends_on "tinyxml2"

--- a/Formula/gz-physics7.rb
+++ b/Formula/gz-physics7.rb
@@ -26,7 +26,6 @@ class GzPhysics7 < Formula
   depends_on "gz-math7"
   depends_on "gz-plugin2"
   depends_on "gz-utils2"
-  depends_on macos: :mojave # c++17
   depends_on "pkgconf"
   depends_on "sdformat14"
   depends_on "tinyxml2"

--- a/Formula/gz-physics8.rb
+++ b/Formula/gz-physics8.rb
@@ -25,7 +25,6 @@ class GzPhysics8 < Formula
   depends_on "gz-math8"
   depends_on "gz-plugin3"
   depends_on "gz-utils3"
-  depends_on macos: :mojave # c++17
   depends_on "pkgconf"
   depends_on "sdformat15"
   depends_on "tinyxml2"

--- a/Formula/gz-physics9.rb
+++ b/Formula/gz-physics9.rb
@@ -17,7 +17,6 @@ class GzPhysics9 < Formula
   depends_on "gz-math9"
   depends_on "gz-plugin4"
   depends_on "gz-utils4"
-  depends_on macos: :mojave # c++17
   depends_on "pkgconf"
   depends_on "sdformat16"
   depends_on "tinyxml2"

--- a/Formula/gz-plugin2.rb
+++ b/Formula/gz-plugin2.rb
@@ -18,7 +18,6 @@ class GzPlugin2 < Formula
   depends_on "gz-cmake3"
   depends_on "gz-tools2"
   depends_on "gz-utils2"
-  depends_on macos: :high_sierra # c++17
   depends_on "pkgconf"
 
   def install

--- a/Formula/gz-plugin3.rb
+++ b/Formula/gz-plugin3.rb
@@ -18,7 +18,6 @@ class GzPlugin3 < Formula
   depends_on "gz-cmake4"
   depends_on "gz-tools2"
   depends_on "gz-utils3"
-  depends_on macos: :high_sierra # c++17
   depends_on "pkgconf"
 
   def install

--- a/Formula/gz-plugin4.rb
+++ b/Formula/gz-plugin4.rb
@@ -11,7 +11,6 @@ class GzPlugin4 < Formula
   depends_on "gz-cmake5"
   depends_on "gz-tools2"
   depends_on "gz-utils4"
-  depends_on macos: :high_sierra # c++17
   depends_on "pkgconf"
 
   def install

--- a/Formula/gz-rendering10.rb
+++ b/Formula/gz-rendering10.rb
@@ -16,7 +16,6 @@ class GzRendering10 < Formula
   depends_on "gz-math9"
   depends_on "gz-plugin4"
   depends_on "gz-utils4"
-  depends_on macos: :mojave # c++17
   depends_on "ogre1.9"
   depends_on "ogre2.3"
 

--- a/Formula/gz-rendering7.rb
+++ b/Formula/gz-rendering7.rb
@@ -26,7 +26,6 @@ class GzRendering7 < Formula
   depends_on "gz-math7"
   depends_on "gz-plugin2"
   depends_on "gz-utils2"
-  depends_on macos: :mojave # c++17
   depends_on "ogre1.9"
   depends_on "ogre2.3"
 

--- a/Formula/gz-rendering8.rb
+++ b/Formula/gz-rendering8.rb
@@ -24,7 +24,6 @@ class GzRendering8 < Formula
   depends_on "gz-math7"
   depends_on "gz-plugin2"
   depends_on "gz-utils2"
-  depends_on macos: :mojave # c++17
   depends_on "ogre1.9"
   depends_on "ogre2.3"
 

--- a/Formula/gz-rendering9.rb
+++ b/Formula/gz-rendering9.rb
@@ -23,7 +23,6 @@ class GzRendering9 < Formula
   depends_on "gz-math8"
   depends_on "gz-plugin3"
   depends_on "gz-utils3"
-  depends_on macos: :mojave # c++17
   depends_on "ogre1.9"
   depends_on "ogre2.3"
 

--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -28,7 +28,6 @@ class GzSim10 < Formula
   depends_on "gz-transport15"
   depends_on "gz-utils4"
   depends_on "libwebsockets"
-  depends_on macos: :mojave # c++17
   depends_on "pkgconf"
   depends_on "protobuf"
   depends_on "qt@6"

--- a/Formula/gz-sim7.rb
+++ b/Formula/gz-sim7.rb
@@ -37,7 +37,6 @@ class GzSim7 < Formula
   depends_on "gz-tools2"
   depends_on "gz-transport12"
   depends_on "gz-utils2"
-  depends_on macos: :mojave # c++17
   depends_on "pkgconf"
   depends_on "protobuf"
   depends_on "python@3.13"

--- a/Formula/gz-sim8.rb
+++ b/Formula/gz-sim8.rb
@@ -28,7 +28,6 @@ class GzSim8 < Formula
   depends_on "gz-tools2"
   depends_on "gz-transport13"
   depends_on "gz-utils2"
-  depends_on macos: :mojave # c++17
   depends_on "pkgconf"
   depends_on "protobuf"
   depends_on "qt@5"

--- a/Formula/gz-sim9.rb
+++ b/Formula/gz-sim9.rb
@@ -28,7 +28,6 @@ class GzSim9 < Formula
   depends_on "gz-tools2"
   depends_on "gz-transport14"
   depends_on "gz-utils3"
-  depends_on macos: :mojave # c++17
   depends_on "pkgconf"
   depends_on "protobuf"
   depends_on "qt@5"

--- a/Formula/gz-transport12.rb
+++ b/Formula/gz-transport12.rb
@@ -27,7 +27,6 @@ class GzTransport12 < Formula
   depends_on "gz-msgs9"
   depends_on "gz-tools2"
   depends_on "gz-utils2"
-  depends_on macos: :mojave # c++17
   depends_on "ossp-uuid"
   depends_on "pkgconf"
   depends_on "protobuf"

--- a/Formula/gz-transport13.rb
+++ b/Formula/gz-transport13.rb
@@ -21,7 +21,6 @@ class GzTransport13 < Formula
   depends_on "gz-msgs10"
   depends_on "gz-tools2"
   depends_on "gz-utils2"
-  depends_on macos: :mojave # c++17
   depends_on "ossp-uuid"
   depends_on "pkgconf"
   depends_on "protobuf"

--- a/Formula/gz-transport14.rb
+++ b/Formula/gz-transport14.rb
@@ -21,7 +21,6 @@ class GzTransport14 < Formula
   depends_on "gz-msgs11"
   depends_on "gz-tools2"
   depends_on "gz-utils3"
-  depends_on macos: :mojave # c++17
   depends_on "ossp-uuid"
   depends_on "pkgconf"
   depends_on "protobuf"

--- a/Formula/gz-transport15.rb
+++ b/Formula/gz-transport15.rb
@@ -20,7 +20,6 @@ class GzTransport15 < Formula
   depends_on "gz-msgs12"
   depends_on "gz-tools2"
   depends_on "gz-utils4"
-  depends_on macos: :mojave # c++17
   depends_on "ossp-uuid"
   depends_on "pkgconf"
   depends_on "protobuf"

--- a/Formula/ignition-citadel.rb
+++ b/Formula/ignition-citadel.rb
@@ -31,7 +31,6 @@ class IgnitionCitadel < Formula
   depends_on "ignition-sensors3"
   depends_on "ignition-tools"
   depends_on "ignition-transport8"
-  depends_on macos: :mojave # c++17
   depends_on "pkgconf"
   depends_on "python@3.11"
   depends_on "sdformat9"

--- a/Formula/ignition-common3.rb
+++ b/Formula/ignition-common3.rb
@@ -21,7 +21,6 @@ class IgnitionCommon3 < Formula
   depends_on "gts"
   depends_on "ignition-cmake2"
   depends_on "ignition-math6"
-  depends_on macos: :high_sierra # c++17
   depends_on "ossp-uuid"
   depends_on "pkgconf"
   depends_on "tinyxml2"

--- a/Formula/ignition-common4.rb
+++ b/Formula/ignition-common4.rb
@@ -22,7 +22,6 @@ class IgnitionCommon4 < Formula
   depends_on "ignition-cmake2"
   depends_on "ignition-math6"
   depends_on "ignition-utils1"
-  depends_on macos: :high_sierra # c++17
   depends_on "ossp-uuid"
   depends_on "pkgconf"
   depends_on "tinyxml2"

--- a/Formula/ignition-fortress.rb
+++ b/Formula/ignition-fortress.rb
@@ -28,7 +28,6 @@ class IgnitionFortress < Formula
   depends_on "ignition-sensors6"
   depends_on "ignition-tools"
   depends_on "ignition-transport11"
-  depends_on macos: :mojave # c++17
   depends_on "pkgconf"
   depends_on "sdformat12"
 

--- a/Formula/ignition-fuel-tools4.rb
+++ b/Formula/ignition-fuel-tools4.rb
@@ -22,7 +22,6 @@ class IgnitionFuelTools4 < Formula
   depends_on "jsoncpp"
   depends_on "libyaml"
   depends_on "libzip"
-  depends_on macos: :high_sierra # c++17
   depends_on "pkgconf"
   depends_on "protobuf"
   depends_on "tinyxml2"

--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -15,7 +15,6 @@ class IgnitionFuelTools7 < Formula
   depends_on "jsoncpp"
   depends_on "libyaml"
   depends_on "libzip"
-  depends_on macos: :high_sierra # c++17
   depends_on "pkgconf"
   depends_on "protobuf"
   depends_on "tinyxml2"

--- a/Formula/ignition-gazebo3.rb
+++ b/Formula/ignition-gazebo3.rb
@@ -29,7 +29,6 @@ class IgnitionGazebo3 < Formula
   depends_on "ignition-sensors3"
   depends_on "ignition-tools"
   depends_on "ignition-transport8"
-  depends_on macos: :mojave # c++17
   depends_on "pkgconf"
   depends_on "protobuf"
   depends_on "ruby"

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -27,7 +27,6 @@ class IgnitionGazebo6 < Formula
   depends_on "ignition-tools"
   depends_on "ignition-transport11"
   depends_on "ignition-utils1"
-  depends_on macos: :mojave # c++17
   depends_on "pkgconf"
   depends_on "protobuf"
   depends_on "python@3.11"

--- a/Formula/ignition-gui3.rb
+++ b/Formula/ignition-gui3.rb
@@ -27,7 +27,6 @@ class IgnitionGui3 < Formula
   depends_on "ignition-plugin1"
   depends_on "ignition-rendering3"
   depends_on "ignition-transport8"
-  depends_on macos: :mojave # c++17
   depends_on "protobuf"
   depends_on "qt@5"
   depends_on "tinyxml2"

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -19,7 +19,6 @@ class IgnitionGui6 < Formula
   depends_on "ignition-plugin1"
   depends_on "ignition-rendering6"
   depends_on "ignition-transport11"
-  depends_on macos: :mojave # c++17
   depends_on "protobuf"
   depends_on "qt@5"
   depends_on "tinyxml2"

--- a/Formula/ignition-msgs5.rb
+++ b/Formula/ignition-msgs5.rb
@@ -14,7 +14,6 @@ class IgnitionMsgs5 < Formula
   depends_on "ignition-cmake2"
   depends_on "ignition-math6"
   depends_on "ignition-tools"
-  depends_on macos: :high_sierra # c++17
   depends_on "pkgconf"
   depends_on "protobuf"
   depends_on "tinyxml2"

--- a/Formula/ignition-msgs8.rb
+++ b/Formula/ignition-msgs8.rb
@@ -12,7 +12,6 @@ class IgnitionMsgs8 < Formula
   depends_on "ignition-cmake2"
   depends_on "ignition-math6"
   depends_on "ignition-tools"
-  depends_on macos: :high_sierra # c++17
   depends_on "pkgconf"
   depends_on "protobuf"
   depends_on "tinyxml2"

--- a/Formula/ignition-physics2.rb
+++ b/Formula/ignition-physics2.rb
@@ -21,7 +21,6 @@ class IgnitionPhysics2 < Formula
   depends_on "ignition-common3"
   depends_on "ignition-math6"
   depends_on "ignition-plugin1"
-  depends_on macos: :mojave # c++17
   depends_on "pkgconf"
   depends_on "sdformat9"
   depends_on "tinyxml2"

--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -28,7 +28,6 @@ class IgnitionPhysics5 < Formula
   depends_on "ignition-math6"
   depends_on "ignition-plugin1"
   depends_on "ignition-utils1"
-  depends_on macos: :mojave # c++17
   depends_on "pkgconf"
   depends_on "sdformat12"
   depends_on "tinyxml2"

--- a/Formula/ignition-plugin1.rb
+++ b/Formula/ignition-plugin1.rb
@@ -20,7 +20,6 @@ class IgnitionPlugin1 < Formula
   depends_on "cmake"
   depends_on "ignition-cmake2"
   depends_on "ignition-tools"
-  depends_on macos: :high_sierra # c++17
   depends_on "pkgconf"
 
   def install

--- a/Formula/ignition-rendering3.rb
+++ b/Formula/ignition-rendering3.rb
@@ -26,7 +26,6 @@ class IgnitionRendering3 < Formula
   depends_on "ignition-common3"
   depends_on "ignition-math6"
   depends_on "ignition-plugin1"
-  depends_on macos: :mojave # c++17
   depends_on "ogre1.9"
   depends_on "ogre2.1"
 

--- a/Formula/ignition-rendering6.rb
+++ b/Formula/ignition-rendering6.rb
@@ -25,7 +25,6 @@ class IgnitionRendering6 < Formula
   depends_on "ignition-common4"
   depends_on "ignition-math6"
   depends_on "ignition-plugin1"
-  depends_on macos: :mojave # c++17
   depends_on "ogre1.9"
   depends_on "ogre2.2"
 

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -17,7 +17,6 @@ class IgnitionTransport11 < Formula
   depends_on "ignition-msgs8"
   depends_on "ignition-tools"
   depends_on "ignition-utils1"
-  depends_on macos: :mojave # c++17
   depends_on "ossp-uuid"
   depends_on "pkgconf"
   depends_on "protobuf"

--- a/Formula/ignition-transport8.rb
+++ b/Formula/ignition-transport8.rb
@@ -17,7 +17,6 @@ class IgnitionTransport8 < Formula
   depends_on "ignition-cmake2"
   depends_on "ignition-msgs5"
   depends_on "ignition-tools"
-  depends_on macos: :mojave # c++17
   depends_on "ossp-uuid"
   depends_on "pkgconf"
   depends_on "protobuf"

--- a/Formula/sdformat12.rb
+++ b/Formula/sdformat12.rb
@@ -23,7 +23,6 @@ class Sdformat12 < Formula
   depends_on "ignition-math6"
   depends_on "ignition-tools"
   depends_on "ignition-utils1"
-  depends_on macos: :mojave # c++17
   depends_on "tinyxml2"
   depends_on "urdfdom"
 

--- a/Formula/sdformat13.rb
+++ b/Formula/sdformat13.rb
@@ -26,7 +26,6 @@ class Sdformat13 < Formula
   depends_on "gz-math7"
   depends_on "gz-tools2"
   depends_on "gz-utils2"
-  depends_on macos: :mojave # c++17
   depends_on "python@3.12"
   depends_on "tinyxml2"
   depends_on "urdfdom"

--- a/Formula/sdformat14.rb
+++ b/Formula/sdformat14.rb
@@ -26,7 +26,6 @@ class Sdformat14 < Formula
   depends_on "gz-math7"
   depends_on "gz-tools2"
   depends_on "gz-utils2"
-  depends_on macos: :mojave # c++17
   depends_on "tinyxml2"
   depends_on "urdfdom"
 

--- a/Formula/sdformat15.rb
+++ b/Formula/sdformat15.rb
@@ -26,7 +26,6 @@ class Sdformat15 < Formula
   depends_on "gz-math8"
   depends_on "gz-tools2"
   depends_on "gz-utils3"
-  depends_on macos: :mojave # c++17
   depends_on "tinyxml2"
   depends_on "urdfdom"
 

--- a/Formula/sdformat16.rb
+++ b/Formula/sdformat16.rb
@@ -18,7 +18,6 @@ class Sdformat16 < Formula
   depends_on "gz-math9"
   depends_on "gz-tools2"
   depends_on "gz-utils4"
-  depends_on macos: :mojave # c++17
   depends_on "tinyxml2"
   depends_on "urdfdom"
 

--- a/Formula/sdformat9.rb
+++ b/Formula/sdformat9.rb
@@ -23,7 +23,6 @@ class Sdformat9 < Formula
   depends_on "doxygen"
   depends_on "ignition-math6"
   depends_on "ignition-tools"
-  depends_on macos: :mojave # c++17
   depends_on "tinyxml1"
   depends_on "urdfdom"
 


### PR DESCRIPTION
The listed versions are all EOL so they can be removed.