### PR TITLE
gz-sim*: test import for one version of python

### DIFF
--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -160,8 +160,8 @@ class GzSim10 < Formula
     # check for Xcode frameworks in bottle
     cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
     system cmd_not_grep_xcode
-    # check python import
-    pythons.each do |python|
+    # check python import for first python in dependency list
+    [pythons.first].each do |python|
       system python.opt_libexec/"bin/python", "-c", "import gz.sim"
     end
   end

--- a/Formula/gz-sim8.rb
+++ b/Formula/gz-sim8.rb
@@ -169,8 +169,8 @@ class GzSim8 < Formula
     # check for Xcode frameworks in bottle
     cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
     system cmd_not_grep_xcode
-    # check python import
-    pythons.each do |python|
+    # check python import for first python in dependency list
+    [pythons.first].each do |python|
       system python.opt_libexec/"bin/python", "-c", "import gz.sim8"
     end
   end

--- a/Formula/gz-sim9.rb
+++ b/Formula/gz-sim9.rb
@@ -156,8 +156,8 @@ class GzSim9 < Formula
     # check for Xcode frameworks in bottle
     cmd_not_grep_xcode = "! grep -rnI 'Applications[/]Xcode' #{prefix}"
     system cmd_not_grep_xcode
-    # check python import
-    pythons.each do |python|
+    # check python import for first python in dependency list
+    [pythons.first].each do |python|
       system python.opt_libexec/"bin/python", "-c", "import gz.sim9"
     end
   end


### PR DESCRIPTION
Part of #3222.

I accidentally broke `brew test gz-sim*` by adding an extra python dependency in #3229, since the test tries to import python bindings for each python version declared as a dependency. This updates the test to only test import with the first python version, matching the logic used to select the python version to build against.

## Test result without this change

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_sim8-install_bottle-homebrew-arm64&build=34)](https://build.osrfoundation.org/job/gz_sim8-install_bottle-homebrew-arm64/34/) https://build.osrfoundation.org/job/gz_sim8-install_bottle-homebrew-arm64/34/

## Test result with this change

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_sim8-install_bottle-homebrew-arm64&build=35)](https://build.osrfoundation.org/job/gz_sim8-install_bottle-homebrew-arm64/35/) https://build.osrfoundation.org/job/gz_sim8-install_bottle-homebrew-arm64/35/