### PR TITLE
Harmonic: build bindings for python@3.14

### DIFF
--- a/Formula/gz-math7.rb
+++ b/Formula/gz-math7.rb
@@ -10,10 +10,9 @@ class GzMath7 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, arm64_sequoia: "09f4c01a95528cce105072bcca431deca4e94f4d8f003756d98f7872306e3e99"
-    sha256 cellar: :any, arm64_sonoma:  "11ddff8d00f115477f88e6f44c1bbf2d0228ab37a389d8f11366e407f0ae11d2"
-    sha256 cellar: :any, sonoma:        "99e604672f50796e7fd63a490a7c46afcc18e3c3f605da20d275749912e3c8de"
-    sha256 cellar: :any, ventura:       "1475598d5d7e72eeee07a39b092b56561e2a03ebd453a5910a885550f3438f84"
+    sha256 cellar: :any, arm64_sequoia: "83a054d71d59df5fd9f28c640fe0592a0a20293339c42afe6553bb2766360c89"
+    sha256 cellar: :any, arm64_sonoma:  "1552823985773290fef9dabad1bb0f757143ba4f2c2e83cc5956d6d5a12417a0"
+    sha256 cellar: :any, sonoma:        "8b2987d011538d06e2a5de1db590b14644fb93de9b209b9cf88e8feece616a44"
   end
 
   depends_on "cmake" => :build

--- a/Formula/gz-msgs10.rb
+++ b/Formula/gz-msgs10.rb
@@ -8,9 +8,9 @@ class GzMsgs10 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "f38385a99aac809e2baaedb39efbe0d4b74d964ad0b95b3830c81a655f274745"
-    sha256 arm64_sonoma:  "4c07e8037985a0ad79c099a81486641f7ab2b966f0bf7a85c63c95d2c0c72bd9"
-    sha256 sonoma:        "313fe800755ce0adc2870f7fd8f5585d602795f705f7d8186c5fcea9b0de82c1"
+    sha256 arm64_sequoia: "a6b3f38719ea2cae5518db617ccf7d0abda98f1cd67a63323a577bc117a95a47"
+    sha256 arm64_sonoma:  "2c4994b8dea6df94e093624a68d7cb9478ba3ed7e939c871b54767600994b6b9"
+    sha256 sonoma:        "1687458cee78366b42c4c146adbd74e45a8e932653cd40fe383b9afab8470b9e"
   end
 
   # head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs10"

--- a/Formula/gz-transport13.rb
+++ b/Formula/gz-transport13.rb
@@ -10,9 +10,9 @@ class GzTransport13 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "6fc58e56ebce832b629c9ef852cd5af7a0a3f719c2d9f908a0650a6dd1789952"
-    sha256 arm64_sonoma:  "bcc35289c428c4b63ea00888697e6d34ec2e7e56b0c8d97067bd31c520af259f"
-    sha256 sonoma:        "dc6b66fbfac464a91a44b6c6816f3cd598c26203600baaf0823c82295b43028d"
+    sha256 arm64_sequoia: "c107c77a072588e90e6697d7275a68262b11ecccba0044ba40c61b077a03cd0e"
+    sha256 arm64_sonoma:  "5da7c76ab632b9dd6403ffed71720002257d874e16949764dd0edbd89226d6db"
+    sha256 sonoma:        "a6d33db92023152e213c7a22d5d6cc49c8d8658380e58df845333afd469d3e55"
   end
 
   depends_on "doxygen" => [:build, :optional]

--- a/Formula/sdformat14.rb
+++ b/Formula/sdformat14.rb
@@ -10,10 +10,9 @@ class Sdformat14 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "7aea2f417ae8eb7064bfd3db1bb85f15fae101b6f115fabb8cc1bf20f2744803"
-    sha256 arm64_sonoma:  "ece47796eb00dd1ea018ca295ad700ef90c74c1caa345433b076cbf07db373c7"
-    sha256 sonoma:        "cfeabb9a7199ff4215c2b20261061ceeb21b3ac51bf6dfefdcf836fe1fe19498"
-    sha256 ventura:       "b7953bfed83b3de1daf4cbe269bd09089950ab59bbb92c775665ee62c99db183"
+    sha256 arm64_sequoia: "c358bc8a7cdf859f5bd15fdfe41b13bc8f781502b008181754c36b4a167561eb"
+    sha256 arm64_sonoma:  "64a5aebbb499735241eb05b617efcc4655a3476863195c13e37703e56ffbfb9f"
+    sha256 sonoma:        "895c1b564e08ee34ec317797d706f6740f278baf3e53c4d6c6fdb7500396376b"
   end
 
   depends_on "cmake" => [:build, :test]


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/3222.

Excludes gz-sim8, which only has bindings for one version of python.