### PR TITLE
gz-cmake2: add patch for cmake 4.4 warnings

### DIFF
--- a/Formula/ignition-cmake2.rb
+++ b/Formula/ignition-cmake2.rb
@@ -10,9 +10,9 @@ class IgnitionCmake2 < Formula
 
   bottle do
     root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "d8917b183cb6300174e4f8e7f38fce04bf4129ca2ae717e4e15fe120d3c13958"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "7bab45ec5d5fd4ebd9589ee2ffba5d571bd10b149ceb2de358d17fd01da97835"
-    sha256 cellar: :any_skip_relocation, sonoma:        "bd0f87fe3b33fa28e1f048720ee54be2ca34060268087bb4e48502ab11053f09"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "75942e91db8426becce21cb6cd23e2c16765e062fb3e5496bef6f2fc7707934a"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "b1e56c95b37c0c5837e5e31e4606dc94752d8a6601a62b49888ea8b05493b34d"
+    sha256 cellar: :any_skip_relocation, sonoma:        "2421641f7a3bb4c3325fc489617d5d1e1f629f026c9e35994492b639f34e11ee"
   end
 
   depends_on "cmake"

--- a/Formula/ignition-cmake2.rb
+++ b/Formula/ignition-cmake2.rb
@@ -4,6 +4,7 @@ class IgnitionCmake2 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-cmake/releases/ignition-cmake-2.19.0.tar.bz2"
   sha256 "032f4172919474c36c209dc6f28513d9ac68cc5a801eb86123bfc03c7e88ae75"
   license "Apache-2.0"
+  revision 1
 
   # head "https://github.com/gazebosim/gz-cmake.git", branch: "ign-cmake2"
 
@@ -16,6 +17,12 @@ class IgnitionCmake2 < Formula
 
   depends_on "cmake"
   depends_on "pkgconf"
+
+  patch do
+    # Fix for warnings with cmake 4.4.0
+    url "https://github.com/gazebosim/gz-cmake/commit/317d056ec2bb3c454fdcaf2ca6063c3cf88c7cc9.patch?full_index=1"
+    sha256 "4ef376c321959b92fae467d66995148020e4fa5825134c2595b8ff8efde5e79c"
+  end
 
   def install
     cmake_args = std_cmake_args


### PR DESCRIPTION
Part of https://github.com/gazebosim/gz-cmake/issues/570.