### PR TITLE
gz-fortress: rebuild dependencies

### DIFF
--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -4,7 +4,7 @@ class IgnitionFuelTools7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/ignition-fuel_tools-7.3.1.tar.bz2"
   sha256 "b8224c574406147ae008ed9a0ac459f1e2582f6aaef7ba44e1fd1c5ac97b6de8"
   license "Apache-2.0"
-  revision 47
+  revision 48
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools7"
 

--- a/Formula/ignition-fuel-tools7.rb
+++ b/Formula/ignition-fuel-tools7.rb
@@ -8,6 +8,13 @@ class IgnitionFuelTools7 < Formula
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "ign-fuel-tools7"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "d5e6764711940e905ab5bf432de058d94b7467c348c9484b64a1d42be7e25bcb"
+    sha256 cellar: :any, arm64_sonoma:  "dd260e059a8644e7f9e1f58c8b143c22309ed6a4f5934233e668cbc8cadfeecc"
+    sha256 cellar: :any, sonoma:        "b979ad94cd8b905b98acd061a58eb33f1911c7bdaa41a2b66f8d969868de33b6"
+  end
+
   depends_on "abseil"
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -4,7 +4,7 @@ class IgnitionGazebo6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/ignition-gazebo-6.18.0.tar.bz2"
   sha256 "9d3bbadc1a9c780b179890f4ac5978195d98a7a12f4cc23614d895276774fc99"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo6"
 

--- a/Formula/ignition-gazebo6.rb
+++ b/Formula/ignition-gazebo6.rb
@@ -8,6 +8,13 @@ class IgnitionGazebo6 < Formula
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "ign-gazebo6"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "6d237f8f89e8e52dcbf24870ec3393c5f0507c66d42633b0048d4b7416f533e3"
+    sha256 arm64_sonoma:  "c37e567eea79a08300a18821778366fefe29df2533825016aa88ca5ae10a6bea"
+    sha256 sonoma:        "798d4ef43ce6bfa0866799562cb3ffc8e09db47585e3852bd0293d13e5d54592"
+  end
+
   depends_on "cmake" => :build
   depends_on "pybind11" => :build
   depends_on "gz-plugin2" => :test

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -8,6 +8,13 @@ class IgnitionGui6 < Formula
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui6"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "16fc7eff0b204ba3c70766238481640badf334f5cc4cbbeb596624e47c7d45e8"
+    sha256 arm64_sonoma:  "01c4908a4144e3115ad1bd1ac05229ec029c5c1c308020ab677e5e8ba6f5069e"
+    sha256 sonoma:        "13b75ff2ffe621b48d0de3fd77ff54f35d7083944fbeb06f3e3b73733e665aa0"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
 

--- a/Formula/ignition-gui6.rb
+++ b/Formula/ignition-gui6.rb
@@ -4,7 +4,7 @@ class IgnitionGui6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/ignition-gui-6.9.0.tar.bz2"
   sha256 "905f740430ae51579d40927f38683d075558c3694ce069f669fb50f7db9a94b5"
   license "Apache-2.0"
-  revision 11
+  revision 12
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "ign-gui6"
 

--- a/Formula/ignition-launch5.rb
+++ b/Formula/ignition-launch5.rb
@@ -8,6 +8,13 @@ class IgnitionLaunch5 < Formula
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "ign-launch5"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "e427210f1d11604333b4a578276d6cec43f320f813bb7a55b9220e0664493a46"
+    sha256 arm64_sonoma:  "037f9aaf473c6a6eb295c2034a57d76271d4abb3f53e4d77beaf4fa504ae76a6"
+    sha256 sonoma:        "e0e6ec1ffa448e838510cfb425ca2e7f0d8738fc25e1a3c733aa0a40a7c97aa4"
+  end
+
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
 

--- a/Formula/ignition-launch5.rb
+++ b/Formula/ignition-launch5.rb
@@ -4,7 +4,7 @@ class IgnitionLaunch5 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/ignition-launch-5.3.1.tar.bz2"
   sha256 "abb724f65e820b04c056ee2e9329bc749dffcd6fc8e481eb9e4f83a719fb5492"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "ign-launch5"
 

--- a/Formula/ignition-msgs8.rb
+++ b/Formula/ignition-msgs8.rb
@@ -4,7 +4,7 @@ class IgnitionMsgs8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/ignition-msgs-8.7.1.tar.bz2"
   sha256 "5de8edbcf971ea223756310129b2a25c0b5cba2657d736fd8f556eeec331bff0"
   license "Apache-2.0"
-  revision 11
+  revision 12
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs8"
 

--- a/Formula/ignition-msgs8.rb
+++ b/Formula/ignition-msgs8.rb
@@ -8,6 +8,13 @@ class IgnitionMsgs8 < Formula
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "ign-msgs8"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "5142da19331a7e2fd912bbfa4a74b437a19af35e2bf0254e22c6d1a3d2bc072d"
+    sha256 cellar: :any, arm64_sonoma:  "3090e2e7c2e7acefb7fa78178eba3550e6c73525f67286dee27a0a87f6eaf13a"
+    sha256 cellar: :any, sonoma:        "614ff53d97f334e13642990c5754f9c96f2fcb95ab32598262250c9a87b02bcf"
+  end
+
   depends_on "abseil"
   depends_on "cmake"
   depends_on "ignition-cmake2"

--- a/Formula/ignition-sensors6.rb
+++ b/Formula/ignition-sensors6.rb
@@ -4,7 +4,7 @@ class IgnitionSensors6 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/ignition-sensors-6.9.0.tar.bz2"
   sha256 "20cc51bf730bfb3f9eba6fec0a8fc6c917b2841aa0b0543e183f60200e57ae4c"
   license "Apache-2.0"
-  revision 15
+  revision 16
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors6"
 

--- a/Formula/ignition-sensors6.rb
+++ b/Formula/ignition-sensors6.rb
@@ -8,6 +8,13 @@ class IgnitionSensors6 < Formula
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "ign-sensors6"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256               arm64_sequoia: "1f95887de1771ba8665a890efe5f24a48d541231f0c4c95c81db2e05c474b00b"
+    sha256               arm64_sonoma:  "8a2ca5b602355dc22d05385c62dc251850571718192453b77662ffdf8764083e"
+    sha256 cellar: :any, sonoma:        "8c6935192ac5dceb65b31a63f1f05ac1a72d1407d94cc68f1db3d4587c6209ae"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
 

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -9,6 +9,13 @@ class IgnitionTransport11 < Formula
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport11"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "b5db1c7006d3a0ac46cffcc440e23b258b3395e2eb5dd37c29d834a4f57b7042"
+    sha256 arm64_sonoma:  "b32bdd16ea11603ecb8bf2d0d5d0b95f215bf732cbff32282b8bae90fe71ffd5"
+    sha256 sonoma:        "ef789183df082a24190e3ce90f4b6e176b47e19e23cbc3b9fd5460d5a69babb7"
+  end
+
   depends_on "doxygen" => [:build, :optional]
 
   depends_on "abseil"

--- a/Formula/ignition-transport11.rb
+++ b/Formula/ignition-transport11.rb
@@ -4,7 +4,7 @@ class IgnitionTransport11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/ignition-transport-11.4.2.tar.bz2"
   sha256 "5cb9a6a70d1c71e4bc60970e494b3ba82ecece757ccaa637c43b2193d4c15c72"
   license "Apache-2.0"
-  revision 11
+  revision 12
   version_scheme 1
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "ign-transport11"


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/3532.

Generated by https://build.osrfoundation.org/job/generic-release-homebrew_bump_unbottled_dependencies/92/