### PR TITLE
gz-jetty: rebuild bottles for libwebsockets

### DIFF
--- a/Formula/gz-launch9.rb
+++ b/Formula/gz-launch9.rb
@@ -8,6 +8,13 @@ class GzLaunch9 < Formula
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "671f4546cced009cd9023ee9b01fc0df6ced5ffbdedf91c342f377d17052fdef"
+    sha256 arm64_sonoma:  "e7bb532d87b6947f0da602e80d0e3428246ff5e3af40de916f67c154e570245f"
+    sha256 sonoma:        "9cc2cf2126af04d282c1984dbcbe4f11bf385a4a4019ed72e9b48fa13f4c5b78"
+  end
+
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
 

--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -8,6 +8,13 @@ class GzSim10 < Formula
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "f8ab4ad04eb89374f1b8554d1d2a9893e3c7caf2869514533f0119f8f9011abe"
+    sha256 arm64_sonoma:  "d2a0c69dd46d4e415ac8f237fc80278f6e42b32e4696c87bbc501e5448f6baa9"
+    sha256 sonoma:        "ef3b62ff894b803b51267b6d1ff325fa84e85d0e4862fd7a18ac857a5da56356"
+  end
+
   depends_on "cmake" => :build
   depends_on "pybind11" => :build
   depends_on "python@3.14" => [:build, :test]


### PR DESCRIPTION
Part of #3270.

Generated by https://build.osrfoundation.org/job/generic-release-homebrew_bump_unbottled_dependencies/30/