### PR TITLE
gz-jetty: rebuild bottles broken by gdal

### DIFF
--- a/Formula/gz-common7.rb
+++ b/Formula/gz-common7.rb
@@ -8,6 +8,13 @@ class GzCommon7 < Formula
 
   head "https://github.com/gazebosim/gz-common.git", branch: "gz-common7"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "84b17d168f5a427901dc3fa492d12eeece8805678a07285b96b56bd3975dd269"
+    sha256 cellar: :any, arm64_sonoma:  "254c47ff16b83bf90454e42fe2840d0a18b1b174c9bcfb151f9991ce1f68d586"
+    sha256 cellar: :any, sonoma:        "081575a50cc3e66e833dd134ad2b976eeef5f8d5f78f749cad2e7b067c2c12ca"
+  end
+
   depends_on "assimp"
   depends_on "cmake"
   depends_on "ffmpeg"

--- a/Formula/gz-fuel-tools11.rb
+++ b/Formula/gz-fuel-tools11.rb
@@ -8,6 +8,13 @@ class GzFuelTools11 < Formula
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools11"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "0e671f805ba9ad22832a1ab773540303922cd395b2eca641453416a43b722669"
+    sha256 cellar: :any, arm64_sonoma:  "d7df0c38cedd8c31859844279c0b81e5ac6ebbc7600a02c3a3645ab8cac2177c"
+    sha256 cellar: :any, sonoma:        "eaa7c7d09cf0cca31ab8ba9b5c4f7da4f0db51ad23dbf98e92fd7d47f264d686"
+  end
+
   depends_on "abseil"
   depends_on "cmake"
   depends_on "gz-cmake5"

--- a/Formula/gz-gui10.rb
+++ b/Formula/gz-gui10.rb
@@ -8,6 +8,13 @@ class GzGui10 < Formula
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "8ad48f98603af20791702dbab06d2bf34a2b11103e387fc20ccb12c90ec1e111"
+    sha256 arm64_sonoma:  "c8b14e12c995ce8fa65fe6ef1a14f1d54f18b62c74cef8f8848c3442a014b02d"
+    sha256 sonoma:        "55bddaa35557752fe3d91c703ed6fdd35f8120a21afcdac7d0d878a19db5edd9"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
   depends_on "abseil"

--- a/Formula/gz-launch9.rb
+++ b/Formula/gz-launch9.rb
@@ -8,6 +8,13 @@ class GzLaunch9 < Formula
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "58f7f8c866a0374cad2293dda1e2e1442241ed9a87de29479d5b1d7385393d76"
+    sha256 arm64_sonoma:  "9975dc0e1afb29ff57303b04621d4ca1c7a5bea852ef5e0ba59788ce21f323e0"
+    sha256 sonoma:        "a9ce4bc51d2f200657fb3548f5f3e612ec7e0978627d10510b36c8bf65770302"
+  end
+
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
 

--- a/Formula/gz-physics9.rb
+++ b/Formula/gz-physics9.rb
@@ -8,6 +8,13 @@ class GzPhysics9 < Formula
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "8289698d9be59ff2353dd694e1fc604b8af23bbe0ab71b0ed1136307e6b97357"
+    sha256 arm64_sonoma:  "99fddbedcb0f97eaecfc8eb298476e1a509927c442c98b2d16c6fb9525b2f309"
+    sha256 sonoma:        "4756fd628f6876051d1d13f6f71835104b789ec38f2162a25dd0f88a0f3413c6"
+  end
+
   depends_on "cmake" => [:build, :test]
 
   depends_on "bullet"

--- a/Formula/gz-rendering10.rb
+++ b/Formula/gz-rendering10.rb
@@ -8,6 +8,13 @@ class GzRendering10 < Formula
 
   head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "ebce1a653c37037d5df39849b6014d9193d0401088506cf73cad0ede2e86b0cf"
+    sha256 arm64_sonoma:  "759e261bf196583eb339bc782078775de3813e2245a8bd03dfa6ffbeb71ebaee"
+    sha256 sonoma:        "1660832a33d84f0b987cad20d6613a803a1b39a0a2bc8507ac73b1cd12e101f3"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
 

--- a/Formula/gz-sensors10.rb
+++ b/Formula/gz-sensors10.rb
@@ -8,6 +8,13 @@ class GzSensors10 < Formula
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256               arm64_sequoia: "54ebb36223e20a45b7f5b65284d4a8b8b8345e7da00477b3990589866c318cb1"
+    sha256               arm64_sonoma:  "06da2bbfab53db71e04b96915b59fbad666048e38de61539e3937eaa5683c0f4"
+    sha256 cellar: :any, sonoma:        "3d0409590078f18984616c18e8e4d8a27170e43bd85c18881fc4d90a32080357"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
 

--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -8,6 +8,13 @@ class GzSim10 < Formula
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "f5f09e0754dba45cd91ea86e1a09a2dc81a5f0753fb60d97d6173a07bafc9538"
+    sha256 arm64_sonoma:  "40a385afcb0c339218abfd6b3e1ddf6cd1c86fad0557881cdda31923b5da1d30"
+    sha256 sonoma:        "4452e0859f1220128e39466761d356b6ae163a2710b3a1a87a7b3738a6f7a69e"
+  end
+
   depends_on "cmake" => :build
   depends_on "pybind11" => :build
   depends_on "python@3.14" => [:build, :test]


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/3247.

Generated by https://build.osrfoundation.org/job/generic-release-homebrew_bump_unbottled_dependencies/26/.