### PR TITLE
gz-ionic: rebuild bottles broken by gdal

### DIFF
--- a/Formula/gz-common6.rb
+++ b/Formula/gz-common6.rb
@@ -6,6 +6,13 @@ class GzCommon6 < Formula
   license "Apache-2.0"
   revision 2
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "43147be8fc4d5ebdb2f544748404010dae8ae44360e81d337670dc369893b2a9"
+    sha256 cellar: :any, arm64_sonoma:  "2076d622c5fc2fa327faf0241f150453731775ee7b5539481cff79bbdd2e0f9b"
+    sha256 cellar: :any, sonoma:        "bdbf706c78c0744ca9e897ee21ae1bef2756efb6a78dda627cc5010649ce1826"
+  end
+
   # head "https://github.com/gazebosim/gz-common.git", branch: "gz-common6"
 
   depends_on "assimp"

--- a/Formula/gz-fuel-tools10.rb
+++ b/Formula/gz-fuel-tools10.rb
@@ -8,6 +8,13 @@ class GzFuelTools10 < Formula
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "5c74b038c399b1dc3fb504e7b38bb24d6ec968ec414ba0b88183c18a139758c0"
+    sha256 cellar: :any, arm64_sonoma:  "816f83bab3c5910cd7222657c9ead0ebc1e548bff18dd839d77bf7ad44f4baf4"
+    sha256 cellar: :any, sonoma:        "140f2fc82e7c37a57bb6c064c06701944f4b35c41357490a7ee72a66b32374b7"
+  end
+
   depends_on "abseil"
   depends_on "cmake"
   depends_on "gz-cmake4"

--- a/Formula/gz-gui9.rb
+++ b/Formula/gz-gui9.rb
@@ -8,6 +8,13 @@ class GzGui9 < Formula
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "5e38bf9861cfa647939a7ed2dc4f14c0a1612a2c56b8a204cb3effb9bef1e1c1"
+    sha256 arm64_sonoma:  "f05a4a6207fbf0844285ecdf0bd2468fe65098490adf1874fd71bc1f2e01529a"
+    sha256 sonoma:        "c071429e9fda41140badfb724e3aedee4cbf4e4059d2c1b6509f706caa025479"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
   depends_on "abseil"

--- a/Formula/gz-launch8.rb
+++ b/Formula/gz-launch8.rb
@@ -6,6 +6,13 @@ class GzLaunch8 < Formula
   license "Apache-2.0"
   revision 5
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "9dc3cc267ea25c2266fe06ff48a8cf01f38c588135b05935504cd97c1f7a51e3"
+    sha256 arm64_sonoma:  "1f7913e88ac21a804ffc5e47ce581bac8890ea0767bb90afac5a94bc2383b973"
+    sha256 sonoma:        "2cd56eefdc50948274df4eb628086e95239d071b13d243c769b45cec402f30b1"
+  end
+
   # head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch8"
 
   depends_on "cmake" => :build

--- a/Formula/gz-physics8.rb
+++ b/Formula/gz-physics8.rb
@@ -6,6 +6,13 @@ class GzPhysics8 < Formula
   license "Apache-2.0"
   revision 7
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "6c6a73e3bb47a9dabcfb065c4dfb563b5d29d5c8b18e7cbb3e894719ab20ad3f"
+    sha256 arm64_sonoma:  "46880cf7310af66a424685250a4cbbecd563ca101235e00e30d66fc9cd1d319e"
+    sha256 sonoma:        "bfd3175b6cec7c9e541266dfdf971b664a9c5d1abb1b77e59cb6a92e25b3b58f"
+  end
+
   # head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics8"
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/gz-rendering9.rb
+++ b/Formula/gz-rendering9.rb
@@ -6,6 +6,13 @@ class GzRendering9 < Formula
   license "Apache-2.0"
   revision 2
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "016fff9ed8772b307d2460d3b17049f2e7fdfde0c7948fbb801001d32b30a8c6"
+    sha256 arm64_sonoma:  "e54e7e3d0f065e1e885a7e58e7ac68fcfdd94a5afd124eff78815b09ffd45709"
+    sha256 sonoma:        "b3a157a42b9bc02900525b7290b89ab09d4e31e44cb0ad41464d4e224e737ab4"
+  end
+
   # head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering9"
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/gz-sensors9.rb
+++ b/Formula/gz-sensors9.rb
@@ -8,6 +8,13 @@ class GzSensors9 < Formula
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256               arm64_sequoia: "cf14a95efa62016fc4ce3afc0d14f441cdc1bda63f80a9f3d06859a7d9acf1eb"
+    sha256               arm64_sonoma:  "981163fc03d6c53052a748c516e848807a794e3e9de732aeff79038a99e07e1f"
+    sha256 cellar: :any, sonoma:        "4a7b4152091a4c4cb967b3826519f309de12d752d62cea9eaa066327665720f3"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
 

--- a/Formula/gz-sim9.rb
+++ b/Formula/gz-sim9.rb
@@ -6,6 +6,13 @@ class GzSim9 < Formula
   license "Apache-2.0"
   revision 4
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "265baa8e0c4d2849c438ce56a290a997f6133243ce1aba19a057a0d6d6efc176"
+    sha256 arm64_sonoma:  "34dc3a7dfc034ba5f364e014a5f3a1a9753bd7787f4b083b8132acdc5eda1726"
+    sha256 sonoma:        "e88f911001c3a702b3c9c295de64a5e17171ea4f0e985ffccc45a60b79306b20"
+  end
+
   # head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim9"
 
   depends_on "cmake" => :build


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/3247.

Generated by https://build.osrfoundation.org/job/generic-release-homebrew_bump_unbottled_dependencies/27.