### PR TITLE
bottled_dependents: use --missing flag

### DIFF
--- a/.github/ci/bottled_dependents.sh
+++ b/.github/ci/bottled_dependents.sh
@@ -15,7 +15,8 @@
 #
 
 # The script will print the bottled dependents from the osrf/simulation
-# tap of a specified formula.
+# tap of a specified formula that are not currently installed. It is
+# intended to be used in a CI context with no formulae installed.
 #
 # Usage:
 # $ ./bottled_dependents.sh <formula> [<bottle_tag>]
@@ -42,7 +43,7 @@ if [ -n "${BOTTLE_TAG}" ]; then
   BOTTLE_FLAG="--tag"
 fi
 
-for f in $(brew uses ${FORMULA} --formulae --eval-all | grep ^osrf/simulation/)
+for f in $(brew uses ${FORMULA} --formulae --missing | grep ^osrf/simulation/)
 do
   # brew unbottled prints "already bottled" for bottled formulae
   if brew unbottled $f ${BOTTLE_FLAG} ${BOTTLE_TAG} | grep --quiet "already bottled"; then


### PR DESCRIPTION
The --eval-all flag is deprecated for `brew uses`, so switch to --missing, which will work equivalently in our CI context with no installed formulae.

## Local testing with `master` branch

~~~
$ ./bottled_dependents.sh gz-physics8
Warning: Calling the `--eval-all` switch is deprecated! There is no replacement.
osrf/simulation/gz-launch8
osrf/simulation/gz-sim9
~~~


## Local testing with this branch

~~~
$ ./bottled_dependents.sh gz-physics8
osrf/simulation/gz-launch8
osrf/simulation/gz-sim9
~~~