### PR TITLE
gz-cmake5: add patch for cmake 4.4 warnings

### DIFF
--- a/Formula/gz-cmake5.rb
+++ b/Formula/gz-cmake5.rb
@@ -4,6 +4,7 @@ class GzCmake5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-cmake/releases/gz-cmake-5.1.1.tar.bz2"
   sha256 "d1ca0245cdcbb050ebd8ccfa67d0837b88d2a0ab7d9ceadbe4478c1f9d533006"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
@@ -18,6 +19,12 @@ class GzCmake5 < Formula
   depends_on "pkgconf"
 
   conflicts_with "gz-rotary-cmake", because: "both install gz-cmake"
+
+  patch do
+    # Fix for warnings with cmake 4.4.0
+    url "https://github.com/gazebosim/gz-cmake/commit/2302ac12989d3a464247224a4b9465a28526c638.patch?full_index=1"
+    sha256 "e6fc0b7f4e7869b2a64e91eabd292207e2a4c9086962d8e013f501a2b699b89e"
+  end
 
   def install
     cmake_args = std_cmake_args

--- a/Formula/gz-cmake5.rb
+++ b/Formula/gz-cmake5.rb
@@ -8,9 +8,9 @@ class GzCmake5 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "a7b036ae727f63dc798ceb6356e0237d06170f305a05110ffe5415dd09abd335"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "1e9dedb7fde345c9f7f2f3e681eef823098ef3db697591108e3b933c9a21d2ee"
-    sha256 cellar: :any_skip_relocation, sonoma:        "8b1d813068a9b02ff68fd47cb24c7c5370d3107d983b71ea17b334561376ec66"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "1246138465bff451f4ffe515bde28c3a7f0b9eb5c957a0d35912227c6a1611a9"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "f422c17515ab57f0b98940192a0ba74c05019b17c79182df827560792cacfd06"
+    sha256 cellar: :any_skip_relocation, sonoma:        "db4286b7329b2f1c494a17fe2d8c1ecd169e1b849dd5e4bd4c1a3e3e71378cbb"
   end
 
   # head "https://github.com/gazebosim/gz-cmake.git", branch: "gz-cmake5"


### PR DESCRIPTION
Part of https://github.com/gazebosim/gz-cmake/issues/570.