### PR TITLE
Jetty: rebuild for protobuf 36.1

### DIFF
--- a/Formula/gz-fuel-tools11.rb
+++ b/Formula/gz-fuel-tools11.rb
@@ -4,7 +4,7 @@ class GzFuelTools11 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-fuel-tools/releases/gz-fuel_tools-11.0.0.tar.bz2"
   sha256 "4b4dee9b5a2e8cf04f1000e568187a65dd379bf54f8acf16d4e31a29240b30f0"
   license "Apache-2.0"
-  revision 35
+  revision 36
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools11"
 

--- a/Formula/gz-fuel-tools11.rb
+++ b/Formula/gz-fuel-tools11.rb
@@ -8,6 +8,12 @@ class GzFuelTools11 < Formula
 
   head "https://github.com/gazebosim/gz-fuel-tools.git", branch: "gz-fuel-tools11"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "8b28737e5e6aa4b35d9949339025d2504529f30029f591e67ea0b3629aa8a49e"
+    sha256 cellar: :any, arm64_sonoma:  "92f08e942c2ad7cf6ca0fcec32a19a9dc35d846d8109f8f77a06b5ce6f073f8e"
+  end
+
   depends_on "abseil"
   depends_on "cmake"
   depends_on "fmt"

--- a/Formula/gz-gui10.rb
+++ b/Formula/gz-gui10.rb
@@ -8,6 +8,12 @@ class GzGui10 < Formula
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "b67a1a998da8ed4ea0baf4f74329cc9613c1dbb94e3997a898794fbb6904bece"
+    sha256 arm64_sonoma:  "c496d8dd3a15ebc40f0991220a506944485ff75608aef0cc9d7e9a97f0a929e9"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
   depends_on "abseil"

--- a/Formula/gz-gui10.rb
+++ b/Formula/gz-gui10.rb
@@ -4,7 +4,7 @@ class GzGui10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-10.1.0.tar.bz2"
   sha256 "2bb422b974a783e6fbb8a57c5f0f2d4f7f9802ec3bb2b6766c7b07f00a193ed7"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui10"
 

--- a/Formula/gz-launch9.rb
+++ b/Formula/gz-launch9.rb
@@ -4,7 +4,7 @@ class GzLaunch9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-9.0.1.tar.bz2"
   sha256 "096f66cd2a5b58dc8ca93e9bc33c65e0cf82af7472f154fc2d8a955bc762cd5f"
   license "Apache-2.0"
-  revision 13
+  revision 14
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch9"
 

--- a/Formula/gz-launch9.rb
+++ b/Formula/gz-launch9.rb
@@ -8,6 +8,12 @@ class GzLaunch9 < Formula
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch9"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "4a741439a57e739e9f4ea94de4158e571f8b0306af3eb0fc39cbbe58011984a6"
+    sha256 arm64_sonoma:  "2df8aeb31387878aab259e8b0597a364ee071c602197cd5dfef47e3a4c3713db"
+  end
+
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
 

--- a/Formula/gz-msgs12.rb
+++ b/Formula/gz-msgs12.rb
@@ -4,7 +4,7 @@ class GzMsgs12 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-msgs/releases/gz-msgs-12.0.2.tar.bz2"
   sha256 "cca452d55937998330801fbef97e3cfdb6298e6807bb53b64fbd826266950bb6"
   license "Apache-2.0"
-  revision 7
+  revision 8
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs12"
 

--- a/Formula/gz-msgs12.rb
+++ b/Formula/gz-msgs12.rb
@@ -8,6 +8,12 @@ class GzMsgs12 < Formula
 
   head "https://github.com/gazebosim/gz-msgs.git", branch: "gz-msgs12"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "f1525b31ae87adde02c60498277c4c3e28810003d5aed514773ecf16bdeaa3c3"
+    sha256 arm64_sonoma:  "70fc181d7ed36f38651cae1aa25e1f02cff9f7d59302d7983148f62135d95555"
+  end
+
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
   depends_on "python@3.14" => [:build, :test]

--- a/Formula/gz-sensors10.rb
+++ b/Formula/gz-sensors10.rb
@@ -8,6 +8,12 @@ class GzSensors10 < Formula
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "ced018496c2154a4e483fd154389f9592428e3ba12946ac54d431893d85b69be"
+    sha256 cellar: :any, arm64_sonoma:  "d9594854a39a0404240091bd4598956a746350469e7a7e185c75cef252afddc7"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]
 

--- a/Formula/gz-sensors10.rb
+++ b/Formula/gz-sensors10.rb
@@ -4,7 +4,7 @@ class GzSensors10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-10.1.1.tar.bz2"
   sha256 "dee2adc768e64f3ddcdb96e6e480dd55135650d6547c61b621e27232b344827a"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors10"
 

--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -4,7 +4,7 @@ class GzSim10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-10.5.0.tar.bz2"
   sha256 "2f609f8130ee3e9ce9de0e8e94aa9aa92f0eb433ac256c84f38932f988edd4f0"
   license "Apache-2.0"
-  revision 11
+  revision 12
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim10"
 

--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -8,6 +8,12 @@ class GzSim10 < Formula
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim10"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "7040118b044f34e3a1b56e9ffcd9a3143f1fbc4cf6814e4a0240d7f853184f09"
+    sha256 arm64_sonoma:  "34a995d6adfa7b3bb8b93f0e343b4b0cddf4e8c3f4a196d76597a4609b1ae3aa"
+  end
+
   depends_on "cmake" => :build
   depends_on "pybind11" => :build
   depends_on "abseil"

--- a/Formula/gz-transport15.rb
+++ b/Formula/gz-transport15.rb
@@ -4,7 +4,7 @@ class GzTransport15 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-transport/releases/gz-transport-15.1.0.tar.bz2"
   sha256 "4518c85f5cf564137d8a8e9001b0b8099b435f6406e99ce28fc3a2f10020954e"
   license "Apache-2.0"
-  revision 9
+  revision 10
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport15"
 

--- a/Formula/gz-transport15.rb
+++ b/Formula/gz-transport15.rb
@@ -8,6 +8,12 @@ class GzTransport15 < Formula
 
   head "https://github.com/gazebosim/gz-transport.git", branch: "gz-transport15"
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 arm64_sequoia: "20882da32ac31aa391403bdb9a04edf846d204c95eeb64e512191aaa844248e6"
+    sha256 arm64_sonoma:  "7968a8cd1d8ca1cafd3086c05054c1f958bc24f3d0f5a5dce07642f466425bad"
+  end
+
   depends_on "doxygen" => [:build, :optional]
   depends_on "pybind11" => :build
   depends_on "python@3.12" => [:build, :test]


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/3557.

Generated by https://build.osrfoundation.org/job/generic-release-homebrew_bump_unbottled_dependencies/93/