### PR TITLE
Revert "Fix brew test-bot action (#3452)"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,9 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HOMEBREW_FORCE_VENDOR_RUBY: 1
-      # mitigation for "Warning: Bubblewrap is required to use the Linux sandbox but was not found."
-      # remove when `brew doctor` can succeed without it
-      HOMEBREW_NO_SANDBOX_LINUX: 1
     steps:
       - name: Activate Homebrew
         if: runner.os == 'Linux'


### PR DESCRIPTION
This reverts commit 87455bb18dc15a974b717be8663de6cfeee022f4.

A brew test-bot error was mitigated in #3452 by setting `HOMEBREW_NO_SANDBOX_LINUX`, but that is now giving errors in https://github.com/osrf/homebrew-simulation/pull/3560 (https://github.com/osrf/homebrew-simulation/pull/3560/commits/d05f82c5938eb4ae06d97e75da457cd11f34374c):

~~~
Error: Calling HOMEBREW_NO_SANDBOX_LINUX is deprecated! Use a Landlock-enabled Linux kernel instead.
~~~

Reverting the mitigation appears to fix the current complaint.