### PR TITLE
gz-sim*: depend on python@3.14

### DIFF
--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -11,6 +11,7 @@ class GzSim10 < Formula
   depends_on "cmake" => :build
   depends_on "pybind11" => :build
   depends_on "python@3.13" => [:build, :test]
+  depends_on "python@3.14" => [:build, :test]
   depends_on "abseil"
   depends_on "ffmpeg"
   depends_on "gflags"

--- a/Formula/gz-sim8.rb
+++ b/Formula/gz-sim8.rb
@@ -18,6 +18,7 @@ class GzSim8 < Formula
   depends_on "cmake" => :build
   depends_on "pybind11" => :build
   depends_on "python@3.13" => [:build, :test]
+  depends_on "python@3.14" => [:build, :test]
   depends_on "abseil"
   depends_on "ffmpeg"
   depends_on "gflags"

--- a/Formula/gz-sim9.rb
+++ b/Formula/gz-sim9.rb
@@ -11,6 +11,7 @@ class GzSim9 < Formula
   depends_on "cmake" => :build
   depends_on "pybind11" => :build
   depends_on "python@3.13" => [:build, :test]
+  depends_on "python@3.14" => [:build, :test]
   depends_on "abseil"
   depends_on "ffmpeg"
   depends_on "gflags"


### PR DESCRIPTION
Needed to fix gz-sim CI. Part of #3222.