### PR TITLE
Remove bottles broken by gdal 3.13.0

### DIFF
--- a/Formula/gz-common5.rb
+++ b/Formula/gz-common5.rb
@@ -4,13 +4,7 @@ class GzCommon5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-common/releases/gz-common-5.8.0.tar.bz2"
   sha256 "d5634846a513d7d51fb8ffdafb51696ab62e01f1f9fc6da237181d9d8d89d0a6"
   license "Apache-2.0"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, arm64_sequoia: "ee5f14244746bffc8ae3343340c8a75c4b9bcbe00194d6e05a59e58556070118"
-    sha256 cellar: :any, arm64_sonoma:  "53a81959794844c3b091aaf43a0fe3fdce63e5877f1d301181c441ccd50053c0"
-    sha256 cellar: :any, sonoma:        "35f7f2f4bee4a0fb40f2dffa1227be691b6175522179eebbe6756e64363dad1c"
-  end
+  revision 1
 
   # head "https://github.com/gazebosim/gz-common.git", branch: "gz-common5"
 

--- a/Formula/gz-common6.rb
+++ b/Formula/gz-common6.rb
@@ -4,13 +4,7 @@ class GzCommon6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-common/releases/gz-common-6.3.0.tar.bz2"
   sha256 "e70e8916f3a82cf6dd7b42e18a68acbc12cd8e9ac433759db4427f8356dc366d"
   license "Apache-2.0"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, arm64_sequoia: "d39f927f9a13ba1d5d1fd6e8e592e0000d86b877c05537f6d0716f4c92c9643c"
-    sha256 cellar: :any, arm64_sonoma:  "0ba61cd5e6336c15ccb72a9dfe3a242377ca1e9483f7c0cc391ea79cdc3c7655"
-    sha256 cellar: :any, sonoma:        "3f16f1ca1ed33a95da982e2f645bc42d323e9df86581af7ff51ddd81a29322c7"
-  end
+  revision 1
 
   # head "https://github.com/gazebosim/gz-common.git", branch: "gz-common6"
 

--- a/Formula/gz-common7.rb
+++ b/Formula/gz-common7.rb
@@ -4,15 +4,9 @@ class GzCommon7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-common/releases/gz-common-7.1.1.tar.bz2"
   sha256 "9ba0e4c7eec67421fd284ccaab07a790df0aa76559589b6c8b86103e96579da4"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-common.git", branch: "gz-common7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, arm64_sequoia: "eadb290b2c645585f8be4b3c8e5fa9b9714cab1baed89995b3c9f1a87a66fe02"
-    sha256 cellar: :any, arm64_sonoma:  "7273f31ff3908e5736407aa19ad2535202812547563e59790abf3ebdfe986b71"
-    sha256 cellar: :any, sonoma:        "93bc8b355cf1c92fe3cab06ef820e42431f54b184f093a44b4bf6e53db1dbb1b"
-  end
 
   depends_on "assimp"
   depends_on "cmake"

--- a/Formula/gz-fuel-tools10.rb
+++ b/Formula/gz-fuel-tools10.rb
@@ -4,16 +4,9 @@ class GzFuelTools10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-10.1.0.tar.bz2"
   sha256 "37ae351be9a9b281d078e36068422dd096f59f46c72c4ef490800dfeb7653e1d"
   license "Apache-2.0"
-  revision 35
+  revision 36
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools10"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, arm64_sequoia: "5019613cd348f44b8c15d751bd49049c367fbce05deb46661dd66b7b9fd9869a"
-    sha256 cellar: :any, arm64_sonoma:  "58152937e52de8ad6e38a3dcfdc87eceb19d2f26bb7697ffc51f5b1cacc1cfda"
-    sha256 cellar: :any, sonoma:        "fbbf7ba0fcc8f2dee0530126a129003895a83a72c840675aae01e9bb4065b9d7"
-  end
 
   depends_on "abseil"
   depends_on "cmake"

--- a/Formula/gz-fuel-tools11.rb
+++ b/Formula/gz-fuel-tools11.rb
@@ -4,16 +4,9 @@ class GzFuelTools11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-11.0.0.tar.bz2"
   sha256 "4b4dee9b5a2e8cf04f1000e568187a65dd379bf54f8acf16d4e31a29240b30f0"
   license "Apache-2.0"
-  revision 22
+  revision 23
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools11"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, arm64_sequoia: "5ed9991b16dca288688e9c6e8c3cff80610d39c82f100e20ae9c37c8f3ee1520"
-    sha256 cellar: :any, arm64_sonoma:  "2bfa8a066877f9c14014b3c93d518cc2cdba0b2b29940b96b35392e8646c3376"
-    sha256 cellar: :any, sonoma:        "0da429ee00638037bc8474d9f5c909b861ac133e400c8c1fdc43ad3041184086"
-  end
 
   depends_on "abseil"
   depends_on "cmake"

--- a/Formula/gz-fuel-tools9.rb
+++ b/Formula/gz-fuel-tools9.rb
@@ -4,16 +4,9 @@ class GzFuelTools9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-9.1.1.tar.bz2"
   sha256 "3189166d4b0078c0b9d98de178e5496a1cc28b88fbd1124603376181b5a053f5"
   license "Apache-2.0"
-  revision 29
+  revision 30
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, arm64_sequoia: "5bfaeca36e58dcf9c797344c2fb2f88dee31334ec1db41b99e1ce31b0e6a8222"
-    sha256 cellar: :any, arm64_sonoma:  "2b2c89ff480dd9f90692cae6c759562ed36161d0c39482ef4b8c876b67050e9b"
-    sha256 cellar: :any, sonoma:        "9c2316bdc2ffd822e17780781b29983fa2c003cb979d8a892621698b3bbfaeb8"
-  end
 
   depends_on "abseil"
   depends_on "cmake"

--- a/Formula/gz-gui10.rb
+++ b/Formula/gz-gui10.rb
@@ -4,16 +4,9 @@ class GzGui10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-10.0.0.tar.bz2"
   sha256 "2ab6facb9473fdafe788efb867fb2f6153e278c9b02d7fe9a84412429bb74ee6"
   license "Apache-2.0"
-  revision 21
+  revision 22
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui10"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "13c4ef7acc6b12a6e42c5edf4da5d6f08cecc078479acebecf6c076626c6ddf0"
-    sha256 arm64_sonoma:  "c96a31e21e6d70717a09a2b24cf06b26d6fe9bf615a357c790d0047cbdcea284"
-    sha256 sonoma:        "32c95492802a25856c4fb48d5a1347de93f5831ff699a39aa94efdb88048146c"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-gui8.rb
+++ b/Formula/gz-gui8.rb
@@ -4,16 +4,9 @@ class GzGui8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-8.4.0.tar.bz2"
   sha256 "1731b01a134afb11b1b3e049fc65e74fa7b5c50532406d3d68366d54016d5498"
   license "Apache-2.0"
-  revision 28
+  revision 29
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "8fd48627d5dc485811ac52a987598024078909bf731da71b5d3818cb22fd255f"
-    sha256 arm64_sonoma:  "d5b493f69f1a0e603c67bea14af18d8ba29252e9e736930b0889fd4f19749c57"
-    sha256 sonoma:        "896c735465603847a535747f5828b9726b52a1b894a27b5633fb88f14db15933"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-gui9.rb
+++ b/Formula/gz-gui9.rb
@@ -4,16 +4,9 @@ class GzGui9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-9.0.2.tar.bz2"
   sha256 "0db7bdbaf32c3e9faba301c6d04e8cbf2daabdf639c45aedc10ec48356ea3d16"
   license "Apache-2.0"
-  revision 22
+  revision 23
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "a15d8a922322e3e260a7c444dc3cb78ace43b350be7f53976e496b79ed8a3ff8"
-    sha256 arm64_sonoma:  "69f903acd3d77d1a7e0ecfaf2d25f372e934d4ca1a1d5daf9b1ec3fb2659aaf6"
-    sha256 sonoma:        "6d2e9d479b6327640c48424d4466f24e02e6ef8ec84b76a7f1a1b6764fc1150a"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-launch7.rb
+++ b/Formula/gz-launch7.rb
@@ -4,16 +4,9 @@ class GzLaunch7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-7.1.1.tar.bz2"
   sha256 "e29f8b4663474cfed1364c45afa3aee8b44d816ffe1679c26c699f7c805cdffd"
   license "Apache-2.0"
-  revision 33
+  revision 34
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "51c94505ee2a93dcab600332b5c0de336da6b30ef89950e50a6cb22f9ab19718"
-    sha256 arm64_sonoma:  "74642c550b1aeb481da2c2d29415523b6584a0c0de8e7908b3f00f6018571666"
-    sha256 sonoma:        "ed9ce0492c05725761af3f81b325e717d5603f1902fc4cb260e008316aa3445a"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build

--- a/Formula/gz-launch8.rb
+++ b/Formula/gz-launch8.rb
@@ -4,14 +4,7 @@ class GzLaunch8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-8.0.2.tar.bz2"
   sha256 "e0ccbd1bc83bc5f178a7a0dc76d1f40e788d5bcad1aeb488c2364ea46466f24e"
   license "Apache-2.0"
-  revision 22
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "9f619adb6c63dd450af9ca54ffae5b199558107e9b31f06f37cb8d6e3da1004f"
-    sha256 arm64_sonoma:  "b5213173bfc59639e10d36302cad01d7c330c354700eb9f55f6b1b801c5a8a43"
-    sha256 sonoma:        "054aa82214175a1d4612f364275e29bf7f53a6552c54211baeb99f4dee0423f8"
-  end
+  revision 23
 
   # head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch8"
 

--- a/Formula/gz-launch9.rb
+++ b/Formula/gz-launch9.rb
@@ -4,16 +4,9 @@ class GzLaunch9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-9.0.0.tar.bz2"
   sha256 "7d8452a98aaf3d9f6f8d417178e52347b8c3505edca38d4525ab1ceb314c25a6"
   license "Apache-2.0"
-  revision 25
+  revision 26
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "00d55b68072aca2b4cb1450fcadadb6a5ed7510a47d6d07b002efdab908582f3"
-    sha256 arm64_sonoma:  "97e16d8a76070b0530bf87c8991327605312c3b090d162b984f6ddaed6130fea"
-    sha256 sonoma:        "9324b66cea585a8ffc0d708b851d14ef1b7a20d836e40fc56dbf7aa79ca1c5e6"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build

--- a/Formula/gz-physics7.rb
+++ b/Formula/gz-physics7.rb
@@ -4,14 +4,7 @@ class GzPhysics7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-7.6.0.tar.bz2"
   sha256 "4b930f61cb02e2cb322f347399b072aa0302d03d88e1788cc38ac719798073fc"
   license "Apache-2.0"
-  revision 8
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "7e0eed9d562693270a539b8bf867a16717513bac0a3ace6edb0a055eaea8cf14"
-    sha256 arm64_sonoma:  "0392489433163715a5586b1ae0fc2755b1217b1220ad282fa6d5618b12393bd5"
-    sha256 sonoma:        "70cccbd9006293495a1225bcda13cfaf4e8a643496070623a5188b10898aacbe"
-  end
+  revision 9
 
   # head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics7"
 

--- a/Formula/gz-physics8.rb
+++ b/Formula/gz-physics8.rb
@@ -4,14 +4,7 @@ class GzPhysics8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-8.3.0.tar.bz2"
   sha256 "ca274cca45c2d6808f4aa09ad01ba6ce17b50a28f71d83dbd8c38b6621c61ef2"
   license "Apache-2.0"
-  revision 13
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "9c3612e5c0ec9c0a540146e793f0ca0594aba40f0977296e34fb2c93fed557bd"
-    sha256 arm64_sonoma:  "e85c7b94873288b067fe6ff7388931670244c79fbff1d2d0098362349e29986f"
-    sha256 sonoma:        "982da7e6a14200030fc3d082be8e952b8dc94b488455da0eee50edae636a2162"
-  end
+  revision 14
 
   # head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics8"
 

--- a/Formula/gz-physics9.rb
+++ b/Formula/gz-physics9.rb
@@ -4,15 +4,9 @@ class GzPhysics9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-9.2.0.tar.bz2"
   sha256 "e568e882edba926066f63f27123fc6ec42af246af529af3da50e95b19cf2437f"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "edbc71ed86cb88844669816f4544b843cb317ecf21dd059a008fef4ffa472153"
-    sha256 arm64_sonoma:  "fd498a53b49f20a401a22e5a6528d2b67126264a6346b3473e4c6a1dda361877"
-    sha256 sonoma:        "e1d4d1117b12075a7037327dcd1b295af5d90ec5912fca449263bb9156a5df71"
-  end
 
   depends_on "cmake" => [:build, :test]
 

--- a/Formula/gz-rendering10.rb
+++ b/Formula/gz-rendering10.rb
@@ -4,15 +4,9 @@ class GzRendering10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-rendering/releases/gz-rendering-10.0.1.tar.bz2"
   sha256 "fde5284b1c462cf1046736bae88d169455ab8e8397f7569a3e5e369cec05d302"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering10"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "e5c59644c055378ea66394fe1a64f534d6cd7a6c855297a3097c259624f78e05"
-    sha256 arm64_sonoma:  "a90260fb6ed776236f254b60de4a242d4b702faf680638344c5006c9cc7c119e"
-    sha256 sonoma:        "d9181c599991315d053f1a44ffe439d69f15417d3867abed913dbeedb2b1d006"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-rendering8.rb
+++ b/Formula/gz-rendering8.rb
@@ -4,14 +4,7 @@ class GzRendering8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-rendering/releases/gz-rendering-8.2.3.tar.bz2"
   sha256 "a8ca484a57256d92e087893140309b8ac2dacfd5ea2f4c014eb8dc77f0705786"
   license "Apache-2.0"
-  revision 2
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "0d82f4ca19c29b3ba71d8e94da51e74a47a1caf432c8337b21d75ad57adce4a6"
-    sha256 arm64_sonoma:  "0e3971833b7b081a3ef4512d951c6223c20aa6d104a81f6ba5734cfce534821b"
-    sha256 sonoma:        "3387d59070daebc748f7412fb5f8c15ba16a5ee6cc31a0e2b4564d407dde57cb"
-  end
+  revision 3
 
   # head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering8"
 

--- a/Formula/gz-rendering9.rb
+++ b/Formula/gz-rendering9.rb
@@ -4,14 +4,7 @@ class GzRendering9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-rendering/releases/gz-rendering-9.5.0.tar.bz2"
   sha256 "cb915b9333e0a9730f05d396efdcdbbb93002c3902181f82f1b4c88a76c47440"
   license "Apache-2.0"
-  revision 4
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "d70134157efc1e3d73043c2b0ed3c9acaf1a2e1657a515e4efd298d84a248416"
-    sha256 arm64_sonoma:  "aa71d118679a1d5f29286f018489bed878a0e3232af860e9865a8ed4457c8a1a"
-    sha256 sonoma:        "9c255c7d5a76c9325e7f9c66e086baee9bcca9b1be07a1e72b4eef911abb9b6c"
-  end
+  revision 5
 
   # head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering9"
 

--- a/Formula/gz-sensors10.rb
+++ b/Formula/gz-sensors10.rb
@@ -4,16 +4,9 @@ class GzSensors10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-10.0.1.tar.bz2"
   sha256 "6f16c4c125d283536f49642109f62b2cdccfc7a421d4b33a1350d46ab7e831a3"
   license "Apache-2.0"
-  revision 10
+  revision 11
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors10"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256               arm64_sequoia: "5185e7fea88b41c190c6e4760c515a0bd6ad25256c04dd4a4749de32ba3c75b5"
-    sha256               arm64_sonoma:  "0d7e628702e6e4ee076d469225a46afdb2e8235ac86c7d5b42220b757de3064c"
-    sha256 cellar: :any, sonoma:        "8e8680eebd3d07ea69ae15d89557ee1b77c11627184913cd9afb5817969fb6fa"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-sensors8.rb
+++ b/Formula/gz-sensors8.rb
@@ -4,16 +4,9 @@ class GzSensors8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-8.2.2.tar.bz2"
   sha256 "9ddc16d5cab0a86f27771732f5cfcfde1efe7611f27da61176ea122273806c42"
   license "Apache-2.0"
-  revision 31
+  revision 32
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256               arm64_sequoia: "8b8f058d7340ca7434ae78e22ba7f1995ea74b48eee9a5a6d1176b7b9f63c93e"
-    sha256               arm64_sonoma:  "d40cea161e5f07137ff883121efb5ab232b80d0b4e449145c271d6d3fc8a3063"
-    sha256 cellar: :any, sonoma:        "ac1a2fb7e28a3b474d4fe5debe962d5bb7f5904a11e22b9dec96ce16eafeb787"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-sensors9.rb
+++ b/Formula/gz-sensors9.rb
@@ -4,16 +4,9 @@ class GzSensors9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-9.2.0.tar.bz2"
   sha256 "af2ec9a453a830338e80e94954160030e81b3ff8f60853e7c5730cdd2950be85"
   license "Apache-2.0"
-  revision 35
+  revision 36
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256               arm64_sequoia: "8d6db05b10e4769453fefc2a22f8508e185edb9d77ad1292a1e60c9b68e88036"
-    sha256               arm64_sonoma:  "b7a516e2563999a49849a04a684246201f1eb5449b02cf4f67c6de27226b30db"
-    sha256 cellar: :any, sonoma:        "555c13a5a2352775f20cf2a2b153c189a47be678f5e8f7113b0f437b851fbde7"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -4,16 +4,9 @@ class GzSim10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-10.2.0.tar.bz2"
   sha256 "9621541f8fcd29a50f677c0fe5f7e3cd9ed2f005dd2bb64df75c87073a0e5203"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim10"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "c9530049031bda518621fc6a24bf0c2579049f5a17556a60ce1d55e4b9dc65f3"
-    sha256 arm64_sonoma:  "1a103849c9d217c6670b2c7273372fb3c2658375c2edc1ebd68e841684eb20c9"
-    sha256 sonoma:        "c79d7acf99eb65630e25c3812dac8e9a12ef0e0b24b0e1966ace89c92cbc07fe"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build

--- a/Formula/gz-sim8.rb
+++ b/Formula/gz-sim8.rb
@@ -4,16 +4,9 @@ class GzSim8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-8.11.0.tar.bz2"
   sha256 "3764fed745dfbf6434c638677ad2c0b8de6295c360911f36e9a12455fabb9326"
   license "Apache-2.0"
-  revision 6
+  revision 7
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "23d77bca6bcd9c3da70afa1bf70829aa2fd223f39c79478b13372a2b70f51a8f"
-    sha256 arm64_sonoma:  "7ee492a83dc3bb230eaf4eeee147e10c0fb57faa487b4ad477654bbdf77caf45"
-    sha256 sonoma:        "e35fcc158097c71b8175a2ded6aff874fa8653eea877f18cb13580bc9abd48ef"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build

--- a/Formula/gz-sim9.rb
+++ b/Formula/gz-sim9.rb
@@ -4,14 +4,7 @@ class GzSim9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-9.5.0.tar.bz2"
   sha256 "2dfb720a6945765c7ead5f474b2dffb645773fd55d43d432abcbdfedb1b32dfe"
   license "Apache-2.0"
-  revision 21
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "037f1e9351d2ecb8cef88adc15776b48f29fb0d8632e4ec847a456c73214700e"
-    sha256 arm64_sonoma:  "dbe5da4e03eca5ad8f27bca1322c5a4865660830902b12af057227869a01563d"
-    sha256 sonoma:        "292ab2c6d119c768ec769d4d06b108537fca6af7868e2490e85eecd1dcabba43"
-  end
+  revision 22
 
   # head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim9"
 


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/3432.

Generated by https://build.osrfoundation.org/job/generic-release-homebrew_remove_dependent_bottles/28/