### PR TITLE
README: add amd64 label to badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,194 +14,194 @@ To use:
 
 ## Bottle status
 
-Status        | Fortress | Harmonic | Ionic | Jetty
-------------- | -------- | -------- | ----- | -------
-[gz-cmake][cmake-repo]           | [![Build Status][cmake-fortress-badge]][cmake-fortress] | [![Build Status][cmake-harmonic-badge]][cmake-harmonic] | [![Build Status][cmake-ionic-badge]][cmake-ionic] | [![Build Status][cmake-jetty-badge]][cmake-jetty] |
-[gz-common][common-repo]         | [![Build Status][common-fortress-badge]][common-fortress] | [![Build Status][common-harmonic-badge]][common-harmonic] | [![Build Status][common-ionic-badge]][common-ionic] | [![Build Status][common-jetty-badge]][common-jetty] |
-[gz-fuel-tools][fuel_tools-repo] | [![Build Status][fuel_tools-fortress-badge]][fuel_tools-fortress] | [![Build Status][fuel_tools-harmonic-badge]][fuel_tools-harmonic] | [![Build Status][fuel_tools-ionic-badge]][fuel_tools-ionic] | [![Build Status][fuel_tools-jetty-badge]][fuel_tools-jetty] |
-[gz-gui][gui-repo]               | [![Build Status][gui-fortress-badge]][gui-fortress] | [![Build Status][gui-harmonic-badge]][gui-harmonic] | [![Build Status][gui-ionic-badge]][gui-ionic] | [![Build Status][gui-jetty-badge]][gui-jetty] |
-[gz-launch][launch-repo]         | [![Build Status][launch-fortress-badge]][launch-fortress] | [![Build Status][launch-harmonic-badge]][launch-harmonic] | [![Build Status][launch-ionic-badge]][launch-ionic] | [![Build Status][launch-jetty-badge]][launch-jetty] |
-[gz-math][math-repo]             | [![Build Status][math-fortress-badge]][math-fortress] | [![Build Status][math-harmonic-badge]][math-harmonic] | [![Build Status][math-ionic-badge]][math-ionic] | [![Build Status][math-jetty-badge]][math-jetty] |
-[gz-msgs][msgs-repo]             | [![Build Status][msgs-fortress-badge]][msgs-fortress] | [![Build Status][msgs-harmonic-badge]][msgs-harmonic] | [![Build Status][msgs-ionic-badge]][msgs-ionic] | [![Build Status][msgs-jetty-badge]][msgs-jetty] |
-[gz-physics][physics-repo]       | [![Build Status][physics-fortress-badge]][physics-fortress] | [![Build Status][physics-harmonic-badge]][physics-harmonic] | [![Build Status][physics-ionic-badge]][physics-ionic] | [![Build Status][physics-jetty-badge]][physics-jetty] |
-[gz-plugin][plugin-repo]         | [![Build Status][plugin-fortress-badge]][plugin-fortress] | [![Build Status][plugin-harmonic-badge]][plugin-harmonic] | [![Build Status][plugin-ionic-badge]][plugin-ionic] | [![Build Status][plugin-jetty-badge]][plugin-jetty] |
-[gz-rendering][rendering-repo]   | [![Build Status][rendering-fortress-badge]][rendering-fortress] | [![Build Status][rendering-harmonic-badge]][rendering-harmonic] | [![Build Status][rendering-ionic-badge]][rendering-ionic] | [![Build Status][rendering-jetty-badge]][rendering-jetty] |
-[gz-sensors][sensors-repo]       | [![Build Status][sensors-fortress-badge]][sensors-fortress] | [![Build Status][sensors-harmonic-badge]][sensors-harmonic] | [![Build Status][sensors-ionic-badge]][sensors-ionic] | [![Build Status][sensors-jetty-badge]][sensors-jetty] |
-[gz-sim][sim-repo]               | [![Build Status][sim-fortress-badge]][sim-fortress] | [![Build Status][sim-harmonic-badge]][sim-harmonic] | [![Build Status][sim-ionic-badge]][sim-ionic] | [![Build Status][sim-jetty-badge]][sim-jetty] |
-[gz-tools][tools-repo]           | [![Build Status][tools-fortress-badge]][tools-fortress] | [![Build Status][tools-harmonic-badge]][tools-harmonic] | [![Build Status][tools-ionic-badge]][tools-ionic] | [![Build Status][tools-jetty-badge]][tools-jetty] |
-[gz-transport][transport-repo]   | [![Build Status][transport-fortress-badge]][transport-fortress] | [![Build Status][transport-harmonic-badge]][transport-harmonic] | [![Build Status][transport-ionic-badge]][transport-ionic] | [![Build Status][transport-jetty-badge]][transport-jetty] |
-[gz-utils][utils-repo]           | [![Build Status][utils-fortress-badge]][utils-fortress] | [![Build Status][utils-harmonic-badge]][utils-harmonic] | [![Build Status][utils-ionic-badge]][utils-ionic] | [![Build Status][utils-jetty-badge]][utils-jetty] |
-[sdformat][sdformat-repo]        | [![Build Status][sdformat-fortress-badge]][sdformat-fortress] | [![Build Status][sdformat-harmonic-badge]][sdformat-harmonic] | [![Build Status][sdformat-ionic-badge]][sdformat-ionic] | [![Build Status][sdformat-jetty-badge]][sdformat-jetty] |
-collection                       | [![Build Status][collection-fortress-badge]][collection-fortress] | [![Build Status][collection-harmonic-badge]][collection-harmonic] | [![Build Status][collection-ionic-badge]][collection-ionic] | [![Build Status][collection-jetty-badge]][collection-jetty] |
+Status        | Arch | Fortress | Harmonic | Ionic | Jetty
+------------- | ---- | -------- | -------- | ----- | -------
+[gz-cmake][cmake-repo]           | amd64 | [![Build Status][cmake-fortress-badge-amd64]][cmake-fortress-amd64] | [![Build Status][cmake-harmonic-badge-amd64]][cmake-harmonic-amd64] | [![Build Status][cmake-ionic-badge-amd64]][cmake-ionic-amd64] | [![Build Status][cmake-jetty-badge-amd64]][cmake-jetty-amd64] |
+[gz-common][common-repo]         | amd64 | [![Build Status][common-fortress-badge-amd64]][common-fortress-amd64] | [![Build Status][common-harmonic-badge-amd64]][common-harmonic-amd64] | [![Build Status][common-ionic-badge-amd64]][common-ionic-amd64] | [![Build Status][common-jetty-badge-amd64]][common-jetty-amd64] |
+[gz-fuel-tools][fuel_tools-repo] | amd64 | [![Build Status][fuel_tools-fortress-badge-amd64]][fuel_tools-fortress-amd64] | [![Build Status][fuel_tools-harmonic-badge-amd64]][fuel_tools-harmonic-amd64] | [![Build Status][fuel_tools-ionic-badge-amd64]][fuel_tools-ionic-amd64] | [![Build Status][fuel_tools-jetty-badge-amd64]][fuel_tools-jetty-amd64] |
+[gz-gui][gui-repo]               | amd64 | [![Build Status][gui-fortress-badge-amd64]][gui-fortress-amd64] | [![Build Status][gui-harmonic-badge-amd64]][gui-harmonic-amd64] | [![Build Status][gui-ionic-badge-amd64]][gui-ionic-amd64] | [![Build Status][gui-jetty-badge-amd64]][gui-jetty-amd64] |
+[gz-launch][launch-repo]         | amd64 | [![Build Status][launch-fortress-badge-amd64]][launch-fortress-amd64] | [![Build Status][launch-harmonic-badge-amd64]][launch-harmonic-amd64] | [![Build Status][launch-ionic-badge-amd64]][launch-ionic-amd64] | [![Build Status][launch-jetty-badge-amd64]][launch-jetty-amd64] |
+[gz-math][math-repo]             | amd64 | [![Build Status][math-fortress-badge-amd64]][math-fortress-amd64] | [![Build Status][math-harmonic-badge-amd64]][math-harmonic-amd64] | [![Build Status][math-ionic-badge-amd64]][math-ionic-amd64] | [![Build Status][math-jetty-badge-amd64]][math-jetty-amd64] |
+[gz-msgs][msgs-repo]             | amd64 | [![Build Status][msgs-fortress-badge-amd64]][msgs-fortress-amd64] | [![Build Status][msgs-harmonic-badge-amd64]][msgs-harmonic-amd64] | [![Build Status][msgs-ionic-badge-amd64]][msgs-ionic-amd64] | [![Build Status][msgs-jetty-badge-amd64]][msgs-jetty-amd64] |
+[gz-physics][physics-repo]       | amd64 | [![Build Status][physics-fortress-badge-amd64]][physics-fortress-amd64] | [![Build Status][physics-harmonic-badge-amd64]][physics-harmonic-amd64] | [![Build Status][physics-ionic-badge-amd64]][physics-ionic-amd64] | [![Build Status][physics-jetty-badge-amd64]][physics-jetty-amd64] |
+[gz-plugin][plugin-repo]         | amd64 | [![Build Status][plugin-fortress-badge-amd64]][plugin-fortress-amd64] | [![Build Status][plugin-harmonic-badge-amd64]][plugin-harmonic-amd64] | [![Build Status][plugin-ionic-badge-amd64]][plugin-ionic-amd64] | [![Build Status][plugin-jetty-badge-amd64]][plugin-jetty-amd64] |
+[gz-rendering][rendering-repo]   | amd64 | [![Build Status][rendering-fortress-badge-amd64]][rendering-fortress-amd64] | [![Build Status][rendering-harmonic-badge-amd64]][rendering-harmonic-amd64] | [![Build Status][rendering-ionic-badge-amd64]][rendering-ionic-amd64] | [![Build Status][rendering-jetty-badge-amd64]][rendering-jetty-amd64] |
+[gz-sensors][sensors-repo]       | amd64 | [![Build Status][sensors-fortress-badge-amd64]][sensors-fortress-amd64] | [![Build Status][sensors-harmonic-badge-amd64]][sensors-harmonic-amd64] | [![Build Status][sensors-ionic-badge-amd64]][sensors-ionic-amd64] | [![Build Status][sensors-jetty-badge-amd64]][sensors-jetty-amd64] |
+[gz-sim][sim-repo]               | amd64 | [![Build Status][sim-fortress-badge-amd64]][sim-fortress-amd64] | [![Build Status][sim-harmonic-badge-amd64]][sim-harmonic-amd64] | [![Build Status][sim-ionic-badge-amd64]][sim-ionic-amd64] | [![Build Status][sim-jetty-badge-amd64]][sim-jetty-amd64] |
+[gz-tools][tools-repo]           | amd64 | [![Build Status][tools-fortress-badge-amd64]][tools-fortress-amd64] | [![Build Status][tools-harmonic-badge-amd64]][tools-harmonic-amd64] | [![Build Status][tools-ionic-badge-amd64]][tools-ionic-amd64] | [![Build Status][tools-jetty-badge-amd64]][tools-jetty-amd64] |
+[gz-transport][transport-repo]   | amd64 | [![Build Status][transport-fortress-badge-amd64]][transport-fortress-amd64] | [![Build Status][transport-harmonic-badge-amd64]][transport-harmonic-amd64] | [![Build Status][transport-ionic-badge-amd64]][transport-ionic-amd64] | [![Build Status][transport-jetty-badge-amd64]][transport-jetty-amd64] |
+[gz-utils][utils-repo]           | amd64 | [![Build Status][utils-fortress-badge-amd64]][utils-fortress-amd64] | [![Build Status][utils-harmonic-badge-amd64]][utils-harmonic-amd64] | [![Build Status][utils-ionic-badge-amd64]][utils-ionic-amd64] | [![Build Status][utils-jetty-badge-amd64]][utils-jetty-amd64] |
+[sdformat][sdformat-repo]        | amd64 | [![Build Status][sdformat-fortress-badge-amd64]][sdformat-fortress-amd64] | [![Build Status][sdformat-harmonic-badge-amd64]][sdformat-harmonic-amd64] | [![Build Status][sdformat-ionic-badge-amd64]][sdformat-ionic-amd64] | [![Build Status][sdformat-jetty-badge-amd64]][sdformat-jetty-amd64] |
+collection                       | amd64 | [![Build Status][collection-fortress-badge-amd64]][collection-fortress-amd64] | [![Build Status][collection-harmonic-badge-amd64]][collection-harmonic-amd64] | [![Build Status][collection-ionic-badge-amd64]][collection-ionic-amd64] | [![Build Status][collection-jetty-badge-amd64]][collection-jetty-amd64] |
 
 [cmake-repo]: https://github.com/gazebosim/gz-cmake
-[cmake-fortress]: https://build.osrfoundation.org/job/gz_cmake2-install_bottle-homebrew-amd64
-[cmake-fortress-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_cmake2-install_bottle-homebrew-amd64
-[cmake-harmonic]: https://build.osrfoundation.org/job/gz_cmake3-install_bottle-homebrew-amd64
-[cmake-harmonic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_cmake3-install_bottle-homebrew-amd64
-[cmake-ionic]: https://build.osrfoundation.org/job/gz_cmake4-install_bottle-homebrew-amd64
-[cmake-ionic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_cmake4-install_bottle-homebrew-amd64
-[cmake-jetty]: https://build.osrfoundation.org/job/gz_cmake5-install_bottle-homebrew-amd64
-[cmake-jetty-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_cmake5-install_bottle-homebrew-amd64
+[cmake-fortress-amd64]: https://build.osrfoundation.org/job/gz_cmake2-install_bottle-homebrew-amd64
+[cmake-fortress-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_cmake2-install_bottle-homebrew-amd64
+[cmake-harmonic-amd64]: https://build.osrfoundation.org/job/gz_cmake3-install_bottle-homebrew-amd64
+[cmake-harmonic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_cmake3-install_bottle-homebrew-amd64
+[cmake-ionic-amd64]: https://build.osrfoundation.org/job/gz_cmake4-install_bottle-homebrew-amd64
+[cmake-ionic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_cmake4-install_bottle-homebrew-amd64
+[cmake-jetty-amd64]: https://build.osrfoundation.org/job/gz_cmake5-install_bottle-homebrew-amd64
+[cmake-jetty-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_cmake5-install_bottle-homebrew-amd64
 
 [common-repo]: https://github.com/gazebosim/gz-common
-[common-fortress]: https://build.osrfoundation.org/job/gz_common4-install_bottle-homebrew-amd64
-[common-fortress-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_common4-install_bottle-homebrew-amd64
-[common-harmonic]: https://build.osrfoundation.org/job/gz_common5-install_bottle-homebrew-amd64
-[common-harmonic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_common5-install_bottle-homebrew-amd64
-[common-ionic]: https://build.osrfoundation.org/job/gz_common6-install_bottle-homebrew-amd64
-[common-ionic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_common6-install_bottle-homebrew-amd64
-[common-jetty]: https://build.osrfoundation.org/job/gz_common7-install_bottle-homebrew-amd64
-[common-jetty-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_common7-install_bottle-homebrew-amd64
+[common-fortress-amd64]: https://build.osrfoundation.org/job/gz_common4-install_bottle-homebrew-amd64
+[common-fortress-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_common4-install_bottle-homebrew-amd64
+[common-harmonic-amd64]: https://build.osrfoundation.org/job/gz_common5-install_bottle-homebrew-amd64
+[common-harmonic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_common5-install_bottle-homebrew-amd64
+[common-ionic-amd64]: https://build.osrfoundation.org/job/gz_common6-install_bottle-homebrew-amd64
+[common-ionic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_common6-install_bottle-homebrew-amd64
+[common-jetty-amd64]: https://build.osrfoundation.org/job/gz_common7-install_bottle-homebrew-amd64
+[common-jetty-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_common7-install_bottle-homebrew-amd64
 
 [fuel_tools-repo]: https://github.com/gazebosim/gz-fuel-tools
-[fuel_tools-fortress]: https://build.osrfoundation.org/job/gz_fuel_tools7-install_bottle-homebrew-amd64
-[fuel_tools-fortress-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_fuel_tools7-install_bottle-homebrew-amd64
-[fuel_tools-harmonic]: https://build.osrfoundation.org/job/gz_fuel_tools9-install_bottle-homebrew-amd64
-[fuel_tools-harmonic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_fuel_tools9-install_bottle-homebrew-amd64
-[fuel_tools-ionic]: https://build.osrfoundation.org/job/gz_fuel_tools10-install_bottle-homebrew-amd64
-[fuel_tools-ionic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_fuel_tools10-install_bottle-homebrew-amd64
-[fuel_tools-jetty]: https://build.osrfoundation.org/job/gz_fuel_tools11-install_bottle-homebrew-amd64
-[fuel_tools-jetty-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_fuel_tools11-install_bottle-homebrew-amd64
+[fuel_tools-fortress-amd64]: https://build.osrfoundation.org/job/gz_fuel_tools7-install_bottle-homebrew-amd64
+[fuel_tools-fortress-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_fuel_tools7-install_bottle-homebrew-amd64
+[fuel_tools-harmonic-amd64]: https://build.osrfoundation.org/job/gz_fuel_tools9-install_bottle-homebrew-amd64
+[fuel_tools-harmonic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_fuel_tools9-install_bottle-homebrew-amd64
+[fuel_tools-ionic-amd64]: https://build.osrfoundation.org/job/gz_fuel_tools10-install_bottle-homebrew-amd64
+[fuel_tools-ionic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_fuel_tools10-install_bottle-homebrew-amd64
+[fuel_tools-jetty-amd64]: https://build.osrfoundation.org/job/gz_fuel_tools11-install_bottle-homebrew-amd64
+[fuel_tools-jetty-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_fuel_tools11-install_bottle-homebrew-amd64
 
 [gui-repo]: https://github.com/gazebosim/gz-gui
-[gui-fortress]: https://build.osrfoundation.org/job/gz_gui6-install_bottle-homebrew-amd64
-[gui-fortress-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_gui6-install_bottle-homebrew-amd64
-[gui-harmonic]: https://build.osrfoundation.org/job/gz_gui8-install_bottle-homebrew-amd64
-[gui-harmonic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_gui8-install_bottle-homebrew-amd64
-[gui-ionic]: https://build.osrfoundation.org/job/gz_gui9-install_bottle-homebrew-amd64
-[gui-ionic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_gui9-install_bottle-homebrew-amd64
-[gui-jetty]: https://build.osrfoundation.org/job/gz_gui10-install_bottle-homebrew-amd64
-[gui-jetty-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_gui10-install_bottle-homebrew-amd64
+[gui-fortress-amd64]: https://build.osrfoundation.org/job/gz_gui6-install_bottle-homebrew-amd64
+[gui-fortress-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_gui6-install_bottle-homebrew-amd64
+[gui-harmonic-amd64]: https://build.osrfoundation.org/job/gz_gui8-install_bottle-homebrew-amd64
+[gui-harmonic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_gui8-install_bottle-homebrew-amd64
+[gui-ionic-amd64]: https://build.osrfoundation.org/job/gz_gui9-install_bottle-homebrew-amd64
+[gui-ionic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_gui9-install_bottle-homebrew-amd64
+[gui-jetty-amd64]: https://build.osrfoundation.org/job/gz_gui10-install_bottle-homebrew-amd64
+[gui-jetty-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_gui10-install_bottle-homebrew-amd64
 
 [launch-repo]: https://github.com/gazebosim/gz-launch
-[launch-fortress]: https://build.osrfoundation.org/job/gz_launch5-install_bottle-homebrew-amd64
-[launch-fortress-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_launch5-install_bottle-homebrew-amd64
-[launch-harmonic]: https://build.osrfoundation.org/job/gz_launch7-install_bottle-homebrew-amd64
-[launch-harmonic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_launch7-install_bottle-homebrew-amd64
-[launch-ionic]: https://build.osrfoundation.org/job/gz_launch8-install_bottle-homebrew-amd64
-[launch-ionic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_launch8-install_bottle-homebrew-amd64
-[launch-jetty]: https://build.osrfoundation.org/job/gz_launch9-install_bottle-homebrew-amd64
-[launch-jetty-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_launch9-install_bottle-homebrew-amd64
+[launch-fortress-amd64]: https://build.osrfoundation.org/job/gz_launch5-install_bottle-homebrew-amd64
+[launch-fortress-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_launch5-install_bottle-homebrew-amd64
+[launch-harmonic-amd64]: https://build.osrfoundation.org/job/gz_launch7-install_bottle-homebrew-amd64
+[launch-harmonic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_launch7-install_bottle-homebrew-amd64
+[launch-ionic-amd64]: https://build.osrfoundation.org/job/gz_launch8-install_bottle-homebrew-amd64
+[launch-ionic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_launch8-install_bottle-homebrew-amd64
+[launch-jetty-amd64]: https://build.osrfoundation.org/job/gz_launch9-install_bottle-homebrew-amd64
+[launch-jetty-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_launch9-install_bottle-homebrew-amd64
 
 [math-repo]: https://github.com/gazebosim/gz-math
-[math-fortress]: https://build.osrfoundation.org/job/gz_math6-install_bottle-homebrew-amd64
-[math-fortress-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_math6-install_bottle-homebrew-amd64
-[math-harmonic]: https://build.osrfoundation.org/job/gz_math7-install_bottle-homebrew-amd64
-[math-harmonic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_math7-install_bottle-homebrew-amd64
-[math-ionic]: https://build.osrfoundation.org/job/gz_math8-install_bottle-homebrew-amd64
-[math-ionic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_math8-install_bottle-homebrew-amd64
-[math-jetty]: https://build.osrfoundation.org/job/gz_math9-install_bottle-homebrew-amd64
-[math-jetty-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_math9-install_bottle-homebrew-amd64
+[math-fortress-amd64]: https://build.osrfoundation.org/job/gz_math6-install_bottle-homebrew-amd64
+[math-fortress-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_math6-install_bottle-homebrew-amd64
+[math-harmonic-amd64]: https://build.osrfoundation.org/job/gz_math7-install_bottle-homebrew-amd64
+[math-harmonic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_math7-install_bottle-homebrew-amd64
+[math-ionic-amd64]: https://build.osrfoundation.org/job/gz_math8-install_bottle-homebrew-amd64
+[math-ionic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_math8-install_bottle-homebrew-amd64
+[math-jetty-amd64]: https://build.osrfoundation.org/job/gz_math9-install_bottle-homebrew-amd64
+[math-jetty-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_math9-install_bottle-homebrew-amd64
 
 [msgs-repo]: https://github.com/gazebosim/gz-msgs
-[msgs-fortress]: https://build.osrfoundation.org/job/gz_msgs8-install_bottle-homebrew-amd64
-[msgs-fortress-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_msgs8-install_bottle-homebrew-amd64
-[msgs-harmonic]: https://build.osrfoundation.org/job/gz_msgs10-install_bottle-homebrew-amd64
-[msgs-harmonic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_msgs10-install_bottle-homebrew-amd64
-[msgs-ionic]: https://build.osrfoundation.org/job/gz_msgs11-install_bottle-homebrew-amd64
-[msgs-ionic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_msgs11-install_bottle-homebrew-amd64
-[msgs-jetty]: https://build.osrfoundation.org/job/gz_msgs12-install_bottle-homebrew-amd64
-[msgs-jetty-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_msgs12-install_bottle-homebrew-amd64
+[msgs-fortress-amd64]: https://build.osrfoundation.org/job/gz_msgs8-install_bottle-homebrew-amd64
+[msgs-fortress-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_msgs8-install_bottle-homebrew-amd64
+[msgs-harmonic-amd64]: https://build.osrfoundation.org/job/gz_msgs10-install_bottle-homebrew-amd64
+[msgs-harmonic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_msgs10-install_bottle-homebrew-amd64
+[msgs-ionic-amd64]: https://build.osrfoundation.org/job/gz_msgs11-install_bottle-homebrew-amd64
+[msgs-ionic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_msgs11-install_bottle-homebrew-amd64
+[msgs-jetty-amd64]: https://build.osrfoundation.org/job/gz_msgs12-install_bottle-homebrew-amd64
+[msgs-jetty-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_msgs12-install_bottle-homebrew-amd64
 
 [physics-repo]: https://github.com/gazebosim/gz-physics
-[physics-fortress]: https://build.osrfoundation.org/job/gz_physics5-install_bottle-homebrew-amd64
-[physics-fortress-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_physics5-install_bottle-homebrew-amd64
-[physics-harmonic]: https://build.osrfoundation.org/job/gz_physics7-install_bottle-homebrew-amd64
-[physics-harmonic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_physics7-install_bottle-homebrew-amd64
-[physics-ionic]: https://build.osrfoundation.org/job/gz_physics8-install_bottle-homebrew-amd64
-[physics-ionic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_physics8-install_bottle-homebrew-amd64
-[physics-jetty]: https://build.osrfoundation.org/job/gz_physics9-install_bottle-homebrew-amd64
-[physics-jetty-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_physics9-install_bottle-homebrew-amd64
+[physics-fortress-amd64]: https://build.osrfoundation.org/job/gz_physics5-install_bottle-homebrew-amd64
+[physics-fortress-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_physics5-install_bottle-homebrew-amd64
+[physics-harmonic-amd64]: https://build.osrfoundation.org/job/gz_physics7-install_bottle-homebrew-amd64
+[physics-harmonic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_physics7-install_bottle-homebrew-amd64
+[physics-ionic-amd64]: https://build.osrfoundation.org/job/gz_physics8-install_bottle-homebrew-amd64
+[physics-ionic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_physics8-install_bottle-homebrew-amd64
+[physics-jetty-amd64]: https://build.osrfoundation.org/job/gz_physics9-install_bottle-homebrew-amd64
+[physics-jetty-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_physics9-install_bottle-homebrew-amd64
 
 [plugin-repo]: https://github.com/gazebosim/gz-plugin
-[plugin-fortress]: https://build.osrfoundation.org/job/gz_plugin1-install_bottle-homebrew-amd64
-[plugin-fortress-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_plugin1-install_bottle-homebrew-amd64
-[plugin-harmonic]: https://build.osrfoundation.org/job/gz_plugin2-install_bottle-homebrew-amd64
-[plugin-harmonic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_plugin2-install_bottle-homebrew-amd64
-[plugin-ionic]: https://build.osrfoundation.org/job/gz_plugin3-install_bottle-homebrew-amd64
-[plugin-ionic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_plugin3-install_bottle-homebrew-amd64
-[plugin-jetty]: https://build.osrfoundation.org/job/gz_plugin4-install_bottle-homebrew-amd64
-[plugin-jetty-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_plugin4-install_bottle-homebrew-amd64
+[plugin-fortress-amd64]: https://build.osrfoundation.org/job/gz_plugin1-install_bottle-homebrew-amd64
+[plugin-fortress-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_plugin1-install_bottle-homebrew-amd64
+[plugin-harmonic-amd64]: https://build.osrfoundation.org/job/gz_plugin2-install_bottle-homebrew-amd64
+[plugin-harmonic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_plugin2-install_bottle-homebrew-amd64
+[plugin-ionic-amd64]: https://build.osrfoundation.org/job/gz_plugin3-install_bottle-homebrew-amd64
+[plugin-ionic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_plugin3-install_bottle-homebrew-amd64
+[plugin-jetty-amd64]: https://build.osrfoundation.org/job/gz_plugin4-install_bottle-homebrew-amd64
+[plugin-jetty-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_plugin4-install_bottle-homebrew-amd64
 
 [rendering-repo]: https://github.com/gazebosim/gz-rendering
-[rendering-fortress]: https://build.osrfoundation.org/job/gz_rendering6-install_bottle-homebrew-amd64
-[rendering-fortress-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_rendering6-install_bottle-homebrew-amd64
-[rendering-harmonic]: https://build.osrfoundation.org/job/gz_rendering8-install_bottle-homebrew-amd64
-[rendering-harmonic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_rendering8-install_bottle-homebrew-amd64
-[rendering-ionic]: https://build.osrfoundation.org/job/gz_rendering9-install_bottle-homebrew-amd64
-[rendering-ionic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_rendering9-install_bottle-homebrew-amd64
-[rendering-jetty]: https://build.osrfoundation.org/job/gz_rendering10-install_bottle-homebrew-amd64
-[rendering-jetty-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_rendering10-install_bottle-homebrew-amd64
+[rendering-fortress-amd64]: https://build.osrfoundation.org/job/gz_rendering6-install_bottle-homebrew-amd64
+[rendering-fortress-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_rendering6-install_bottle-homebrew-amd64
+[rendering-harmonic-amd64]: https://build.osrfoundation.org/job/gz_rendering8-install_bottle-homebrew-amd64
+[rendering-harmonic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_rendering8-install_bottle-homebrew-amd64
+[rendering-ionic-amd64]: https://build.osrfoundation.org/job/gz_rendering9-install_bottle-homebrew-amd64
+[rendering-ionic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_rendering9-install_bottle-homebrew-amd64
+[rendering-jetty-amd64]: https://build.osrfoundation.org/job/gz_rendering10-install_bottle-homebrew-amd64
+[rendering-jetty-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_rendering10-install_bottle-homebrew-amd64
 
 [sensors-repo]: https://github.com/gazebosim/gz-sensors
-[sensors-fortress]: https://build.osrfoundation.org/job/gz_sensors6-install_bottle-homebrew-amd64
-[sensors-fortress-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_sensors6-install_bottle-homebrew-amd64
-[sensors-harmonic]: https://build.osrfoundation.org/job/gz_sensors8-install_bottle-homebrew-amd64
-[sensors-harmonic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_sensors8-install_bottle-homebrew-amd64
-[sensors-ionic]: https://build.osrfoundation.org/job/gz_sensors9-install_bottle-homebrew-amd64
-[sensors-ionic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_sensors9-install_bottle-homebrew-amd64
-[sensors-jetty]: https://build.osrfoundation.org/job/gz_sensors10-install_bottle-homebrew-amd64
-[sensors-jetty-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_sensors10-install_bottle-homebrew-amd64
+[sensors-fortress-amd64]: https://build.osrfoundation.org/job/gz_sensors6-install_bottle-homebrew-amd64
+[sensors-fortress-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_sensors6-install_bottle-homebrew-amd64
+[sensors-harmonic-amd64]: https://build.osrfoundation.org/job/gz_sensors8-install_bottle-homebrew-amd64
+[sensors-harmonic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_sensors8-install_bottle-homebrew-amd64
+[sensors-ionic-amd64]: https://build.osrfoundation.org/job/gz_sensors9-install_bottle-homebrew-amd64
+[sensors-ionic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_sensors9-install_bottle-homebrew-amd64
+[sensors-jetty-amd64]: https://build.osrfoundation.org/job/gz_sensors10-install_bottle-homebrew-amd64
+[sensors-jetty-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_sensors10-install_bottle-homebrew-amd64
 
 [sim-repo]: https://github.com/gazebosim/gz-sim
-[sim-fortress]: https://build.osrfoundation.org/job/gz_sim6-install_bottle-homebrew-amd64
-[sim-fortress-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_sim6-install_bottle-homebrew-amd64
-[sim-harmonic]: https://build.osrfoundation.org/job/gz_sim8-install_bottle-homebrew-amd64
-[sim-harmonic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_sim8-install_bottle-homebrew-amd64
-[sim-ionic]: https://build.osrfoundation.org/job/gz_sim9-install_bottle-homebrew-amd64
-[sim-ionic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_sim9-install_bottle-homebrew-amd64
-[sim-jetty]: https://build.osrfoundation.org/job/gz_sim10-install_bottle-homebrew-amd64
-[sim-jetty-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_sim10-install_bottle-homebrew-amd64
+[sim-fortress-amd64]: https://build.osrfoundation.org/job/gz_sim6-install_bottle-homebrew-amd64
+[sim-fortress-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_sim6-install_bottle-homebrew-amd64
+[sim-harmonic-amd64]: https://build.osrfoundation.org/job/gz_sim8-install_bottle-homebrew-amd64
+[sim-harmonic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_sim8-install_bottle-homebrew-amd64
+[sim-ionic-amd64]: https://build.osrfoundation.org/job/gz_sim9-install_bottle-homebrew-amd64
+[sim-ionic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_sim9-install_bottle-homebrew-amd64
+[sim-jetty-amd64]: https://build.osrfoundation.org/job/gz_sim10-install_bottle-homebrew-amd64
+[sim-jetty-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_sim10-install_bottle-homebrew-amd64
 
 [tools-repo]: https://github.com/gazebosim/gz-tools
-[tools-fortress]: https://build.osrfoundation.org/job/gz_tools1-install_bottle-homebrew-amd64
-[tools-fortress-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_tools1-install_bottle-homebrew-amd64
-[tools-harmonic]: https://build.osrfoundation.org/job/gz_tools2-install_bottle-homebrew-amd64
-[tools-harmonic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_tools2-install_bottle-homebrew-amd64
-[tools-ionic]: https://build.osrfoundation.org/job/gz_tools2-install_bottle-homebrew-amd64
-[tools-ionic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_tools2-install_bottle-homebrew-amd64
-[tools-jetty]: https://build.osrfoundation.org/job/gz_tools2-install_bottle-homebrew-amd64
-[tools-jetty-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_tools2-install_bottle-homebrew-amd64
+[tools-fortress-amd64]: https://build.osrfoundation.org/job/gz_tools1-install_bottle-homebrew-amd64
+[tools-fortress-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_tools1-install_bottle-homebrew-amd64
+[tools-harmonic-amd64]: https://build.osrfoundation.org/job/gz_tools2-install_bottle-homebrew-amd64
+[tools-harmonic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_tools2-install_bottle-homebrew-amd64
+[tools-ionic-amd64]: https://build.osrfoundation.org/job/gz_tools2-install_bottle-homebrew-amd64
+[tools-ionic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_tools2-install_bottle-homebrew-amd64
+[tools-jetty-amd64]: https://build.osrfoundation.org/job/gz_tools2-install_bottle-homebrew-amd64
+[tools-jetty-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_tools2-install_bottle-homebrew-amd64
 
 [transport-repo]: https://github.com/gazebosim/gz-transport
-[transport-fortress]: https://build.osrfoundation.org/job/gz_transport11-install_bottle-homebrew-amd64
-[transport-fortress-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_transport11-install_bottle-homebrew-amd64
-[transport-harmonic]: https://build.osrfoundation.org/job/gz_transport13-install_bottle-homebrew-amd64
-[transport-harmonic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_transport13-install_bottle-homebrew-amd64
-[transport-ionic]: https://build.osrfoundation.org/job/gz_transport14-install_bottle-homebrew-amd64
-[transport-ionic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_transport14-install_bottle-homebrew-amd64
-[transport-jetty]: https://build.osrfoundation.org/job/gz_transport15-install_bottle-homebrew-amd64
-[transport-jetty-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_transport15-install_bottle-homebrew-amd64
+[transport-fortress-amd64]: https://build.osrfoundation.org/job/gz_transport11-install_bottle-homebrew-amd64
+[transport-fortress-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_transport11-install_bottle-homebrew-amd64
+[transport-harmonic-amd64]: https://build.osrfoundation.org/job/gz_transport13-install_bottle-homebrew-amd64
+[transport-harmonic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_transport13-install_bottle-homebrew-amd64
+[transport-ionic-amd64]: https://build.osrfoundation.org/job/gz_transport14-install_bottle-homebrew-amd64
+[transport-ionic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_transport14-install_bottle-homebrew-amd64
+[transport-jetty-amd64]: https://build.osrfoundation.org/job/gz_transport15-install_bottle-homebrew-amd64
+[transport-jetty-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_transport15-install_bottle-homebrew-amd64
 
 [utils-repo]: https://github.com/gazebosim/gz-utils
-[utils-fortress]: https://build.osrfoundation.org/job/gz_utils1-install_bottle-homebrew-amd64
-[utils-fortress-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_utils1-install_bottle-homebrew-amd64
-[utils-harmonic]: https://build.osrfoundation.org/job/gz_utils2-install_bottle-homebrew-amd64
-[utils-harmonic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_utils2-install_bottle-homebrew-amd64
-[utils-ionic]: https://build.osrfoundation.org/job/gz_utils3-install_bottle-homebrew-amd64
-[utils-ionic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_utils3-install_bottle-homebrew-amd64
-[utils-jetty]: https://build.osrfoundation.org/job/gz_utils4-install_bottle-homebrew-amd64
-[utils-jetty-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_utils4-install_bottle-homebrew-amd64
+[utils-fortress-amd64]: https://build.osrfoundation.org/job/gz_utils1-install_bottle-homebrew-amd64
+[utils-fortress-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_utils1-install_bottle-homebrew-amd64
+[utils-harmonic-amd64]: https://build.osrfoundation.org/job/gz_utils2-install_bottle-homebrew-amd64
+[utils-harmonic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_utils2-install_bottle-homebrew-amd64
+[utils-ionic-amd64]: https://build.osrfoundation.org/job/gz_utils3-install_bottle-homebrew-amd64
+[utils-ionic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_utils3-install_bottle-homebrew-amd64
+[utils-jetty-amd64]: https://build.osrfoundation.org/job/gz_utils4-install_bottle-homebrew-amd64
+[utils-jetty-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_utils4-install_bottle-homebrew-amd64
 
 [sdformat-repo]: https://github.com/gazebosim/gz-sdformat
-[sdformat-fortress]: https://build.osrfoundation.org/job/sdformat12-install_bottle-homebrew-amd64
-[sdformat-fortress-badge]: https://build.osrfoundation.org/buildStatus/icon?job=sdformat12-install_bottle-homebrew-amd64
-[sdformat-harmonic]: https://build.osrfoundation.org/job/sdformat14-install_bottle-homebrew-amd64
-[sdformat-harmonic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=sdformat14-install_bottle-homebrew-amd64
-[sdformat-ionic]: https://build.osrfoundation.org/job/sdformat15-install_bottle-homebrew-amd64
-[sdformat-ionic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=sdformat15-install_bottle-homebrew-amd64
-[sdformat-jetty]: https://build.osrfoundation.org/job/sdformat16-install_bottle-homebrew-amd64
-[sdformat-jetty-badge]: https://build.osrfoundation.org/buildStatus/icon?job=sdformat16-install_bottle-homebrew-amd64
+[sdformat-fortress-amd64]: https://build.osrfoundation.org/job/sdformat12-install_bottle-homebrew-amd64
+[sdformat-fortress-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=sdformat12-install_bottle-homebrew-amd64
+[sdformat-harmonic-amd64]: https://build.osrfoundation.org/job/sdformat14-install_bottle-homebrew-amd64
+[sdformat-harmonic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=sdformat14-install_bottle-homebrew-amd64
+[sdformat-ionic-amd64]: https://build.osrfoundation.org/job/sdformat15-install_bottle-homebrew-amd64
+[sdformat-ionic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=sdformat15-install_bottle-homebrew-amd64
+[sdformat-jetty-amd64]: https://build.osrfoundation.org/job/sdformat16-install_bottle-homebrew-amd64
+[sdformat-jetty-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=sdformat16-install_bottle-homebrew-amd64
 
-[collection-fortress]: https://build.osrfoundation.org/job/gz_fortress-install_bottle-homebrew-amd64
-[collection-fortress-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_fortress-install_bottle-homebrew-amd64
-[collection-harmonic]: https://build.osrfoundation.org/job/gz_harmonic-install_bottle-homebrew-amd64
-[collection-harmonic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_harmonic-install_bottle-homebrew-amd64
-[collection-ionic]: https://build.osrfoundation.org/job/gz_ionic-install_bottle-homebrew-amd64
-[collection-ionic-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_ionic-install_bottle-homebrew-amd64
-[collection-jetty]: https://build.osrfoundation.org/job/gz_jetty-install_bottle-homebrew-amd64
-[collection-jetty-badge]: https://build.osrfoundation.org/buildStatus/icon?job=gz_jetty-install_bottle-homebrew-amd64
+[collection-fortress-amd64]: https://build.osrfoundation.org/job/gz_fortress-install_bottle-homebrew-amd64
+[collection-fortress-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_fortress-install_bottle-homebrew-amd64
+[collection-harmonic-amd64]: https://build.osrfoundation.org/job/gz_harmonic-install_bottle-homebrew-amd64
+[collection-harmonic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_harmonic-install_bottle-homebrew-amd64
+[collection-ionic-amd64]: https://build.osrfoundation.org/job/gz_ionic-install_bottle-homebrew-amd64
+[collection-ionic-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_ionic-install_bottle-homebrew-amd64
+[collection-jetty-amd64]: https://build.osrfoundation.org/job/gz_jetty-install_bottle-homebrew-amd64
+[collection-jetty-badge-amd64]: https://build.osrfoundation.org/buildStatus/icon?job=gz_jetty-install_bottle-homebrew-amd64
 
 ## To build bottles
 


### PR DESCRIPTION
There are now separate bottle install jobs for amd64 and arm64. The current README badges are only for amd64; this labels them as such.

A follow-up will add arm64 labels and badges.