### PR TITLE
gz-jetty: rebuild dependencies up to gz-sim10

### DIFF
--- a/Formula/gz-common7.rb
+++ b/Formula/gz-common7.rb
@@ -8,6 +8,13 @@ class GzCommon7 < Formula
 
   head "https://github.com/gazebosim/gz-common.git", branch: "gz-common7"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "adacf7e87629b2be2684579784e0d9527d4e7e30bd63c2dbbd0ffcbaf35b4dfe"
+    sha256 cellar: :any, arm64_sonoma:  "9e02541118455f17eb0220c664083df59ac86a90a5a30312d98baf70bede47c3"
+    sha256 cellar: :any, sonoma:        "9b3b30852200696a2a5fc79348ca9a1f3ecbb40546b0e4f61a0d5de0e0a874b8"
+  end
+
   depends_on "assimp"
   depends_on "cmake"
   depends_on "ffmpeg"

--- a/Formula/gz-fuel-tools11.rb
+++ b/Formula/gz-fuel-tools11.rb
@@ -8,6 +8,13 @@ class GzFuelTools11 < Formula
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools11"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "119a99776c4dab878f024f278861fa4983c153838316de47c8cac2b5b967ae63"
+    sha256 cellar: :any, arm64_sonoma:  "6bc7324a22229f0b0e36a56936a49554f04904f08fd0e2e2232de895324aef58"
+    sha256 cellar: :any, sonoma:        "36342731514b362518c56d13375471fd31ced928704261cedcd85da6a01fd1dc"
+  end
+
   depends_on "abseil"
   depends_on "cmake"
   depends_on "gz-cmake5"

--- a/Formula/gz-gui10.rb
+++ b/Formula/gz-gui10.rb
@@ -8,6 +8,13 @@ class GzGui10 < Formula
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "7f509995ae9f00c7959622a977be2ef0b55fafc313a8a3b8a817c47dee95eb49"
+    sha256 arm64_sonoma:  "35bfa4c75995448ad885855a61edf4dea53cbbd97ec30ebe9c67446684a01c80"
+    sha256 sonoma:        "02c554d4885a09904795ddc2ac52744bbea2564fcb4790e2045cc8637e9d07ad"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
   depends_on "abseil"

--- a/Formula/gz-math9.rb
+++ b/Formula/gz-math9.rb
@@ -8,6 +8,13 @@ class GzMath9 < Formula
 
   head "https://github.com/gazebosim/gz-math.git", branch: "gz-math9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "3279823ca3192994a8bc4589b22f56a00ee1924f3f03176960950daf5c2b6af5"
+    sha256 cellar: :any, arm64_sonoma:  "a837e022a8814c5e5b090772abf2678d058156b3fb2f2f2247cb19f42820f848"
+    sha256 cellar: :any, sonoma:        "b5f4d841fdb50ca9be2f64b2ab2938c4820838cb36978b96c9f87534f94433fa"
+  end
+
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
   depends_on "pybind11" => :build

--- a/Formula/gz-msgs12.rb
+++ b/Formula/gz-msgs12.rb
@@ -8,6 +8,13 @@ class GzMsgs12 < Formula
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs12"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "2245d254ca7362ecba5d827d40b48d71a236c1b222fc1a89effc422f182c8462"
+    sha256 arm64_sonoma:  "16b798b8dc300338d25aa9bb55119d418af4a356538a97f9269c98ce57dc8acc"
+    sha256 sonoma:        "bf18d6633b35b41685b31c60c3c4679c2d1b0d85cd02ac2dd55eb5b281800804"
+  end
+
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
   depends_on "python@3.14" => [:build, :test]

--- a/Formula/gz-physics9.rb
+++ b/Formula/gz-physics9.rb
@@ -8,6 +8,13 @@ class GzPhysics9 < Formula
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "1fd897cc37d9097150e5ab2f10d88d974237673db1957c969f1c0273a1aa537f"
+    sha256 arm64_sonoma:  "9561b1a8c8079e4972b8fc21ae25988e3cd99c132db49b5afc9006b9c01014b3"
+    sha256 sonoma:        "b913199f4735355c1f8a814abf432e54eddb30688c63431fc5832cf1a02de19b"
+  end
+
   depends_on "cmake" => [:build, :test]
 
   depends_on "bullet"

--- a/Formula/gz-plugin4.rb
+++ b/Formula/gz-plugin4.rb
@@ -8,6 +8,13 @@ class GzPlugin4 < Formula
 
   head "https://github.com/gazebosim/gz-plugin.git", branch: "gz-plugin4"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "0367acd4b42f938f16f98e68649ae73c2c52810c1f55a20d9a0fa3f6eff54c98"
+    sha256 cellar: :any, arm64_sonoma:  "cee1fe7692532000196721be77d0f8501f05a8fc9dce636e6cd941483cbf2586"
+    sha256 cellar: :any, sonoma:        "f6b9cd9f18fcda1dc17018fdaf2ef819d7f89195c13b974ff57ba3fd6af83f9a"
+  end
+
   depends_on "cmake"
   depends_on "gz-cmake5"
   depends_on "gz-tools2"

--- a/Formula/gz-rendering10.rb
+++ b/Formula/gz-rendering10.rb
@@ -8,6 +8,13 @@ class GzRendering10 < Formula
 
   head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "7819e0f7e3666a16aa968cdd5b9681c2756065cb48ce82fb1a96cc2342f56ef6"
+    sha256 arm64_sonoma:  "4a55e7baa82d2c5383dfbee7446d914b4ca20df07df22ded0248415878ea0693"
+    sha256 sonoma:        "484b6513b5597fe91b7c9557afc06e564010f1b10f7c3201140afbf56bd5a5bd"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
 

--- a/Formula/gz-sensors10.rb
+++ b/Formula/gz-sensors10.rb
@@ -8,6 +8,13 @@ class GzSensors10 < Formula
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256               arm64_sequoia: "ca4a23f85d30d4ade1b2a5e94dca2c7ef1fd9c3e0d8d753bc8391bc526d0f9c3"
+    sha256               arm64_sonoma:  "36a756f0ebf842e53a3f0ddf5cd16480a95432f4de2aadac5264f4fc6ea07b78"
+    sha256 cellar: :any, sonoma:        "949982a3f13ea9bd7946cfb7373ebbc1c6728c4280a054a2843c464030aeb133"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
 

--- a/Formula/gz-transport15.rb
+++ b/Formula/gz-transport15.rb
@@ -8,6 +8,13 @@ class GzTransport15 < Formula
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport15"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "f99f42ba3b2ed24def11d45ee7439e6e01706166ad5acbce34575ffad6e00bb6"
+    sha256 arm64_sonoma:  "c4e8f829cc45859c240a6861344099fd0358ccec90cf02beb5a75cd6ff8a63e9"
+    sha256 sonoma:        "0d8e0d737c76214e0034817961a284c6e48e01344760f5e6fbda89c1648ec1ed"
+  end
+
   depends_on "doxygen" => [:build, :optional]
   depends_on "pybind11" => :build
   depends_on "python@3.12" => [:build, :test]

--- a/Formula/gz-utils4.rb
+++ b/Formula/gz-utils4.rb
@@ -6,6 +6,13 @@ class GzUtils4 < Formula
   license "Apache-2.0"
   revision 2
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "916a271b86c51a4274afe81abfde2c94e8c5d644365ea268b18293b14e601590"
+    sha256 cellar: :any, arm64_sonoma:  "67cf35e150f760abedc15866e816893ce273e78aee45f5f4813ac4802e06864f"
+    sha256 cellar: :any, sonoma:        "7166ba5ee21dc081f17ba37037c4e0b0aa74a6b70dfa9dd7d2888647eb28d064"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
   depends_on "cli11"

--- a/Formula/sdformat16.rb
+++ b/Formula/sdformat16.rb
@@ -8,6 +8,13 @@ class Sdformat16 < Formula
 
   head "https://github.com/gazebosim/sdformat.git", branch: "sdf16"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "4a2daf884a95bc0fbe5aad62f0ca689e9ee126bc613eea7ab070264cab95fb48"
+    sha256 arm64_sonoma:  "68c939fbab17872b299acbeafbe05c3d2a4f2c3bdf94e7d5fbaa64df7a6a107f"
+    sha256 sonoma:        "7b921d21c3ad4cf4ee3bbe0444a45a4f599beb8ca806f3bb8890d5176cf62b5e"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
   depends_on "pybind11" => :build


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/3220, https://github.com/osrf/homebrew-simulation/issues/3222.