### PR TITLE
Fortress: rebuild for jsoncpp 1.9.7

### DIFF
--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -4,7 +4,7 @@ class IgnitionFuelTools7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/ignition-fuel_tools-7.3.1.tar.bz2"
   sha256 "b8224c574406147ae008ed9a0ac459f1e2582f6aaef7ba44e1fd1c5ac97b6de8"
   license "Apache-2.0"
-  revision 39
+  revision 40
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools7"
 

--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -8,6 +8,13 @@ class IgnitionFuelTools7 < Formula
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools7"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "ac1deb979d0f30621e825c585e4f557a1e02a831deaab3fa271e403e1d3333f5"
+    sha256 cellar: :any, arm64_sonoma:  "f3f1605d9d2581829503a6aec7ee438542d9a4cedd9255cd55ff4940c4ee6e74"
+    sha256 cellar: :any, sonoma:        "08cbc1ade9cac70616c29470aa13c07ba0cf6b050d85eee1e2982d5f03027f91"
+  end
+
   depends_on "abseil"
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -4,7 +4,7 @@ class IgnitionGazebo6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/ignition-gazebo-6.17.1.tar.bz2"
   sha256 "30001eff50b175565e5d10df5a6ad3dab8638f3c2ea53e365ac264bc33f6b04d"
   license "Apache-2.0"
-  revision 7
+  revision 8
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo6"
 

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -8,6 +8,13 @@ class IgnitionGazebo6 < Formula
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo6"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "be53de3bc400f49bb5c2a8d456966be8700c3452a075b4aad78a85af3d77a487"
+    sha256 arm64_sonoma:  "d851be272ddd1ef8a9861fc4b8ad9dda9041fba9462e8b1de55d0c81f1b2697a"
+    sha256 sonoma:        "c29202d42a7c225bcc3a81a10726cb63188f7373786fd4a53c0fcdec69541e45"
+  end
+
   depends_on "cmake" => :build
   depends_on "pybind11" => :build
   depends_on "gz-plugin2" => :test

--- a/Formula/ignition-launch5.rb
+++ b/Formula/ignition-launch5.rb
@@ -4,7 +4,7 @@ class IgnitionLaunch5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/ign-launch/releases/ignition-launch5-5.3.0.tar.bz2"
   sha256 "84d356b9c85609da1bb7feda2f90ae6d1a1fd2d6713b284799d5605de42e2613"
   license "Apache-2.0"
-  revision 79
+  revision 80
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "ign-launch5"
 

--- a/Formula/ignition-launch5.rb
+++ b/Formula/ignition-launch5.rb
@@ -8,6 +8,13 @@ class IgnitionLaunch5 < Formula
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "ign-launch5"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "4932704d68aaf0f587df0ec1fbd0d269b153d9072d300202d6a0af7285a5a6b6"
+    sha256 arm64_sonoma:  "f4a6f11a83c668d861067a07053b3a5bf0ef9918b1956a15cbe586e4c6862492"
+    sha256 sonoma:        "8fe9e1d9fbcfb619840420e907f5c1ef041f3963af598f6a87d37688a06f7ba1"
+  end
+
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
 


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/3426.

Generated by https://build.osrfoundation.org/job/generic-release-homebrew_bump_unbottled_dependencies/65/