### PR TITLE
Jetty: build bindings for python@3.14

### DIFF
--- a/Formula/gz-math9.rb
+++ b/Formula/gz-math9.rb
@@ -13,6 +13,7 @@ class GzMath9 < Formula
   depends_on "pybind11" => :build
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
+  depends_on "python@3.14" => [:build, :test]
   depends_on "pkgconf" => :test
   depends_on "eigen"
   depends_on "gz-cmake5"
@@ -90,5 +91,6 @@ class GzMath9 < Formula
     pythons.each do |python|
       system python.opt_libexec/"bin/python", "-c", "import gz.math"
     end
+    system Formula["python3"].opt_libexec/"bin/python", "-c", "import gz.math"
   end
 end

--- a/Formula/gz-msgs12.rb
+++ b/Formula/gz-msgs12.rb
@@ -10,6 +10,7 @@ class GzMsgs12 < Formula
 
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
+  depends_on "python@3.14" => [:build, :test]
   depends_on "abseil"
   depends_on "cmake"
   depends_on "gz-cmake5"
@@ -93,6 +94,7 @@ class GzMsgs12 < Formula
     pythons.each do |python|
       system python.opt_libexec/"bin/python", "-c", "import gz.msgs"
     end
+    system Formula["python3"].opt_libexec/"bin/python", "-c", "import gz.msgs"
     # check gz msg command
     ENV["GZ_CONFIG_PATH"] = "#{opt_share}/gz"
     system Formula["gz-tools2"].opt_bin/"gz", "msg"

--- a/Formula/gz-transport15.rb
+++ b/Formula/gz-transport15.rb
@@ -12,6 +12,7 @@ class GzTransport15 < Formula
   depends_on "pybind11" => :build
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
+  depends_on "python@3.14" => [:build, :test]
 
   depends_on "abseil"
   depends_on "cmake"
@@ -106,5 +107,6 @@ class GzTransport15 < Formula
     pythons.each do |python|
       system python.opt_libexec/"bin/python", "-c", "import gz.transport"
     end
+    system Formula["python3"].opt_libexec/"bin/python", "-c", "import gz.transport"
   end
 end

--- a/Formula/sdformat16.rb
+++ b/Formula/sdformat16.rb
@@ -13,6 +13,7 @@ class Sdformat16 < Formula
   depends_on "pybind11" => :build
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
+  depends_on "python@3.14" => [:build, :test]
 
   depends_on "doxygen"
   depends_on "gz-cmake5"
@@ -109,5 +110,7 @@ class Sdformat16 < Formula
       system python.opt_libexec/"bin/python", "-c",
         "import sdformat; sdformat.Box().size()"
     end
+    system Formula["python3"].opt_libexec/"bin/python", "-c",
+      "import sdformat; sdformat.Box().size()"
   end
 end


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/3222.

Since gz-utils4 does not have a bottle right now, just merge this without bottles if the build in #3223 succeeds.