### PR TITLE
Remove bottles broken by libwebsockets 5.0.0

### DIFF
--- a/Formula/gz-launch9.rb
+++ b/Formula/gz-launch9.rb
@@ -4,16 +4,9 @@ class GzLaunch9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-9.0.1.tar.bz2"
   sha256 "096f66cd2a5b58dc8ca93e9bc33c65e0cf82af7472f154fc2d8a955bc762cd5f"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "13df5bbbd6f335a25e20151e1f7536c7c94dc08de0c94d7cec598c003b5635cd"
-    sha256 arm64_sonoma:  "95f9a9a2c789bce559c3ad8f97b92c69a81dff445ccc743eec259b157bc58a4d"
-    sha256 sonoma:        "7f2c13f14b35336b71d860b759f18b4e76b8d4ac8d3c6d12aa604a4dfc5c44a2"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build

--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -4,16 +4,9 @@ class GzSim10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-10.4.0.tar.bz2"
   sha256 "208514aac65ab7cdc3dacac8775a9bb35d793be4b72805e39f741afca86ff8b6"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim10"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "6c875ebe62bb167b4dbb53da91ad0d7cce35d8efa9e6b944d7091a6be85500fc"
-    sha256 arm64_sonoma:  "9d2842c3aa734f62e56493971dc5f3dfd7a28aba022cf5764bc0c7ce010c6344"
-    sha256 sonoma:        "7871686ac524d46a9ec7b72e94bd5715dd0be15fe5c68057a423b0d142455dc9"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/3503.

Generated by https://build.osrfoundation.org/job/generic-release-homebrew_remove_dependent_bottles/39/