### PR TITLE
gz-cmake4: build arm64_sequoia bottle

### DIFF
--- a/Formula/gz-cmake4.rb
+++ b/Formula/gz-cmake4.rb
@@ -19,7 +19,6 @@ class GzCmake4 < Formula
 
   def install
     cmake_args = std_cmake_args
-    cmake_args << "-DBUILD_TESTING=OFF"
 
     # Use a build folder
     mkdir "build" do

--- a/Formula/gz-cmake4.rb
+++ b/Formula/gz-cmake4.rb
@@ -9,9 +9,10 @@ class GzCmake4 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "9a5f35d977bed3779f9d073a29609d3e2122c6618800ef1d0d3dcd11cc801524"
-    sha256 cellar: :any_skip_relocation, sonoma:       "eb9861dd42a5137c9d4cc58777b1521c84e12d01e92e7df685ff918937c1ebe2"
-    sha256 cellar: :any_skip_relocation, ventura:      "70891eec4fdbab5366f1a3a160a282fe6abcfc86c0c570f141470165e414d751"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "5726e1b734b659cb62475c3b2a58f162a89f45e92334df821ac0263a594363f0"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "9a5f35d977bed3779f9d073a29609d3e2122c6618800ef1d0d3dcd11cc801524"
+    sha256 cellar: :any_skip_relocation, sonoma:        "eb9861dd42a5137c9d4cc58777b1521c84e12d01e92e7df685ff918937c1ebe2"
+    sha256 cellar: :any_skip_relocation, ventura:       "70891eec4fdbab5366f1a3a160a282fe6abcfc86c0c570f141470165e414d751"
   end
 
   depends_on "cmake"


### PR DESCRIPTION
Need to make a minor change to files to build new bottles, so remove the `BUILD_TESTING` cmake arg since it's already set to `OFF` in [std_cmake_args](https://github.com/Homebrew/brew/blob/b352fff140b2e55bef2953f43bdfa5867adae6b6/Library/Homebrew/formula.rb#L1878).