### PR TITLE
gz-jetty-ogre2.3: alias to ogre2.3

### DIFF
--- a/Aliases/gz-jetty-ogre2.3
+++ b/Aliases/gz-jetty-ogre2.3
@@ -1,0 +1,1 @@
+../Formula/ogre2.3.rb


### PR DESCRIPTION
Complement to gz-rotary-ogre2.3-vendor that helps with the tips for linking and unlinking Gazebo formulae in #3406.