### PR TITLE
gz-common7: drop freeimage dependency

### DIFF
--- a/Formula/gz-common7.rb
+++ b/Formula/gz-common7.rb
@@ -18,7 +18,6 @@ class GzCommon7 < Formula
   depends_on "cmake"
   depends_on "ffmpeg"
   depends_on "fmt"
-  depends_on "freeimage"
   depends_on "gdal"
   depends_on "gz-cmake5"
   depends_on "gz-math9"


### PR DESCRIPTION
Dependency was dropped in 7.2.0, so remove it from formula metadata.