### PR TITLE
gz-rotary: manually install README

### DIFF
--- a/Formula/gz-rotary.rb
+++ b/Formula/gz-rotary.rb
@@ -26,7 +26,10 @@ class GzRotary < Formula
   def install
     mkdir "build" do
       system "cmake", "..", *std_cmake_args
+      # this won't install anything, but test that it doesn't fail
       system "make", "install"
+      # manually install README so brew doesn't complain about empty installation
+      (share/"gz/gz-rotary").install "../README.md"
     end
   end
 
@@ -37,6 +40,7 @@ class GzRotary < Formula
   end
 
   test do
+    assert_path_exists share/"gz/gz-rotary/README.md"
     system "gz", "sim", "--versions"
   end
 end


### PR DESCRIPTION
Manually install a file so that `make install` can be a no-op for the upstream package.

Needed by https://github.com/gazebosim/gz-rotary/pull/3

## testing with gz-rotary `main`

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_rotary-install_formula-homebrew-arm64&build=15)](https://build.osrfoundation.org/job/gz_rotary-install_formula-homebrew-arm64/15/) https://build.osrfoundation.org/job/gz_rotary-install_formula-homebrew-arm64/15/