### PR TITLE
Remove bottles broken by urdfdom 6.0

### DIFF
--- a/Formula/sdformat12.rb
+++ b/Formula/sdformat12.rb
@@ -4,14 +4,7 @@ class Sdformat12 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-12.9.0.tar.bz2"
   sha256 "4c546c106265fecc5600de56ce1e979c73e1068d3d89022de1672084db2d5a22"
   license "Apache-2.0"
-  revision 2
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "264febc7c88b2281d1b2e9e69375faa9e7127b3929e8acec5584a3583c18c0f4"
-    sha256 arm64_sonoma:  "5e722a31aa2d514acf9f55648101083338503639c7965ec69c11e97c2970afe6"
-    sha256 sonoma:        "60628c8224329a93b0cabf96ff445291eb5f3c0fdb636f44b8d7ab0b8d30f7a8"
-  end
+  revision 3
 
   # head "https://github.com/gazebosim/sdformat.git", branch: "sdf12"
 

--- a/Formula/sdformat14.rb
+++ b/Formula/sdformat14.rb
@@ -4,14 +4,7 @@ class Sdformat14 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-14.9.0.tar.bz2"
   sha256 "7b9c49bcb9f10ba7e84b575497f64f63e7fddf32f573c3644c55575604fecd0f"
   license "Apache-2.0"
-  revision 2
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "06b4f47752dcae94f4fdbe442ce5512bc7d7a606a94d50a1560f2bfd2174e243"
-    sha256 arm64_sonoma:  "01874630d42196d405eac19d54cd6aa26bab79a1d928dbf88ec66f2a1e577934"
-    sha256 sonoma:        "3fb3e7311266f7a68940d7e560af5abcf54f8d95d0fe1b9dc000d828dbed53bf"
-  end
+  revision 3
 
   # head "https://github.com/gazebosim/sdformat.git", branch: "main"
 

--- a/Formula/sdformat15.rb
+++ b/Formula/sdformat15.rb
@@ -4,14 +4,7 @@ class Sdformat15 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-15.4.0.tar.bz2"
   sha256 "22b9825201bfd7c0c7ecc60995efca90bf05aeaddcc308ae5180746a08cd0b90"
   license "Apache-2.0"
-  revision 2
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "1fb89218d9f12f16e46260a3aab12fcc1dd6a626806a42a6276cd21510366bb1"
-    sha256 arm64_sonoma:  "f935885c117730e93a1343990dce80ccb38fd7aa625504ae22dafa4741b9cb7c"
-    sha256 sonoma:        "57ddcaf4389c1bdfb4cf5472b3d00e6ffd3462fa94f096926ac359df5ed6b11f"
-  end
+  revision 3
 
   # head "https://github.com/gazebosim/sdformat.git", branch: "sdf15"
 

--- a/Formula/sdformat16.rb
+++ b/Formula/sdformat16.rb
@@ -4,16 +4,9 @@ class Sdformat16 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-16.0.1.tar.bz2"
   sha256 "e39b8228f93b660344d532e5b4cf3b6b3b7f58bfafd86d174b4c632c000575ab"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/sdformat.git", branch: "sdf16"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "2a1c4626fe406349a2d618032fd482997607ae6204e05482b18cac2addc05275"
-    sha256 arm64_sonoma:  "1da316a7d49598594bbbb34358eb153d6a3794786228734da2b06f21d7893afb"
-    sha256 sonoma:        "579c01b7e2597b7dac4df349466e50d17ed5162dc048210c8615cc77523af0f4"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/3413.

Generated by https://build.osrfoundation.org/job/generic-release-homebrew_remove_dependent_bottles/25/