### PR TITLE
gz-common6: bump revision of unbottled dependencies

### DIFF
--- a/Formula/gz-math8.rb
+++ b/Formula/gz-math8.rb
@@ -6,6 +6,13 @@ class GzMath8 < Formula
   license "Apache-2.0"
   revision 6
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "ce1c866a49bfad7d3c4a0fdd87c1b25ef667cbad804d3c7f1df471f5a93d006b"
+    sha256 cellar: :any, arm64_sonoma:  "14f28e0c76a65f34aa5ba71d5aa8c2e65cd1850f0013848bd3cc1c1e3a94ce4a"
+    sha256 cellar: :any, sonoma:        "2d6a581e9e1eb7bce169b3daa6ff82b3591ddf4451e6bfd61be81f81fba346c0"
+  end
+
   # head "https://github.com/gazebosim/gz-math.git", branch: "gz-math8"
 
   depends_on "cmake" => :build

--- a/Formula/gz-utils3.rb
+++ b/Formula/gz-utils3.rb
@@ -6,6 +6,13 @@ class GzUtils3 < Formula
   license "Apache-2.0"
   revision 4
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "319278597fa175ff2873a9e8611e29ea703afd48d8119563ba2df686bc0f3c14"
+    sha256 cellar: :any, arm64_sonoma:  "18674419a1008ce81f7787b8563aaad3530a9e80968ee8555a3e52aeb5c475e4"
+    sha256 cellar: :any, sonoma:        "f4d00528ecc1e3fa456f6c8e8bb3c3d354937d56e7227cc9bc21f3f60bb535ee"
+  end
+
   # head "https://github.com/gazebosim/gz-utils.git", branch: "gz-utils3"
 
   depends_on "cmake" => [:build, :test]


### PR DESCRIPTION
Needed by https://github.com/osrf/homebrew-simulation/pull/3253.