### PR TITLE
gz-sim10: switch to python@3.14

### DIFF
--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -4,13 +4,12 @@ class GzSim10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-10.0.0.tar.bz2"
   sha256 "d0bb60a902b8d311dbd25e8fc47e0e4bc984ef1b2ed582f62dfa742d879a4c56"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim10"
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build
-  depends_on "python@3.13" => [:build, :test]
   depends_on "python@3.14" => [:build, :test]
   depends_on "abseil"
   depends_on "ffmpeg"
@@ -42,7 +41,7 @@ class GzSim10 < Formula
         .select { |f| f.name.match?(/^python@3\.\d+$/) }
   end
 
-  def python_cmake_arg(python = Formula["python@3.13"])
+  def python_cmake_arg(python = Formula["python@3.14"])
     "-DPython3_EXECUTABLE=#{python.opt_libexec}/bin/python"
   end
 
@@ -164,5 +163,6 @@ class GzSim10 < Formula
     [pythons.first].each do |python|
       system python.opt_libexec/"bin/python", "-c", "import gz.sim"
     end
+    system Formula["python3"].opt_libexec/"bin/python", "-c", "import gz.sim"
   end
 end


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/3222.