### PR TITLE
Jetty: rebuild for pybind11

### DIFF
--- a/Formula/gz-math9.rb
+++ b/Formula/gz-math9.rb
@@ -8,6 +8,13 @@ class GzMath9 < Formula
 
   head "https://github.com/gazebosim/gz-math.git", branch: "gz-math9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "5b22d8f52cacb31f0a511d3e21ea575aebe77a56c3e12c48364dcd645883d2bc"
+    sha256 cellar: :any, arm64_sonoma:  "f697a6127e49d049fc877468f8129126d427bac17464dbe575648698ed0f1318"
+    sha256 cellar: :any, sonoma:        "4b398176e1970a07bb7b90dd5d31d833837587834cd1e11760c31990eed7762a"
+  end
+
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
   depends_on "pybind11" => :build

--- a/Formula/gz-math9.rb
+++ b/Formula/gz-math9.rb
@@ -4,7 +4,7 @@ class GzMath9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-math/releases/gz-math-9.2.0.tar.bz2"
   sha256 "0fd6d0b992c16b60ab9c4dae29f10abb389557ec7ccd3b9450b5f4a66ee52140"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-math.git", branch: "gz-math9"
 

--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -4,7 +4,7 @@ class GzSim10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-10.5.0.tar.bz2"
   sha256 "2f609f8130ee3e9ce9de0e8e94aa9aa92f0eb433ac256c84f38932f988edd4f0"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim10"
 

--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -8,6 +8,13 @@ class GzSim10 < Formula
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "177922cf989873ef6424481f4c0cc6d7adc181388a3474f3767c5768beb333b0"
+    sha256 arm64_sonoma:  "a91c4df85c5295463215b88e73602ade5519a5ed4b83af5b733c6bc80a38e40c"
+    sha256 sonoma:        "966ee8e6a631b80e51e4d48848c1d3f55d908f6f89f78e336921838e936e900d"
+  end
+
   depends_on "cmake" => :build
   depends_on "pybind11" => :build
   depends_on "abseil"

--- a/Formula/gz-transport15.rb
+++ b/Formula/gz-transport15.rb
@@ -8,6 +8,13 @@ class GzTransport15 < Formula
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport15"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "3ec25aa92af93f9f416533254ddba235df446a0e656421a697eb66c935d6b564"
+    sha256 arm64_sonoma:  "c3aa2df061180ff587b67381e69aad58743c07bc5e2ac267051d43e6e6a0fa58"
+    sha256 sonoma:        "59113a72ac2574f0d4eb37ded181fe80d97f2f79d5260178c559d3012549faf1"
+  end
+
   depends_on "doxygen" => [:build, :optional]
   depends_on "pybind11" => :build
   depends_on "python@3.12" => [:build, :test]

--- a/Formula/gz-transport15.rb
+++ b/Formula/gz-transport15.rb
@@ -4,7 +4,7 @@ class GzTransport15 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/gz-transport-15.1.0.tar.bz2"
   sha256 "4518c85f5cf564137d8a8e9001b0b8099b435f6406e99ce28fc3a2f10020954e"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport15"
 

--- a/Formula/sdformat16.rb
+++ b/Formula/sdformat16.rb
@@ -4,7 +4,7 @@ class Sdformat16 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/sdformat/releases/sdformat-16.1.0.tar.bz2"
   sha256 "bda25c528fd3e340f5b3acface72ce9ac731cdd27674f2007595a4c77e31a051"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/sdformat.git", branch: "sdf16"
 

--- a/Formula/sdformat16.rb
+++ b/Formula/sdformat16.rb
@@ -8,6 +8,13 @@ class Sdformat16 < Formula
 
   head "https://github.com/gazebosim/sdformat.git", branch: "sdf16"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "f0d20e1b580e0ebb065920c4f2af1bb972fd841b19c92f7737b3880ebfbb89c5"
+    sha256 arm64_sonoma:  "1444d95b54dc319da955d83f80f399858f6156bcf52e4fd769fc083920f4377a"
+    sha256 sonoma:        "7889e12c7b787748afc0f78f7ca592a94a9b466982dffb96e5a0bdd5c93a5bca"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
   depends_on "pybind11" => :build


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/3454.

Generated by https://build.osrfoundation.org/job/generic-release-homebrew_bump_unbottled_dependencies/82/