### PR TITLE
Jetty: rebuild for jsoncpp 1.9.7

### DIFF
--- a/Formula/gz-fuel-tools11.rb
+++ b/Formula/gz-fuel-tools11.rb
@@ -8,6 +8,13 @@ class GzFuelTools11 < Formula
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools11"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "5ed9991b16dca288688e9c6e8c3cff80610d39c82f100e20ae9c37c8f3ee1520"
+    sha256 cellar: :any, arm64_sonoma:  "2bfa8a066877f9c14014b3c93d518cc2cdba0b2b29940b96b35392e8646c3376"
+    sha256 cellar: :any, sonoma:        "0da429ee00638037bc8474d9f5c909b861ac133e400c8c1fdc43ad3041184086"
+  end
+
   depends_on "abseil"
   depends_on "cmake"
   depends_on "fmt"

--- a/Formula/gz-fuel-tools11.rb
+++ b/Formula/gz-fuel-tools11.rb
@@ -4,7 +4,7 @@ class GzFuelTools11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-11.0.0.tar.bz2"
   sha256 "4b4dee9b5a2e8cf04f1000e568187a65dd379bf54f8acf16d4e31a29240b30f0"
   license "Apache-2.0"
-  revision 21
+  revision 22
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools11"
 

--- a/Formula/gz-launch9.rb
+++ b/Formula/gz-launch9.rb
@@ -8,6 +8,13 @@ class GzLaunch9 < Formula
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "00d55b68072aca2b4cb1450fcadadb6a5ed7510a47d6d07b002efdab908582f3"
+    sha256 arm64_sonoma:  "97e16d8a76070b0530bf87c8991327605312c3b090d162b984f6ddaed6130fea"
+    sha256 sonoma:        "9324b66cea585a8ffc0d708b851d14ef1b7a20d836e40fc56dbf7aa79ca1c5e6"
+  end
+
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
 

--- a/Formula/gz-launch9.rb
+++ b/Formula/gz-launch9.rb
@@ -4,7 +4,7 @@ class GzLaunch9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-9.0.0.tar.bz2"
   sha256 "7d8452a98aaf3d9f6f8d417178e52347b8c3505edca38d4525ab1ceb314c25a6"
   license "Apache-2.0"
-  revision 24
+  revision 25
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch9"
 

--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -4,7 +4,7 @@ class GzSim10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-10.2.0.tar.bz2"
   sha256 "9621541f8fcd29a50f677c0fe5f7e3cd9ed2f005dd2bb64df75c87073a0e5203"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim10"
 

--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -8,6 +8,13 @@ class GzSim10 < Formula
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "c9530049031bda518621fc6a24bf0c2579049f5a17556a60ce1d55e4b9dc65f3"
+    sha256 arm64_sonoma:  "1a103849c9d217c6670b2c7273372fb3c2658375c2edc1ebd68e841684eb20c9"
+    sha256 sonoma:        "c79d7acf99eb65630e25c3812dac8e9a12ef0e0b24b0e1966ace89c92cbc07fe"
+  end
+
   depends_on "cmake" => :build
   depends_on "pybind11" => :build
   depends_on "abseil"


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/3426.

Generated by https://build.osrfoundation.org/job/generic-release-homebrew_bump_unbottled_dependencies/62/