### PR TITLE
Test sdf, math types together in python

### DIFF
--- a/Formula/gz-rotary-sdformat.rb
+++ b/Formula/gz-rotary-sdformat.rb
@@ -113,9 +113,11 @@ class GzRotarySdformat < Formula
     # check python import
     pythons.each do |python|
       system python.opt_libexec/"bin/python", "-c",
-        "import sdformat; sdformat.Box().size()"
+        "import gz.math; import sdformat;" \
+        "sdformat.Atmosphere.set_temperature(gz.math.Temperature())"
     end
     system formula_opt_libexec("python3")/"bin/python", "-c",
-      "import sdformat; sdformat.Box().size()"
+      "import gz.math; import sdformat;" \
+      "sdformat.Atmosphere.set_temperature(gz.math.Temperature())"
   end
 end

--- a/Formula/sdformat14.rb
+++ b/Formula/sdformat14.rb
@@ -107,9 +107,11 @@ class Sdformat14 < Formula
     # check python import
     pythons.each do |python|
       system python.opt_libexec/"bin/python", "-c",
-        "import sdformat14; sdformat14.Box().size()"
+        "import gz.math7; import sdformat14;" \
+        "sdformat14.Atmosphere.set_temperature(gz.math7.Temperature())"
     end
     system formula_opt_libexec("python3")/"bin/python", "-c",
-      "import sdformat14; sdformat14.Box().size()"
+      "import gz.math7; import sdformat14;" \
+      "sdformat14.Atmosphere.set_temperature(gz.math7.Temperature())"
   end
 end

--- a/Formula/sdformat15.rb
+++ b/Formula/sdformat15.rb
@@ -112,9 +112,11 @@ class Sdformat15 < Formula
     # check python import
     pythons.each do |python|
       system python.opt_libexec/"bin/python", "-c",
-        "import sdformat15; sdformat15.Box().size()"
+        "import gz.math8; import sdformat15;" \
+        "sdformat15.Atmosphere.set_temperature(gz.math8.Temperature())"
     end
     system formula_opt_libexec("python3")/"bin/python", "-c",
-      "import sdformat15; sdformat15.Box().size()"
+      "import gz.math8; import sdformat15;" \
+      "sdformat15.Atmosphere.set_temperature(gz.math8.Temperature())"
   end
 end

--- a/Formula/sdformat16.rb
+++ b/Formula/sdformat16.rb
@@ -116,9 +116,11 @@ class Sdformat16 < Formula
     # check python import
     pythons.each do |python|
       system python.opt_libexec/"bin/python", "-c",
-        "import sdformat; sdformat.Box().size()"
+        "import gz.math; import sdformat;" \
+        "sdformat.Atmosphere.set_temperature(gz.math.Temperature())"
     end
     system formula_opt_libexec("python3")/"bin/python", "-c",
-      "import sdformat; sdformat.Box().size()"
+      "import gz.math; import sdformat;" \
+      "sdformat.Atmosphere.set_temperature(gz.math.Temperature())"
   end
 end


### PR DESCRIPTION
Issue #3513 tracks bottles broken by pybind 3.1, but the sdformat formula tests don't currently show these failures. The updates to tests in this PR are based on sdformat python test failures observed in CI:

From [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci-sdf15-homebrew-amd64&build=202)](https://build.osrfoundation.org/job/sdformat-ci-sdf15-homebrew-amd64/202/) https://build.osrfoundation.org/job/sdformat-ci-sdf15-homebrew-amd64/202/

~~~
260: ../../sdformat/python/test/pyAtmosphere_TEST.py FFF                      [100%]
260: 
260: =================================== FAILURES ===================================
260: _____________________ AtmosphereTEST.test_copy_assignment ______________________
260: 
260: self = <pyAtmosphere_TEST.AtmosphereTEST testMethod=test_copy_assignment>
260: 
260:     def test_copy_assignment(self):
260:       atmosphere = Atmosphere()
260: >     atmosphere.set_temperature(Temperature(123.23))
260: E     TypeError: set_temperature(): incompatible function arguments. The following argument types are supported:
260: E         1. (self: sdformat15.Atmosphere, arg0: gz::math::v8::Temperature) -> None
260: E     
260: E     Invoked with: <sdformat15.Atmosphere object at 0x1114b86b0>, 123.23
260: 
260: ../../sdformat/python/test/pyAtmosphere_TEST.py:48: TypeError
~~~

## Tested

The rotary test passes since it isn't bottled:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_rotary_sdformat-install_formula-homebrew-amd64&build=149)](https://build.osrfoundation.org/job/gz_rotary_sdformat-install_formula-homebrew-amd64/149/) https://build.osrfoundation.org/job/gz_rotary_sdformat-install_formula-homebrew-amd64/149/

