### PR TITLE
README: add brew trust osrf/simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Homebrew tap for osrf simulation software
 To use:
 
     brew tap osrf/simulation
+    brew trust osrf/simulation
     brew install gz-harmonic
 
 ## Bottle status


### PR DESCRIPTION
Homebrew's package descriptions (formulae) are implemented as executable ruby code, which can lead to security issues when using 3rd-party taps, so they have recently added a `brew trust` command to help mitigate security issues, [documented here](https://docs.brew.sh/Tap-Trust). It will soon be required to use `brew trust osrf/simulation` after `brew tap osrf/simulation` in order to run additional commands like `brew install gz-jetty`. I have added these commands to our CI scripts to fix brew doctor complaints in CI in https://github.com/gazebo-tooling/release-tools/pull/1508 and am updating some documentation here.