### PR TITLE
gz-harmonic: rebuild bottles broken by gdal

### DIFF
--- a/Formula/gz-common5.rb
+++ b/Formula/gz-common5.rb
@@ -6,6 +6,13 @@ class GzCommon5 < Formula
   license "Apache-2.0"
   revision 14
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "088f0079aa27eff2026777c92fffb5a58f844e96ae9f3d9927cd6e3324982be6"
+    sha256 cellar: :any, arm64_sonoma:  "0fdeafeda872b140fce178a6a552cd28d005c9ff84abd35c5c0dd4515940fad7"
+    sha256 cellar: :any, sonoma:        "66016b23e6a385d4bb923998973ccadab546d6335103df2bf2d23d8051fcffc2"
+  end
+
   # head "https://github.com/gazebosim/gz-common.git", branch: "gz-common5"
 
   depends_on "assimp"

--- a/Formula/gz-fuel-tools9.rb
+++ b/Formula/gz-fuel-tools9.rb
@@ -8,6 +8,13 @@ class GzFuelTools9 < Formula
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "230871fcc65c271a457e9ef7b009466c06d9cb5101d521735b0d0b6b9190d04c"
+    sha256 cellar: :any, arm64_sonoma:  "f4b7f2d4822d4352ce4facd59f8b7527f1a5e041c9d1160f2db9949cc1d532fa"
+    sha256 cellar: :any, sonoma:        "54821269ae45df2c0dd15d2858dd0ac4b1d8820c9805a0a128a81e0363fe3130"
+  end
+
   depends_on "abseil"
   depends_on "cmake"
   depends_on "gz-cmake3"

--- a/Formula/gz-gui8.rb
+++ b/Formula/gz-gui8.rb
@@ -8,6 +8,13 @@ class GzGui8 < Formula
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui8"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "87c7510fce937fd21e71ac39bbf28923f0c0741ba13057b5af1df73a5d023475"
+    sha256 arm64_sonoma:  "b7e88411f90bf122256782f58728c0e69b329085367f3d2449dadb0bb7c5d51f"
+    sha256 sonoma:        "551b12b9ecf340f37c649738271bdeef7beead7d64fd9fb96bb93a58c274bfe1"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
   depends_on "abseil"

--- a/Formula/gz-launch7.rb
+++ b/Formula/gz-launch7.rb
@@ -8,6 +8,13 @@ class GzLaunch7 < Formula
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch7"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "76f0497392b672ef76737b1fc7113208e5f175d866241948c804a9ce8ab2de84"
+    sha256 arm64_sonoma:  "e7ff6af6b0d2c2e2a85f3cc94d9938e4035941cde93032666d642001a1dbf94c"
+    sha256 sonoma:        "228d1d3c6119d4237ac7ee7115df8bb2d10ecbd46632eb9bcad42016b7f210ac"
+  end
+
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
 

--- a/Formula/gz-msgs10.rb
+++ b/Formula/gz-msgs10.rb
@@ -6,6 +6,13 @@ class GzMsgs10 < Formula
   license "Apache-2.0"
   revision 18
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "5fb9cd87704112eda4fb91b59a44a885504190d1b478a5a6ca74110a0d7046ae"
+    sha256 arm64_sonoma:  "670bcc5eb5b04c43ec5a7c3c745df23603bc479976cce8acc88df68c12b17a84"
+    sha256 sonoma:        "817e48cb2181071696936e9eea022dfa56a6356eca67d81a4b901a31e8565784"
+  end
+
   # head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs10"
 
   depends_on "python@3.12" => [:build, :test]

--- a/Formula/gz-physics7.rb
+++ b/Formula/gz-physics7.rb
@@ -6,6 +6,13 @@ class GzPhysics7 < Formula
   license "Apache-2.0"
   revision 4
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "b23098580565a46f15dbb4efe3a7563cbb23a21f57f66c864e8957dbedbd59c6"
+    sha256 arm64_sonoma:  "5b851649cb35d6ff6c59c6f3b5dea0e6a6f588df0c83bd90f518ea835c87a56f"
+    sha256 sonoma:        "5fa12dc36b667dbd3b50933a2de161165ad4854f16485c9dbc85b6eef80aa268"
+  end
+
   # head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics7"
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/gz-rendering8.rb
+++ b/Formula/gz-rendering8.rb
@@ -6,6 +6,13 @@ class GzRendering8 < Formula
   license "Apache-2.0"
   revision 2
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "0d82f4ca19c29b3ba71d8e94da51e74a47a1caf432c8337b21d75ad57adce4a6"
+    sha256 arm64_sonoma:  "0e3971833b7b081a3ef4512d951c6223c20aa6d104a81f6ba5734cfce534821b"
+    sha256 sonoma:        "3387d59070daebc748f7412fb5f8c15ba16a5ee6cc31a0e2b4564d407dde57cb"
+  end
+
   # head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering8"
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/gz-sensors8.rb
+++ b/Formula/gz-sensors8.rb
@@ -8,6 +8,13 @@ class GzSensors8 < Formula
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors8"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256               arm64_sequoia: "9977f1cdbc57ac9927a0f88b7a0dafd888675a0c877410b0fa2c054ec36d6853"
+    sha256               arm64_sonoma:  "545466291e48f24d43bd1f0310e1121ae975673c95d19108eb323b29c5a993a4"
+    sha256 cellar: :any, sonoma:        "4e60c6646b93e91e4e8464feb32c77f98166cdcbec1adb6ca2df7d9cfb465afc"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
 

--- a/Formula/gz-sim8.rb
+++ b/Formula/gz-sim8.rb
@@ -8,6 +8,13 @@ class GzSim8 < Formula
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim8"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "280ef94b5f00521ff30393a9c684f6804a96890e82468a7495f65d234163a829"
+    sha256 arm64_sonoma:  "da884e02cf529ce5679584424053be85e743bdf894bec86d9e297066e1f0e4aa"
+    sha256 sonoma:        "6843b4c802c1def703934d56ee4b9897eb37c0f116843444982b9fe722dca7f4"
+  end
+
   depends_on "cmake" => :build
   depends_on "pybind11" => :build
   depends_on "python@3.14" => [:build, :test]

--- a/Formula/gz-transport13.rb
+++ b/Formula/gz-transport13.rb
@@ -8,6 +8,13 @@ class GzTransport13 < Formula
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport13"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "94fae4831c414445bd1f4e379fcedbf674214ad0e50e6b94e4b8a6b9d9c98c99"
+    sha256 arm64_sonoma:  "2c60fe27fab94c306a5678d4e07c79849a2652d5b26d91891222334c19135afc"
+    sha256 sonoma:        "ed8254f9cf3e46c2d421b1f79e00908cbb80be2986b717a1efe73fd8c9405db1"
+  end
+
   depends_on "doxygen" => [:build, :optional]
   depends_on "pybind11" => :build
   depends_on "python@3.12" => [:build, :test]


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/3247.

Generated by https://build.osrfoundation.org/job/generic-release-homebrew_bump_unbottled_dependencies/28.