### PR TITLE
Jetty: rebuild for protobuf 33.4

### DIFF
--- a/Formula/gz-fuel-tools11.rb
+++ b/Formula/gz-fuel-tools11.rb
@@ -8,6 +8,13 @@ class GzFuelTools11 < Formula
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools11"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "e01a33e6535b1285d77d850277043d08894c8d3816091a3a8f6fa8f9eebcb887"
+    sha256 cellar: :any, arm64_sonoma:  "67177ee6ee16790871b1c5e462e3418fe8a40e9f3fb56738fda3cd19b564a4d9"
+    sha256 cellar: :any, sonoma:        "e9825d1823106461a9ee0fe150a4bf5a3336fc8e683bac9ac0676b95595ea7e8"
+  end
+
   depends_on "abseil"
   depends_on "cmake"
   depends_on "fmt"

--- a/Formula/gz-gui10.rb
+++ b/Formula/gz-gui10.rb
@@ -8,6 +8,13 @@ class GzGui10 < Formula
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "69202f1f98e54ee976c5501e9fc6cc62792ea0535aa9820e4c0bd6cb20bad47c"
+    sha256 arm64_sonoma:  "67c24f996509dbd609151043530f045ce76137ce07ee3baaeef439139331c908"
+    sha256 sonoma:        "2c538a6d314c374e3416790699320d0e264ad69a4b0b209820ca0e22279ffb7d"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
   depends_on "abseil"

--- a/Formula/gz-sensors10.rb
+++ b/Formula/gz-sensors10.rb
@@ -8,6 +8,13 @@ class GzSensors10 < Formula
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256               arm64_sequoia: "c1368616af172c25bffc6b64a68c95530e153625f59057cc04835255f045e574"
+    sha256               arm64_sonoma:  "a3bb902e5c81c4bbfa5c2e486b5b83c8fd8a83b2b7af59dafc3b523eb1bff291"
+    sha256 cellar: :any, sonoma:        "dd95432462dbd28c21dba00b03313403463ec1cc224b4b47a3e48e704c292999"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
 

--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -8,6 +8,13 @@ class GzSim10 < Formula
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "00e3e8f96219c1c232173193d8f87ea2019ac74e23a26b67d9b9d444bfd0f18a"
+    sha256 arm64_sonoma:  "45e0cf66ad20ddfad60ef1b2481096d717e58555bdea869d693196a45e3cf9eb"
+    sha256 sonoma:        "3847dbd27458e5afdd13cac295339752bd8fd79c1eabfcfddd0cf9a3f5a6b2e3"
+  end
+
   depends_on "cmake" => :build
   depends_on "pybind11" => :build
   depends_on "abseil"


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/3296.

Generated by https://build.osrfoundation.org/job/generic-release-homebrew_bump_unbottled_dependencies/37/