### PR TITLE
Fix brew test-bot action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,9 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       HOMEBREW_FORCE_VENDOR_RUBY: 1
+      # mitigation for "Warning: Bubblewrap is required to use the Linux sandbox but was not found."
+      # remove when `brew doctor` can succeed without it
+      HOMEBREW_NO_SANDBOX_LINUX: 1
     steps:
       - name: Activate Homebrew
         if: runner.os == 'Linux'


### PR DESCRIPTION
The `brew test-bot` action is failing `brew doctor` in #3451. This sets an environment variable to work around the problem.