### PR TITLE
Jetty: rebuild for protobuf 33.2

### DIFF
--- a/Formula/gz-fuel-tools11.rb
+++ b/Formula/gz-fuel-tools11.rb
@@ -8,6 +8,13 @@ class GzFuelTools11 < Formula
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools11"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "a6e6258007a655c9ce01b732977504f31407a8d115d9880881f78318abb35160"
+    sha256 cellar: :any, arm64_sonoma:  "744c07ac2210716a90ffae7826e1dafef3a86707295fd6dcc715481cb2c545c8"
+    sha256 cellar: :any, sonoma:        "2e02372f44a24985234abbc44acee586ee854d19f15d90ec024f5d0468583393"
+  end
+
   depends_on "abseil"
   depends_on "cmake"
   depends_on "gz-cmake5"

--- a/Formula/gz-gui10.rb
+++ b/Formula/gz-gui10.rb
@@ -8,6 +8,13 @@ class GzGui10 < Formula
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "aad11df853a8ca5b718a11a2109bf8081ba0a9ccbf7e8d9436b7ce03b11d5f78"
+    sha256 arm64_sonoma:  "9e3ea19e578331522b54810b5a53f6484895989e23af4f5d6d1727147286c574"
+    sha256 sonoma:        "d3bb18de8d07c038400af4929781181e3ef6ebbc144a850ea62551712d54c7fe"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
   depends_on "abseil"

--- a/Formula/gz-launch9.rb
+++ b/Formula/gz-launch9.rb
@@ -8,6 +8,13 @@ class GzLaunch9 < Formula
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "fb01af1b0bca42be2334492b514fab0fbf630e0f7e8dec44d4eadf7499cde76c"
+    sha256 arm64_sonoma:  "8afa46df4d31911424abbf1f00365e4ffb33bf8b5036e888e2024f548b071741"
+    sha256 sonoma:        "78df45151cd298d2caad3b25dd35d59724eaeebb0eb5d2dd17cdaa4bb83f49fa"
+  end
+
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
 

--- a/Formula/gz-msgs12.rb
+++ b/Formula/gz-msgs12.rb
@@ -8,6 +8,13 @@ class GzMsgs12 < Formula
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs12"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "1501aba1b7442b4030b9e8bf6c429ae95ebc4e9014b06fcb50fd07e64f49028e"
+    sha256 arm64_sonoma:  "59f4a89f51ac2fbc7ef7b5f8fc09c5e257d16b1c6b832fb8e35d4206c52900ae"
+    sha256 sonoma:        "0197760c5ba850e79ddedc1881f81b149d24f10f5d43b0dcf3e357beae95e2a7"
+  end
+
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
   depends_on "python@3.14" => [:build, :test]

--- a/Formula/gz-sensors10.rb
+++ b/Formula/gz-sensors10.rb
@@ -8,6 +8,13 @@ class GzSensors10 < Formula
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256               arm64_sequoia: "a63e4ec6caa8fa56ec6e5b73d187c217ef5beef34518bd9fb2b84d12a4f716a9"
+    sha256               arm64_sonoma:  "419b450e930cafe0ca967b3a7eb12dd1bf64583f0cde48b6603ded923706776c"
+    sha256 cellar: :any, sonoma:        "eede94fa31c90c29479817a8daed6acca10c4c10f2fd093a2ae6288aaccc7aeb"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
 

--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -8,6 +8,13 @@ class GzSim10 < Formula
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "da6daf60a99e45d4713196c791ed24802826974b9aab3ad61db1d29bc661222b"
+    sha256 arm64_sonoma:  "bcf5d804ec137153da838b871d6de22e1ab38fcc12a98bdf0cca92e3846a8925"
+    sha256 sonoma:        "1af128056ddf67becafbe680f6b37e145ecee5b256b8ba4f74121d89266aeb43"
+  end
+
   depends_on "cmake" => :build
   depends_on "pybind11" => :build
   depends_on "python@3.14" => [:build, :test]

--- a/Formula/gz-transport15.rb
+++ b/Formula/gz-transport15.rb
@@ -8,6 +8,13 @@ class GzTransport15 < Formula
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport15"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "f011a8e649601b7da5730af63767764a2480ad2bc0d5b58ba6bec9611ab5ac9a"
+    sha256 arm64_sonoma:  "2ff863aa6d44e7dbce6a5f746b736ba514591c7cb99ececb2b42aa01ec21f093"
+    sha256 sonoma:        "451150ac68976deec707ad71385ab30bef6cd5764701e3d02226ec351a2b5223"
+  end
+
   depends_on "doxygen" => [:build, :optional]
   depends_on "pybind11" => :build
   depends_on "python@3.12" => [:build, :test]


### PR DESCRIPTION
Part of #3274.

Generated by https://build.osrfoundation.org/job/generic-release-homebrew_bump_unbottled_dependencies/31/