### PR TITLE
Fortress: rebuild for protobuf 35.1

### DIFF
--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -4,7 +4,7 @@ class IgnitionFuelTools7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/ignition-fuel_tools-7.3.1.tar.bz2"
   sha256 "b8224c574406147ae008ed9a0ac459f1e2582f6aaef7ba44e1fd1c5ac97b6de8"
   license "Apache-2.0"
-  revision 43
+  revision 44
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools7"
 

--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -8,6 +8,13 @@ class IgnitionFuelTools7 < Formula
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools7"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "60d97a05d0321a55e4a73c27f60aa3d1c78bfe455d851fad050463c16e475143"
+    sha256 cellar: :any, arm64_sonoma:  "7562f98e581363636a2732b021d29cd4398cc7d24715294f7fcea3f5264e8637"
+    sha256 cellar: :any, sonoma:        "9e2ca96e05bc763224ba4779723c33e11ed8fba72a93ede0386193036795f4de"
+  end
+
   depends_on "abseil"
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -4,7 +4,7 @@ class IgnitionGazebo6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/ignition-gazebo-6.18.0.tar.bz2"
   sha256 "9d3bbadc1a9c780b179890f4ac5978195d98a7a12f4cc23614d895276774fc99"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo6"
 

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -8,6 +8,13 @@ class IgnitionGazebo6 < Formula
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo6"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "de7aa2187f9b32c61f7a799439f30652e8df11f49f68f1ab3a760deaa0a8e3d5"
+    sha256 arm64_sonoma:  "16215c51dd71eb6b32d8bbc169e558ab8ef65a73722031fabcc9c3dbe9272f95"
+    sha256 sonoma:        "dbb02d21899b7bf5c8b58aae37c695c6877fd66cd0fa740adf719f05ee54bfb5"
+  end
+
   depends_on "cmake" => :build
   depends_on "pybind11" => :build
   depends_on "gz-plugin2" => :test

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -8,6 +8,13 @@ class IgnitionGui6 < Formula
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui6"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "331ec5cc95d154a0fea379c10f5d971ca5ea324bb86a2ed75c278266fb231bb4"
+    sha256 arm64_sonoma:  "1b8a81b3848a7de641dc2f5b6d85fd5b17e77557139f4f14cdff7f6a7dccb9af"
+    sha256 sonoma:        "ebaa24cbc418230cd42e8d6ed1b96c03c400654285bb58f335b7e1ebf4dcb74a"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
 

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -4,7 +4,7 @@ class IgnitionGui6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/ignition-gui-6.9.0.tar.bz2"
   sha256 "905f740430ae51579d40927f38683d075558c3694ce069f669fb50f7db9a94b5"
   license "Apache-2.0"
-  revision 7
+  revision 8
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui6"
 

--- a/Formula/ignition-launch5.rb
+++ b/Formula/ignition-launch5.rb
@@ -4,7 +4,7 @@ class IgnitionLaunch5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/ignition-launch-5.3.1.tar.bz2"
   sha256 "abb724f65e820b04c056ee2e9329bc749dffcd6fc8e481eb9e4f83a719fb5492"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "ign-launch5"
 

--- a/Formula/ignition-launch5.rb
+++ b/Formula/ignition-launch5.rb
@@ -8,6 +8,13 @@ class IgnitionLaunch5 < Formula
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "ign-launch5"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "cc54474514280017cc7643924c7f70d41c3f5b3f447106a770e6c80104bcdb30"
+    sha256 arm64_sonoma:  "b1e9c9b633febfa3176a5cbf42678a0299b2e56f8eafb73cbfea322aee4170f6"
+    sha256 sonoma:        "e6d1efa330cf8eb7ba496fae72f8fb42fb65e0a799acdf914bd9e65fe0bbdc01"
+  end
+
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
 

--- a/Formula/ignition-msgs8.rb
+++ b/Formula/ignition-msgs8.rb
@@ -8,6 +8,13 @@ class IgnitionMsgs8 < Formula
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs8"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "4cc20b578e2e51a7e1f7cd5fc36825b67678c89adcf70ebd3e59ef3caf857936"
+    sha256 cellar: :any, arm64_sonoma:  "fc74996489b1ecfab3999a944e5a841a8c8957b9de656e4bdde3149bba5ed189"
+    sha256 cellar: :any, sonoma:        "858d633c06751a5e41fbfd9fde9f71f6da466c581bd4bef7f9b0067703b49c67"
+  end
+
   depends_on "abseil"
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-msgs8.rb
+++ b/Formula/ignition-msgs8.rb
@@ -4,7 +4,7 @@ class IgnitionMsgs8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/ignition-msgs-8.7.1.tar.bz2"
   sha256 "5de8edbcf971ea223756310129b2a25c0b5cba2657d736fd8f556eeec331bff0"
   license "Apache-2.0"
-  revision 7
+  revision 8
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs8"
 

--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -4,7 +4,7 @@ class IgnitionPhysics5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-physics/releases/ignition-physics-5.4.0.tar.bz2"
   sha256 "0675bf9a0db8cc67ade5e71ff7ccbca57e6ff7d2f7c400ef10787f501a87ae56"
   license "Apache-2.0"
-  revision 7
+  revision 8
 
   # head "https://github.com/gazebosim/gz-physics.git", branch: "ign-physics5"
 

--- a/Formula/ignition-physics5.rb
+++ b/Formula/ignition-physics5.rb
@@ -6,6 +6,13 @@ class IgnitionPhysics5 < Formula
   license "Apache-2.0"
   revision 8
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256               arm64_sequoia: "1f690e3eb12f88741f2085a447ae472e30903216e48fb1ab9faccfa1e237fb82"
+    sha256               arm64_sonoma:  "719b6f5781e7f7326e359ab7065cd26bcb3da3ba75ec209018f34d543ac4ba25"
+    sha256 cellar: :any, sonoma:        "ac7d600c88947a47e42d692f1742f84b1759581b427af0a8b63e3557eae8aec7"
+  end
+
   # head "https://github.com/gazebosim/gz-physics.git", branch: "ign-physics5"
 
   depends_on "cmake" => :build

--- a/Formula/ignition-sensors6.rb
+++ b/Formula/ignition-sensors6.rb
@@ -4,7 +4,7 @@ class IgnitionSensors6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/ignition-sensors-6.9.0.tar.bz2"
   sha256 "20cc51bf730bfb3f9eba6fec0a8fc6c917b2841aa0b0543e183f60200e57ae4c"
   license "Apache-2.0"
-  revision 11
+  revision 12
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors6"
 

--- a/Formula/ignition-sensors6.rb
+++ b/Formula/ignition-sensors6.rb
@@ -8,6 +8,13 @@ class IgnitionSensors6 < Formula
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors6"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256               arm64_sequoia: "0fed01e3a8587d304c768883208f33fade2e8a0fc2ed3a2b9bd5618ebf0f1af2"
+    sha256               arm64_sonoma:  "a3cea0e2f3009bee1487566ef8613752e38770864a577862889637fc15db0743"
+    sha256 cellar: :any, sonoma:        "7ce66eea5472c2116438e25cba7edec8eede56d522ccfbce0fcb40debdba9368"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
 

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -9,6 +9,13 @@ class IgnitionTransport11 < Formula
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport11"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "15a69076ec92b588af51bdaa92c56bf1b4eab1834f16b6a07730dd4141282894"
+    sha256 arm64_sonoma:  "31f426dccac8a14c910b28ad7dd1f9cf3d968443781ea2b7dfc1ba058af2a306"
+    sha256 sonoma:        "7a80e5d1e4f8a3686c3b85e271a7124b049eb7dad273e21c46f34474b5e298a3"
+  end
+
   depends_on "doxygen" => [:build, :optional]
 
   depends_on "abseil"

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -4,7 +4,7 @@ class IgnitionTransport11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/ignition-transport-11.4.2.tar.bz2"
   sha256 "5cb9a6a70d1c71e4bc60970e494b3ba82ecece757ccaa637c43b2193d4c15c72"
   license "Apache-2.0"
-  revision 7
+  revision 8
   version_scheme 1
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport11"


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/3473.

Generated by https://build.osrfoundation.org/job/generic-release-homebrew_bump_unbottled_dependencies/76/