### PR TITLE
Jetty: rebuild for spdlog 1.17

### DIFF
--- a/Formula/gz-common7.rb
+++ b/Formula/gz-common7.rb
@@ -8,6 +8,13 @@ class GzCommon7 < Formula
 
   head "https://github.com/gazebosim/gz-common.git", branch: "gz-common7"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "12dbb0c650582941654e129ee9a7e9ab49447a3fe422a7fcfe00dbbe0fb265f6"
+    sha256 cellar: :any, arm64_sonoma:  "c10d59f53982403c5426d8ce47ad079ed1df5f7dd2062345cd83f17d929818c7"
+    sha256 cellar: :any, sonoma:        "f39eff780780c9d9c179cb226cc1e786399b55843a2f646666897501395612ed"
+  end
+
   depends_on "assimp"
   depends_on "cmake"
   depends_on "ffmpeg"

--- a/Formula/gz-fuel-tools11.rb
+++ b/Formula/gz-fuel-tools11.rb
@@ -8,6 +8,13 @@ class GzFuelTools11 < Formula
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools11"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "76944b8a592cff94e1b576888cf07fb3426a8bff8b129c2c6edf9a73a03f3d83"
+    sha256 cellar: :any, arm64_sonoma:  "71c2e0dfa8de5f825a6616d0b3ecaa1fc9f65379f9f8705a60c77b51d71a89c3"
+    sha256 cellar: :any, sonoma:        "185e5c7a7dc281fb888b68c6028db31228c132100d75822f24703b17859902b2"
+  end
+
   depends_on "abseil"
   depends_on "cmake"
   depends_on "gz-cmake5"

--- a/Formula/gz-gui10.rb
+++ b/Formula/gz-gui10.rb
@@ -8,6 +8,13 @@ class GzGui10 < Formula
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "7325ad75006e8cd6a567c625d6c9f103876be892eab0ca7e116a5521c36d90d8"
+    sha256 arm64_sonoma:  "f4297e2d91bc765f98abd60da686ac7641d244e47f6bd60167a756bd6526805c"
+    sha256 sonoma:        "fb7abe124ed47be18f93bdb8edcb592eb5393a0dd35231fb4d96b4958f2facf8"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
   depends_on "abseil"

--- a/Formula/gz-launch9.rb
+++ b/Formula/gz-launch9.rb
@@ -8,6 +8,13 @@ class GzLaunch9 < Formula
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "2d5ce12c5244ce940b1be0f9c6b80ade26dbbbc166d51d429936a4a9bc1d86f2"
+    sha256 arm64_sonoma:  "deb27bda8c672b18af3b36e22d8ccaffe4cc6433c7ea8578984250dd54d0e6bc"
+    sha256 sonoma:        "7f822e2c81bda97f6e776db3bd9929388e0cd75f2292d7ba2f4f732be9217688"
+  end
+
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
 

--- a/Formula/gz-math9.rb
+++ b/Formula/gz-math9.rb
@@ -8,6 +8,13 @@ class GzMath9 < Formula
 
   head "https://github.com/gazebosim/gz-math.git", branch: "gz-math9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "452381681a3a9c305da870eed2020c6fd1672ade705f8d438aec21812082a4dd"
+    sha256 cellar: :any, arm64_sonoma:  "714859110c105b842387e0e8f0686ea2caa8c0be450375a41647c2d53ff9dd19"
+    sha256 cellar: :any, sonoma:        "dcffc4b518f02615dbf17f8e78ad31e9256c8fec8e78268927a8527ed49aa198"
+  end
+
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
   depends_on "pybind11" => :build

--- a/Formula/gz-msgs12.rb
+++ b/Formula/gz-msgs12.rb
@@ -8,6 +8,13 @@ class GzMsgs12 < Formula
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs12"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "4552846150afc4830a813c1f2b54fabdd778c0cb906ee0647aa58bf5414460d6"
+    sha256 arm64_sonoma:  "04c58757357d2aad5c465db11bcd152fb2a328079bf77c1594bafd13fd0dfa1a"
+    sha256 sonoma:        "9f7bf53b35651d85f67ee81abab3f5c91d246d791d2a6bc4ac12c978d9929126"
+  end
+
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
   depends_on "python@3.14" => [:build, :test]

--- a/Formula/gz-physics9.rb
+++ b/Formula/gz-physics9.rb
@@ -8,6 +8,13 @@ class GzPhysics9 < Formula
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "f5cfd4462187ffe5f66aff98f14730ff697eae0478f23dbe7bb397a05cf9d47d"
+    sha256 arm64_sonoma:  "86a39c28dbe4ef6f12e0fedd9f9297718f4e84a388136dfe6508d9d02127ae1e"
+    sha256 sonoma:        "354e948061558affc08188d9d966ada4ec1477a4ddbda614325d39465150cab5"
+  end
+
   depends_on "cmake" => [:build, :test]
 
   depends_on "bullet"

--- a/Formula/gz-plugin4.rb
+++ b/Formula/gz-plugin4.rb
@@ -8,6 +8,13 @@ class GzPlugin4 < Formula
 
   head "https://github.com/gazebosim/gz-plugin.git", branch: "gz-plugin4"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "ec78a2746df21ea90531f623711f2dcb4d389f98ed6e331076d5dd00b391607b"
+    sha256 cellar: :any, arm64_sonoma:  "4bf407ef568a0401e99f1af52a819fffc1dc5e103ea1ac998084b05f8a88ae6c"
+    sha256 cellar: :any, sonoma:        "e56af85ca12bcafff45e7bf216e979044a79ddd78591e5a6a60c7223ae033dd2"
+  end
+
   depends_on "cmake"
   depends_on "gz-cmake5"
   depends_on "gz-tools2"

--- a/Formula/gz-rendering10.rb
+++ b/Formula/gz-rendering10.rb
@@ -8,6 +8,13 @@ class GzRendering10 < Formula
 
   head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "84a1b1bbf3d1f8c3e070ec1198274c8dce304f0e08c2099c8ccf3926f1baa34f"
+    sha256 arm64_sonoma:  "d65e7c505969aa1fd485b35a1a9f7ae3e01745e5ef8418064e16778c058e0315"
+    sha256 sonoma:        "9ad23415f455e2cc31a6c41ef68b49cdac28f1d0424eaf8fd37dbb944f6bd9b6"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
 

--- a/Formula/gz-sensors10.rb
+++ b/Formula/gz-sensors10.rb
@@ -8,6 +8,13 @@ class GzSensors10 < Formula
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256               arm64_sequoia: "e70003b52c648f7169752daf4e5b88d0e1709feaa0abf17793dcd61467945c4b"
+    sha256               arm64_sonoma:  "b28af7a2a85e0d7592ab526f933bea1c98cb183bab6e343ed6a08c34d732cc0e"
+    sha256 cellar: :any, sonoma:        "b1dc1e90c308d9a2d13d801ac40df5e5195984d40c8cd923016c3873c1043957"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
 

--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -8,6 +8,13 @@ class GzSim10 < Formula
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "b3c0e6ab18930e91def650d495860cccecb658720b0416bbc2a5c54174ecdd5a"
+    sha256 arm64_sonoma:  "2f63910b335cded0fc4af62f38c6a717c3890a3cda62027b6a144acc9bc35fd6"
+    sha256 sonoma:        "bfff6721d6b1da5c005f478eca05109cb53dff87968f0ab2c78b7560020d2a4e"
+  end
+
   depends_on "cmake" => :build
   depends_on "pybind11" => :build
   depends_on "python@3.14" => [:build, :test]

--- a/Formula/gz-transport15.rb
+++ b/Formula/gz-transport15.rb
@@ -8,6 +8,13 @@ class GzTransport15 < Formula
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport15"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "dcfd959d5556cf0a9d66e59ae391dcf4140aecbbc2b81ac3edca65cf70dcce00"
+    sha256 arm64_sonoma:  "591e0743579a277c98ae4b38f02485ac7e6045f73be529be7b1ab28ac392aa27"
+    sha256 sonoma:        "bd994ff22863437bceac7f352ba95ad72ac632feaced7e23ca4dda7d71fa6ee8"
+  end
+
   depends_on "doxygen" => [:build, :optional]
   depends_on "pybind11" => :build
   depends_on "python@3.12" => [:build, :test]

--- a/Formula/gz-utils4.rb
+++ b/Formula/gz-utils4.rb
@@ -6,6 +6,13 @@ class GzUtils4 < Formula
   license "Apache-2.0"
   revision 6
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "adbc01e0b9c92f40a1d6fea0a90bb8d9fe0b752644a3087193834da0fe2ec1d2"
+    sha256 cellar: :any, arm64_sonoma:  "357ab3a6e5377ae91df8db43b3c97dd30a1d6d5ce8a0647da303f3ac2d7f5b65"
+    sha256 cellar: :any, sonoma:        "366af92c63811abb1dbfd9aebe7698b4ead764a7e878d18c3e256dfc6518c350"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
   depends_on "cli11"

--- a/Formula/sdformat16.rb
+++ b/Formula/sdformat16.rb
@@ -8,6 +8,13 @@ class Sdformat16 < Formula
 
   head "https://github.com/gazebosim/sdformat.git", branch: "sdf16"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "269b994f82293af246f0e10d59257681c2fd263edb4a030d174c3172babf01f6"
+    sha256 arm64_sonoma:  "f1e82520c1f05e0983ced0eeab2cea05bb5ac63b0273b6335c06be2a37841911"
+    sha256 sonoma:        "5a695eb9f603eafe1fd204ea7d70c64db644d0e24bdaa2667008daadaa8a4093"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
   depends_on "pybind11" => :build


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/3291.

Generated by https://build.osrfoundation.org/job/generic-release-homebrew_bump_unbottled_dependencies/35/