### PR TITLE
Fortress: rebuild for pybind11, ffmpeg

### DIFF
--- a/Formula/ignition-common4.rb
+++ b/Formula/ignition-common4.rb
@@ -6,6 +6,13 @@ class IgnitionCommon4 < Formula
   license "Apache-2.0"
   revision 2
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "9eeb86a8da79d5e54c3b31657c2e6d288ab772e4005e685dc488fcac4275d5dc"
+    sha256 cellar: :any, arm64_sonoma:  "fbe73f1990471b42d0dfe4175555fb25fa70c3f306e42b6a8adda5513081494d"
+    sha256 cellar: :any, sonoma:        "0dace6b5ab2a5a7b75a09aeea52c04c1c1fc95bc3599441a68dd94f052e44c37"
+  end
+
   # head "https://github.com/gazebosim/gz-common.git", branch: "ign-common4"
 
   depends_on "cmake"

--- a/Formula/ignition-common4.rb
+++ b/Formula/ignition-common4.rb
@@ -4,7 +4,7 @@ class IgnitionCommon4 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-common/releases/ignition-common-4.8.1.tar.bz2"
   sha256 "fc6263b819cc320c6ce8c6956aa2713e62330aeca63e4c0c352c852c9af55ad4"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   # head "https://github.com/gazebosim/gz-common.git", branch: "ign-common4"
 

--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -8,6 +8,13 @@ class IgnitionFuelTools7 < Formula
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools7"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "ddc26d4d70c0ccd5fa48e531aac26809e0b4511bf59d25f4c6e1dc00cdafebf1"
+    sha256 cellar: :any, arm64_sonoma:  "8c9883725353ba4412f8b5a57e49c5bea5ce47ffcd90895cfd0f7d80eaad4d97"
+    sha256 cellar: :any, sonoma:        "25e638c0b79d53e243ff958e25151933bdb5617608375fbc5a4ba76a85a998e8"
+  end
+
   depends_on "abseil"
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -4,7 +4,7 @@ class IgnitionFuelTools7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/ignition-fuel_tools-7.3.1.tar.bz2"
   sha256 "b8224c574406147ae008ed9a0ac459f1e2582f6aaef7ba44e1fd1c5ac97b6de8"
   license "Apache-2.0"
-  revision 45
+  revision 46
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools7"
 

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -8,6 +8,13 @@ class IgnitionGazebo6 < Formula
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo6"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "1b4dea3bd94cb5e5129f733f66467e507d092d2cdd21f139821e490c9ba8ec95"
+    sha256 arm64_sonoma:  "7b28151d70221f9b01aa84c1280cf82cf19427ed63ecf76f4ebc1745d46683b2"
+    sha256 sonoma:        "8e0718cbfd0ebce45450a61649bdd07d8c4ec483e1114a877e1c1276aa108f88"
+  end
+
   depends_on "cmake" => :build
   depends_on "pybind11" => :build
   depends_on "gz-plugin2" => :test

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -4,7 +4,7 @@ class IgnitionGazebo6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/ignition-gazebo-6.18.0.tar.bz2"
   sha256 "9d3bbadc1a9c780b179890f4ac5978195d98a7a12f4cc23614d895276774fc99"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo6"
 

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -8,6 +8,13 @@ class IgnitionGui6 < Formula
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui6"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "20ed5a51200731da24f377e71912bca4163db77adc57dd32f8f6c93b975f0925"
+    sha256 arm64_sonoma:  "990cfee6fe84726bd1cfccf476eda6917df4cc6e7958b0feed0dbe25dadc858b"
+    sha256 sonoma:        "ab2eabf83d657e1ee4983318c5d4499df5052a832c166572a54fe0f8929f4c66"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
 

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -4,7 +4,7 @@ class IgnitionGui6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/ignition-gui-6.9.0.tar.bz2"
   sha256 "905f740430ae51579d40927f38683d075558c3694ce069f669fb50f7db9a94b5"
   license "Apache-2.0"
-  revision 9
+  revision 10
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui6"
 

--- a/Formula/ignition-launch5.rb
+++ b/Formula/ignition-launch5.rb
@@ -8,6 +8,13 @@ class IgnitionLaunch5 < Formula
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "ign-launch5"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "ee4fd12b6b6d42c1a5a9e13171b7464f51df5348f06a4ce99a6ac7ff3c34ed12"
+    sha256 arm64_sonoma:  "33b5cb5723c78338683a775848b01aff08fd978d362f25ae4572c14157a99358"
+    sha256 sonoma:        "6c1df6044da2f11e58fb2698dfe528b1e83606c97d11a4181eba25b272d116b2"
+  end
+
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
 

--- a/Formula/ignition-launch5.rb
+++ b/Formula/ignition-launch5.rb
@@ -4,7 +4,7 @@ class IgnitionLaunch5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/ignition-launch-5.3.1.tar.bz2"
   sha256 "abb724f65e820b04c056ee2e9329bc749dffcd6fc8e481eb9e4f83a719fb5492"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "ign-launch5"
 

--- a/Formula/ignition-math6.rb
+++ b/Formula/ignition-math6.rb
@@ -6,6 +6,13 @@ class IgnitionMath6 < Formula
   license "Apache-2.0"
   revision 2
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "e1ccb2baa14790a842c994c439af64a3cfe56bce070fb268743a1b9c58c53573"
+    sha256 cellar: :any, arm64_sonoma:  "ae9bf3c1dccb2570c6e5717db51a4b902f3f971a7aff774d61bacb5dcc431a5b"
+    sha256 cellar: :any, sonoma:        "a8ef83982466c31519add1d4fe95f0966ceada9318beb145e9448ca961a2c315"
+  end
+
   # head "https://github.com/gazebosim/gz-math.git", branch: "ign-math6"
 
   depends_on "cmake" => :build

--- a/Formula/ignition-math6.rb
+++ b/Formula/ignition-math6.rb
@@ -4,7 +4,7 @@ class IgnitionMath6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-math/releases/ignition-math-6.16.0.tar.bz2"
   sha256 "831a153253044bcb505dc9cf50b7f1e8c4ccd9213dd5bdb1d6d13719f775c991"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   # head "https://github.com/gazebosim/gz-math.git", branch: "ign-math6"
 

--- a/Formula/ignition-msgs8.rb
+++ b/Formula/ignition-msgs8.rb
@@ -8,6 +8,13 @@ class IgnitionMsgs8 < Formula
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs8"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "5f5f9f3f158417fb73e95332f4c6e911bde9c1f032ccfa40d31346404efd0184"
+    sha256 cellar: :any, arm64_sonoma:  "55563258d9f972cd792625bd19e7d3f12f2cb3d2c43cedaceeca3547f881bfbc"
+    sha256 cellar: :any, sonoma:        "28cc6ef3c0d042335964235eedbd91852bb6c68177fbc7f7bbe4183d0ffa8bcc"
+  end
+
   depends_on "abseil"
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-msgs8.rb
+++ b/Formula/ignition-msgs8.rb
@@ -4,7 +4,7 @@ class IgnitionMsgs8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/ignition-msgs-8.7.1.tar.bz2"
   sha256 "5de8edbcf971ea223756310129b2a25c0b5cba2657d736fd8f556eeec331bff0"
   license "Apache-2.0"
-  revision 9
+  revision 10
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs8"
 

--- a/Formula/ignition-sensors6.rb
+++ b/Formula/ignition-sensors6.rb
@@ -8,6 +8,13 @@ class IgnitionSensors6 < Formula
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors6"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256               arm64_sequoia: "98d606d8b7417a5d84ae18cc33aa82ed3c0dab08b1d2bf14de8ce32c3ccedbe6"
+    sha256               arm64_sonoma:  "be7e6cc5f3e96f4ef2466049233636c7e6939bdc978365f6a1cbf3ad08670afd"
+    sha256 cellar: :any, sonoma:        "efe6d2ba34acfa5906e3a77d70613df58abd915943db5cfd7af8f694a245ecbd"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
 

--- a/Formula/ignition-sensors6.rb
+++ b/Formula/ignition-sensors6.rb
@@ -4,7 +4,7 @@ class IgnitionSensors6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/ignition-sensors-6.9.0.tar.bz2"
   sha256 "20cc51bf730bfb3f9eba6fec0a8fc6c917b2841aa0b0543e183f60200e57ae4c"
   license "Apache-2.0"
-  revision 13
+  revision 14
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors6"
 

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -9,6 +9,13 @@ class IgnitionTransport11 < Formula
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport11"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "9708580682b2855e8cfa34c434d61d97d3d66d8ffa3e9529e63375dd231900e6"
+    sha256 arm64_sonoma:  "08ea9a8502e4c507f3e43154b7c879fa7ddd6ed306fc14c9a669a65b4146e9ad"
+    sha256 sonoma:        "67b3f57c86557213c0e48bcf56cd2def9486bb7bd9065c2bf78a1e7f18d697e9"
+  end
+
   depends_on "doxygen" => [:build, :optional]
 
   depends_on "abseil"

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -4,7 +4,7 @@ class IgnitionTransport11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/ignition-transport-11.4.2.tar.bz2"
   sha256 "5cb9a6a70d1c71e4bc60970e494b3ba82ecece757ccaa637c43b2193d4c15c72"
   license "Apache-2.0"
-  revision 9
+  revision 10
   version_scheme 1
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport11"


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/3513.

Generated by https://build.osrfoundation.org/job/generic-release-homebrew_bump_unbottled_dependencies/85/