### PR TITLE
gz-fortress: rebuild bottles broken by protobuf 33.1

### DIFF
--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -8,6 +8,13 @@ class IgnitionFuelTools7 < Formula
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools7"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "00b5846352d838135f90549e5af708c88489e3c0c1748b6b03486bab5d542470"
+    sha256 cellar: :any, arm64_sonoma:  "7860d7feb4139817d0b29669c8d0685ae1234428e7570fe245619c401cf82cdb"
+    sha256 cellar: :any, sonoma:        "1655f10d50e553dfa49d4d90f39da5cedd9ab877f1b7be12a84ae954dc07cc06"
+  end
+
   depends_on "cmake"
   depends_on "ignition-cmake2"
   depends_on "ignition-common4"

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -8,6 +8,13 @@ class IgnitionGazebo6 < Formula
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo6"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "240f124a21d290b435ba401ee37bba5ee3272ac8935d2341e53046bd52cf7826"
+    sha256 arm64_sonoma:  "ca36bd724161341cba516983790a8c7364e97b626fe7a02b7ec8360b4e6f288c"
+    sha256 sonoma:        "c6c2cbda7ae779ec68bfc7cc780c5c816d109247b9dc03300445016198287e98"
+  end
+
   depends_on "cmake" => :build
   depends_on "pybind11" => :build
   depends_on "gz-plugin2" => :test

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -8,6 +8,13 @@ class IgnitionGui6 < Formula
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui6"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "ea760820bc6300c636f1f4118cf4592a42f35839f30649b5c599319e8dad7d31"
+    sha256 arm64_sonoma:  "e0128dde7b78c912aa9561ecb29ccc2dba899a5f90be5eda0255fb484b40af1c"
+    sha256 sonoma:        "dcf7fe6033cd385eb20ade8e4f1e6bd4ae79e1e2b2c03edf6618326dc068f4aa"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
 

--- a/Formula/ignition-launch5.rb
+++ b/Formula/ignition-launch5.rb
@@ -8,6 +8,13 @@ class IgnitionLaunch5 < Formula
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "ign-launch5"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "148dd65f966496e5eb55862326c53b8378c9d401e7cd7b25eed2036d8f9e6a24"
+    sha256 arm64_sonoma:  "c2cc66771262b034bbeda76eaa6552696fb31cb48e893e950d46f2971a233822"
+    sha256 sonoma:        "a84a63c1da4a3507faacc4db40b2863f27149bc59743a94c9a2722cf980bb948"
+  end
+
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
 

--- a/Formula/ignition-msgs8.rb
+++ b/Formula/ignition-msgs8.rb
@@ -8,6 +8,13 @@ class IgnitionMsgs8 < Formula
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs8"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "eb93e1acbf617f9587534902dc7a580e5779856e66f2ff02c648bcea8e512e8f"
+    sha256 cellar: :any, arm64_sonoma:  "e1d082f048ad4595f11bf573665a054aa0495cb866e3075913a88147972ebfc6"
+    sha256 cellar: :any, sonoma:        "fe7f88660c1e3b580efb7c72c0136e4d4aa49cd75570f5eb1ce454023a4b2d99"
+  end
+
   depends_on "cmake"
   depends_on "ignition-cmake2"
   depends_on "ignition-math6"

--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -6,6 +6,13 @@ class IgnitionPhysics5 < Formula
   license "Apache-2.0"
   revision 26
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256               arm64_sequoia: "49eaa5748f6c9226582f55701bbee03c62ff5396971622c547cd1bbeff700215"
+    sha256               arm64_sonoma:  "af7036b4113c49ecf0fa0f50f592c7d90662c6818e6d0885c8b8fe4bc0d31e3a"
+    sha256 cellar: :any, sonoma:        "bee31b2a227cc07b27973178a9615208d5598d41475c8c7fcf37b28ef73b016f"
+  end
+
   # head "https://github.com/gazebosim/gz-physics.git", branch: "ign-physics5"
 
   depends_on "cmake" => :build

--- a/Formula/ignition-sensors6.rb
+++ b/Formula/ignition-sensors6.rb
@@ -8,6 +8,13 @@ class IgnitionSensors6 < Formula
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors6"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256               arm64_sequoia: "61c5fdcb50b2c720f40726e456b66cc2918a3cefbfad304ad24b7ffe5b3193cb"
+    sha256               arm64_sonoma:  "639891f392b402be33e4b9ccf24541f469edf554c820429ab02a0e2c27d8f234"
+    sha256 cellar: :any, sonoma:        "0d1110342cfd95d65e03d5fdf95b14e2493fb8b2526797751a50acc01ec16c27"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
 

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -9,6 +9,13 @@ class IgnitionTransport11 < Formula
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport11"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "70ef1fc953598b15e74fd7ce7b07da6812100d862bad0a979047903cd485cf2b"
+    sha256 arm64_sonoma:  "1637de081cc465b630d7a97832defbc12d9e7a04b802c077c6ee27feacd09ef2"
+    sha256 sonoma:        "9ced1a545cfd5ba531148dc8e08d553ca1e4a49dc5a58c1af3c69f722d5489e2"
+  end
+
   depends_on "doxygen" => [:build, :optional]
 
   depends_on "cmake"


### PR DESCRIPTION
Part of #3260.

Generated by https://build.osrfoundation.org/job/generic-release-homebrew_bump_unbottled_dependencies/22/.