### PR TITLE
gz-gui10: rebuild dependencies

### DIFF
--- a/Formula/gz-msgs12.rb
+++ b/Formula/gz-msgs12.rb
@@ -8,6 +8,13 @@ class GzMsgs12 < Formula
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs12"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "75871f8c2deb022f3f9ae71ec6592d5d1193878f3cf4139145b8a3f9608059aa"
+    sha256 arm64_sonoma:  "56aaf578470be7518ceb2ff6ae38f6346843814c1497997c615505c284a2de01"
+    sha256 sonoma:        "ac569a369bbc69c28c060125a9c202084258ebfb156541b0f83d6e758426ddb7"
+  end
+
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
   depends_on "python@3.14" => [:build, :test]

--- a/Formula/gz-msgs12.rb
+++ b/Formula/gz-msgs12.rb
@@ -4,7 +4,7 @@ class GzMsgs12 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/gz-msgs-12.0.2.tar.bz2"
   sha256 "cca452d55937998330801fbef97e3cfdb6298e6807bb53b64fbd826266950bb6"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs12"
 

--- a/Formula/gz-transport15.rb
+++ b/Formula/gz-transport15.rb
@@ -4,7 +4,7 @@ class GzTransport15 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/gz-transport-15.1.0.tar.bz2"
   sha256 "4518c85f5cf564137d8a8e9001b0b8099b435f6406e99ce28fc3a2f10020954e"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport15"
 

--- a/Formula/gz-transport15.rb
+++ b/Formula/gz-transport15.rb
@@ -8,6 +8,13 @@ class GzTransport15 < Formula
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport15"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "e06014ca5e8690e2d849e1d8897f74e9c64127998c010f984b5305d37d975297"
+    sha256 arm64_sonoma:  "bb541b9009b15514f5d4a989cc0e2b99c24af533ce00e6e26cf02548aec7f899"
+    sha256 sonoma:        "86aca07deba652c02ede1af3813681a084c4caa95f73e61f763bebd598f4a0fd"
+  end
+
   depends_on "doxygen" => [:build, :optional]
   depends_on "pybind11" => :build
   depends_on "python@3.12" => [:build, :test]


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/pull/3534.

Generated by https://build.osrfoundation.org/job/generic-release-homebrew_bump_unbottled_dependencies/87/