### PR TITLE
Jetty: rebuild for libwebsockets 5.0.0

### DIFF
--- a/Formula/gz-launch9.rb
+++ b/Formula/gz-launch9.rb
@@ -8,6 +8,13 @@ class GzLaunch9 < Formula
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "23a97d4d92f275737164a5cab90e5dbb4da3c0dd790a192a4f6175d0b22bbe00"
+    sha256 arm64_sonoma:  "b0508a8f71297076af684bff3c5e2a41c42da22a988e4adc87e7130fcfc1cfcd"
+    sha256 sonoma:        "7b4376f6b3ddf944ad2bd9632ca2b35d3729b05bc9f307d23312e384ec9fd184"
+  end
+
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
 

--- a/Formula/gz-launch9.rb
+++ b/Formula/gz-launch9.rb
@@ -4,7 +4,7 @@ class GzLaunch9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-9.0.1.tar.bz2"
   sha256 "096f66cd2a5b58dc8ca93e9bc33c65e0cf82af7472f154fc2d8a955bc762cd5f"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch9"
 

--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -8,6 +8,13 @@ class GzSim10 < Formula
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "b0cd60b9ebb1fc23503e608e0b370ea7531462caea8f168ce59582eb0f1a71a6"
+    sha256 arm64_sonoma:  "7df9723815c7341485b3f9e11d3b65b4e206af0c0415d5a186180d30a5de2a40"
+    sha256 sonoma:        "2d76783e2723e0adc07f5231ffe4f4defcb451091be528079db71277f8d3dd93"
+  end
+
   depends_on "cmake" => :build
   depends_on "pybind11" => :build
   depends_on "abseil"

--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -4,7 +4,7 @@ class GzSim10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-10.4.0.tar.bz2"
   sha256 "208514aac65ab7cdc3dacac8775a9bb35d793be4b72805e39f741afca86ff8b6"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim10"
 


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/3503.

Generated by https://build.osrfoundation.org/job/generic-release-homebrew_bump_unbottled_dependencies/77/