### PR TITLE
Jetty: rebuild for protobuf 35.1

### DIFF
--- a/Formula/gz-fuel-tools11.rb
+++ b/Formula/gz-fuel-tools11.rb
@@ -8,6 +8,13 @@ class GzFuelTools11 < Formula
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools11"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "974888582db9346168bd8eef982902f5b7eb867406dae46bb655e4bc71ad740d"
+    sha256 cellar: :any, arm64_sonoma:  "214d762adc819c0aa41188aa3e8b78ea7997c2e2a94bfe1fe419255545f234e1"
+    sha256 cellar: :any, sonoma:        "4ea50ff52efc87e0bb14efa1ec0d55c6c88df20c69b02d10ed14a6ebdf9a08c2"
+  end
+
   depends_on "abseil"
   depends_on "cmake"
   depends_on "fmt"

--- a/Formula/gz-fuel-tools11.rb
+++ b/Formula/gz-fuel-tools11.rb
@@ -4,7 +4,7 @@ class GzFuelTools11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-11.0.0.tar.bz2"
   sha256 "4b4dee9b5a2e8cf04f1000e568187a65dd379bf54f8acf16d4e31a29240b30f0"
   license "Apache-2.0"
-  revision 27
+  revision 28
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools11"
 

--- a/Formula/gz-gui10.rb
+++ b/Formula/gz-gui10.rb
@@ -8,6 +8,13 @@ class GzGui10 < Formula
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "259808050ee4e6b8389349f7b81ad3e39a623b7228b888a3706098e0cc798134"
+    sha256 arm64_sonoma:  "c1bf6a0a42a270f55d414703fb31cc28ba90e5ff9a8f5cdcbc628a526f4bd11f"
+    sha256 sonoma:        "92762e67fe4eb8509cba14b782b173d809db670079280bc972de688229f8963e"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
   depends_on "abseil"

--- a/Formula/gz-gui10.rb
+++ b/Formula/gz-gui10.rb
@@ -4,7 +4,7 @@ class GzGui10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-10.0.0.tar.bz2"
   sha256 "2ab6facb9473fdafe788efb867fb2f6153e278c9b02d7fe9a84412429bb74ee6"
   license "Apache-2.0"
-  revision 26
+  revision 27
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui10"
 

--- a/Formula/gz-launch9.rb
+++ b/Formula/gz-launch9.rb
@@ -4,7 +4,7 @@ class GzLaunch9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-9.0.1.tar.bz2"
   sha256 "096f66cd2a5b58dc8ca93e9bc33c65e0cf82af7472f154fc2d8a955bc762cd5f"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch9"
 

--- a/Formula/gz-launch9.rb
+++ b/Formula/gz-launch9.rb
@@ -8,6 +8,13 @@ class GzLaunch9 < Formula
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "13df5bbbd6f335a25e20151e1f7536c7c94dc08de0c94d7cec598c003b5635cd"
+    sha256 arm64_sonoma:  "95f9a9a2c789bce559c3ad8f97b92c69a81dff445ccc743eec259b157bc58a4d"
+    sha256 sonoma:        "7f2c13f14b35336b71d860b759f18b4e76b8d4ac8d3c6d12aa604a4dfc5c44a2"
+  end
+
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
 

--- a/Formula/gz-msgs12.rb
+++ b/Formula/gz-msgs12.rb
@@ -8,6 +8,13 @@ class GzMsgs12 < Formula
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs12"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "d086078ccb36b0717afaf3a0f1883c9b7a251f2c60a3ad02c1df6cb175cfc5bd"
+    sha256 arm64_sonoma:  "5584a8100d29bc388a0ab491593cbcf31926e35a91a235d2d3228ed78d27e549"
+    sha256 sonoma:        "8e007b99be2ec190b2269a8e56a2d06d6a18ad426a4797dd12ad41def7f94d4c"
+  end
+
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
   depends_on "python@3.14" => [:build, :test]

--- a/Formula/gz-msgs12.rb
+++ b/Formula/gz-msgs12.rb
@@ -4,7 +4,7 @@ class GzMsgs12 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/gz-msgs-12.0.1.tar.bz2"
   sha256 "f43316821204c37836a23640fdfe161241ec7eafd683b1e721a8ed879301ce75"
   license "Apache-2.0"
-  revision 9
+  revision 10
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs12"
 

--- a/Formula/gz-physics9.rb
+++ b/Formula/gz-physics9.rb
@@ -4,7 +4,7 @@ class GzPhysics9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/gz-physics-9.3.0.tar.bz2"
   sha256 "ae966050e19e034c6bd191dfa2c76c0d75ce73719eb6f5a0cc34148d2b8385d5"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics9"
 

--- a/Formula/gz-physics9.rb
+++ b/Formula/gz-physics9.rb
@@ -8,6 +8,13 @@ class GzPhysics9 < Formula
 
   head "https://github.com/gazebosim/gz-physics.git", branch: "gz-physics9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "7ea8c3d82de2958279b363aa4bc9a6917ecb7544feb979ce6dc37a1daead96c6"
+    sha256 arm64_sonoma:  "84c480b71431b728c344cf72a2226d21b50d105f89ef9027adfcffcf1750417d"
+    sha256 sonoma:        "9cc90f97e42237d9054e29ad66d139c336f1135f61a319dd4f19ca09b10dfd66"
+  end
+
   depends_on "cmake" => [:build, :test]
 
   depends_on "assimp"

--- a/Formula/gz-sensors10.rb
+++ b/Formula/gz-sensors10.rb
@@ -8,6 +8,13 @@ class GzSensors10 < Formula
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256               arm64_sequoia: "566cedb87eb278df1704d7edbe1d271844526bee85c0f7127b5fef1d53ecc714"
+    sha256               arm64_sonoma:  "96234784ea5337e624b506054126bae4327325dc939d0adc0124bb320219b042"
+    sha256 cellar: :any, sonoma:        "ef2b165ced951886ca67224138e2c3c050ea6cb3c379ec9a0dcbbbc35177af52"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
 

--- a/Formula/gz-sensors10.rb
+++ b/Formula/gz-sensors10.rb
@@ -4,7 +4,7 @@ class GzSensors10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-10.0.1.tar.bz2"
   sha256 "6f16c4c125d283536f49642109f62b2cdccfc7a421d4b33a1350d46ab7e831a3"
   license "Apache-2.0"
-  revision 15
+  revision 16
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors10"
 

--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -4,7 +4,7 @@ class GzSim10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-10.4.0.tar.bz2"
   sha256 "208514aac65ab7cdc3dacac8775a9bb35d793be4b72805e39f741afca86ff8b6"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim10"
 

--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -8,6 +8,13 @@ class GzSim10 < Formula
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "6c875ebe62bb167b4dbb53da91ad0d7cce35d8efa9e6b944d7091a6be85500fc"
+    sha256 arm64_sonoma:  "9d2842c3aa734f62e56493971dc5f3dfd7a28aba022cf5764bc0c7ce010c6344"
+    sha256 sonoma:        "7871686ac524d46a9ec7b72e94bd5715dd0be15fe5c68057a423b0d142455dc9"
+  end
+
   depends_on "cmake" => :build
   depends_on "pybind11" => :build
   depends_on "abseil"

--- a/Formula/gz-transport15.rb
+++ b/Formula/gz-transport15.rb
@@ -8,6 +8,13 @@ class GzTransport15 < Formula
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport15"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "cd49c176bea2ca85764c55ce91bd68772f803a9f3e7f94ad480b0bac847d6195"
+    sha256 arm64_sonoma:  "ca00adb12ebf5459f71a3a971f1445369ed75e7ad7597da2194cf491d983a6dd"
+    sha256 sonoma:        "c3c7ce603d8785ff91b3a667b2f2de463d016ffa215610f91a6a6b5b585cc220"
+  end
+
   depends_on "doxygen" => [:build, :optional]
   depends_on "pybind11" => :build
   depends_on "python@3.12" => [:build, :test]

--- a/Formula/gz-transport15.rb
+++ b/Formula/gz-transport15.rb
@@ -4,7 +4,7 @@ class GzTransport15 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/gz-transport-15.0.2.tar.bz2"
   sha256 "86569a868c58683f8e3e26b2305566e1a6c3398d596f026d5bb56ca7e9743ff1"
   license "Apache-2.0"
-  revision 9
+  revision 10
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport15"
 


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/3473.

Generated by https://build.osrfoundation.org/job/generic-release-homebrew_bump_unbottled_dependencies/73/