### PR TITLE
Jetty: rebuild for gdal 3.13.0

### DIFF
--- a/Formula/gz-common7.rb
+++ b/Formula/gz-common7.rb
@@ -4,7 +4,7 @@ class GzCommon7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-common/releases/gz-common-7.1.1.tar.bz2"
   sha256 "9ba0e4c7eec67421fd284ccaab07a790df0aa76559589b6c8b86103e96579da4"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-common.git", branch: "gz-common7"
 

--- a/Formula/gz-common7.rb
+++ b/Formula/gz-common7.rb
@@ -8,6 +8,13 @@ class GzCommon7 < Formula
 
   head "https://github.com/gazebosim/gz-common.git", branch: "gz-common7"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "72ac5492dc40495d82f9ab9d8e2f79efed849d41aa4b59263ec236a66e1065ea"
+    sha256 cellar: :any, arm64_sonoma:  "5869abda261f987b9777da089cfd6888faf39d5d2df31bc2493d34715d24159a"
+    sha256 cellar: :any, sonoma:        "04fbd1c10fc1f43fc353294bae26873c6348be3ea091cf3dd769da718bb9b7db"
+  end
+
   depends_on "assimp"
   depends_on "cmake"
   depends_on "ffmpeg"

--- a/Formula/gz-fuel-tools11.rb
+++ b/Formula/gz-fuel-tools11.rb
@@ -8,6 +8,13 @@ class GzFuelTools11 < Formula
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools11"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "f201b54265d1db5f3e0000e7f8bde5ae31b6b71b73359ac8c67ac87185af4109"
+    sha256 cellar: :any, arm64_sonoma:  "c8fdfe42bbcf3f0d3c7d2be759969202ab7dbb427bc7324318944548783944b8"
+    sha256 cellar: :any, sonoma:        "04690f0eb8d2b510fefb836f95ab36bbef6abe0315626e74e6cf48c6c2dbbc4b"
+  end
+
   depends_on "abseil"
   depends_on "cmake"
   depends_on "fmt"

--- a/Formula/gz-fuel-tools11.rb
+++ b/Formula/gz-fuel-tools11.rb
@@ -4,7 +4,7 @@ class GzFuelTools11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-11.0.0.tar.bz2"
   sha256 "4b4dee9b5a2e8cf04f1000e568187a65dd379bf54f8acf16d4e31a29240b30f0"
   license "Apache-2.0"
-  revision 23
+  revision 24
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools11"
 

--- a/Formula/gz-gui10.rb
+++ b/Formula/gz-gui10.rb
@@ -4,7 +4,7 @@ class GzGui10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-10.0.0.tar.bz2"
   sha256 "2ab6facb9473fdafe788efb867fb2f6153e278c9b02d7fe9a84412429bb74ee6"
   license "Apache-2.0"
-  revision 22
+  revision 23
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui10"
 

--- a/Formula/gz-gui10.rb
+++ b/Formula/gz-gui10.rb
@@ -8,6 +8,13 @@ class GzGui10 < Formula
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "07caf51a8d34be886ca5bab643bbfdda9ef4ce4c9780992cb515e3483886770d"
+    sha256 arm64_sonoma:  "5e347950ca1ae6ca4509bb4c5dc52a7a9ba6c9cc5b669bbf3481befaa2445a54"
+    sha256 sonoma:        "a9b5d6dced31b31a66e7f30995d290045ae96a356bb26c2591c0513adf6054b3"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
   depends_on "abseil"

--- a/Formula/gz-launch9.rb
+++ b/Formula/gz-launch9.rb
@@ -4,7 +4,7 @@ class GzLaunch9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-9.0.0.tar.bz2"
   sha256 "7d8452a98aaf3d9f6f8d417178e52347b8c3505edca38d4525ab1ceb314c25a6"
   license "Apache-2.0"
-  revision 26
+  revision 27
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch9"
 

--- a/Formula/gz-launch9.rb
+++ b/Formula/gz-launch9.rb
@@ -8,6 +8,13 @@ class GzLaunch9 < Formula
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "6d7deaa571dec54eb8e648876b53f8aae76e146e642fad1ec79624457caefeff"
+    sha256 arm64_sonoma:  "8c48ecb14c8b14d674adbc1b3367bac8c74ff5f0297fb25433f2aba075b3af1d"
+    sha256 sonoma:        "fdd7c6f18adc44a438e7d923d8c1a1da7ff9856c75185e104e880a15cc0bc166"
+  end
+
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
 

--- a/Formula/gz-physics9.rb
+++ b/Formula/gz-physics9.rb
@@ -8,6 +8,13 @@ class GzPhysics9 < Formula
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "591fbbe7721dce6a8829c4b5acab8414f5bd779ba7b24e0f72f25cc582ef9329"
+    sha256 arm64_sonoma:  "fef0e882c9ae37f843684f669ff5595f639938626f996d058cf9d090d43cf56a"
+    sha256 sonoma:        "ed00048174fd3b89706710f3fed285fb69acac86a8ad7d7a3bb26592cd998ba6"
+  end
+
   depends_on "cmake" => [:build, :test]
 
   depends_on "assimp"

--- a/Formula/gz-physics9.rb
+++ b/Formula/gz-physics9.rb
@@ -4,7 +4,7 @@ class GzPhysics9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-9.2.0.tar.bz2"
   sha256 "e568e882edba926066f63f27123fc6ec42af246af529af3da50e95b19cf2437f"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics9"
 

--- a/Formula/gz-rendering10.rb
+++ b/Formula/gz-rendering10.rb
@@ -8,6 +8,13 @@ class GzRendering10 < Formula
 
   head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "13757a4ba1c4e479bc79eab6ba4892bb0f94016e1d55a4448ba98722027c2664"
+    sha256 arm64_sonoma:  "f053646e0965a29c7d33cdc5161a27741e0372f528ca25f4f569f16b36a5360c"
+    sha256 sonoma:        "64e560226980807643a92f4a32e288cb1881c70c0340953e1d1a65a0d60dd23e"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
 

--- a/Formula/gz-rendering10.rb
+++ b/Formula/gz-rendering10.rb
@@ -4,7 +4,7 @@ class GzRendering10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-rendering/releases/gz-rendering-10.0.1.tar.bz2"
   sha256 "fde5284b1c462cf1046736bae88d169455ab8e8397f7569a3e5e369cec05d302"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering10"
 

--- a/Formula/gz-sensors10.rb
+++ b/Formula/gz-sensors10.rb
@@ -4,7 +4,7 @@ class GzSensors10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-10.0.1.tar.bz2"
   sha256 "6f16c4c125d283536f49642109f62b2cdccfc7a421d4b33a1350d46ab7e831a3"
   license "Apache-2.0"
-  revision 11
+  revision 12
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors10"
 

--- a/Formula/gz-sensors10.rb
+++ b/Formula/gz-sensors10.rb
@@ -8,6 +8,13 @@ class GzSensors10 < Formula
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256               arm64_sequoia: "09a45d7f40197206380c90ec55e8a02fa74c3c877ef1555f1c56e332f7201e16"
+    sha256               arm64_sonoma:  "5f09603cc7e96a47e5284ce27eec498f604f529bb788948c6522f5039401c4ba"
+    sha256 cellar: :any, sonoma:        "5f7e1ba9b264f2b2c1b42eb0aafafdd9729bf583422f37b6283e6f8a88690f9c"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
 

--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -4,7 +4,7 @@ class GzSim10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-10.2.0.tar.bz2"
   sha256 "9621541f8fcd29a50f677c0fe5f7e3cd9ed2f005dd2bb64df75c87073a0e5203"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim10"
 

--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -8,6 +8,13 @@ class GzSim10 < Formula
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "7dd5df0d461e5329989397bc30d00b7e4ae998ff489b063fe8d8018fb4b2e971"
+    sha256 arm64_sonoma:  "5217c3a1ffc05e03c689e01cd408b4a0df8a667b645dc61e85b4f4a39f748836"
+    sha256 sonoma:        "1876e2c7e4987589b840612e9e08ac52380e3e98825a8fd01c078bda284a6a66"
+  end
+
   depends_on "cmake" => :build
   depends_on "pybind11" => :build
   depends_on "abseil"


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/3432.

Generated by https://build.osrfoundation.org/job/generic-release-homebrew_bump_unbottled_dependencies/66/