### PR TITLE
Remove ogre2.3 and dependent bottles

### DIFF
--- a/Formula/gz-gui10.rb
+++ b/Formula/gz-gui10.rb
@@ -4,15 +4,9 @@ class GzGui10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-10.1.0.tar.bz2"
   sha256 "2bb422b974a783e6fbb8a57c5f0f2d4f7f9802ec3bb2b6766c7b07f00a193ed7"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui10"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "b67a1a998da8ed4ea0baf4f74329cc9613c1dbb94e3997a898794fbb6904bece"
-    sha256 arm64_sonoma:  "c496d8dd3a15ebc40f0991220a506944485ff75608aef0cc9d7e9a97f0a929e9"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-gui8.rb
+++ b/Formula/gz-gui8.rb
@@ -4,15 +4,9 @@ class GzGui8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-8.4.0.tar.bz2"
   sha256 "1731b01a134afb11b1b3e049fc65e74fa7b5c50532406d3d68366d54016d5498"
   license "Apache-2.0"
-  revision 40
+  revision 41
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "46c2f74e5abd04abbe2d630122bee5e33aec2619bea3505257ad301ea01acccc"
-    sha256 arm64_sonoma:  "d1abfdf7450ffd0a29c35289de75ff67aae03437a05ce6e5d2e1d9a781409168"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-gui9.rb
+++ b/Formula/gz-gui9.rb
@@ -4,15 +4,9 @@ class GzGui9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-gui/releases/gz-gui-9.0.2.tar.bz2"
   sha256 "0db7bdbaf32c3e9faba301c6d04e8cbf2daabdf639c45aedc10ec48356ea3d16"
   license "Apache-2.0"
-  revision 34
+  revision 35
 
   head "https://github.com/gazebosim/gz-gui.git", branch: "gz-gui9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "7b461549014fa883a7f8a92d96afd83041c57adcc75c109f90261e3e8fd9baf8"
-    sha256 arm64_sonoma:  "91e7121d53ed7ed90f0ca0d86237cd92eac9436f6e38928cf12bce109a2d25dd"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-launch7.rb
+++ b/Formula/gz-launch7.rb
@@ -4,15 +4,9 @@ class GzLaunch7 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-7.1.2.tar.bz2"
   sha256 "d47e393e50b8da244562f7b75c8dc4f9882c966d0331c53bec107f6bf7d95a0f"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch7"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "b8b13d1f003ac6a1d8f7ed0c90772f424c646c47d1537ad80dddd4b4545e8c6c"
-    sha256 arm64_sonoma:  "123063a39723ae2a503291678e52288d47928b0df2b10ca11046f36889df48d5"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build

--- a/Formula/gz-launch8.rb
+++ b/Formula/gz-launch8.rb
@@ -4,13 +4,7 @@ class GzLaunch8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-8.0.3.tar.bz2"
   sha256 "faf72b89d32d796f767893898ffb7c4ad49b52715b64bc51398a939ab23fa6ce"
   license "Apache-2.0"
-  revision 8
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "f663fc8997ef89ab8ad6a5e9e81d8a8ff65ddad17a939a4349e312363e443d81"
-    sha256 arm64_sonoma:  "f450620bbdda0167dd954292b0d70917b97b79d02dd7e29a5f2c37ba29127573"
-  end
+  revision 9
 
   # head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch8"
 

--- a/Formula/gz-launch9.rb
+++ b/Formula/gz-launch9.rb
@@ -4,15 +4,9 @@ class GzLaunch9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-launch/releases/gz-launch-9.0.1.tar.bz2"
   sha256 "096f66cd2a5b58dc8ca93e9bc33c65e0cf82af7472f154fc2d8a955bc762cd5f"
   license "Apache-2.0"
-  revision 14
+  revision 15
 
   head "https://github.com/gazebosim/gz-launch.git", branch: "gz-launch9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "4a741439a57e739e9f4ea94de4158e571f8b0306af3eb0fc39cbbe58011984a6"
-    sha256 arm64_sonoma:  "2df8aeb31387878aab259e8b0597a364ee071c602197cd5dfef47e3a4c3713db"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build

--- a/Formula/gz-rendering10.rb
+++ b/Formula/gz-rendering10.rb
@@ -4,15 +4,9 @@ class GzRendering10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-rendering/releases/gz-rendering-10.0.2.tar.bz2"
   sha256 "6a4b71dad22a758494570b6e76344744106934ba56f5e58ad3f6bb9e7efb60e2"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering10"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "2bbce7da56001c626b463f66d2934465949e4721093655ee384c717c63122186"
-    sha256 arm64_sonoma:  "67f8ee64e75b9899e7c0b2100cae147f17860ddf414fecb56f12417f3cb2d18c"
-    sha256 sonoma:        "adbb4f4bfc52569a80cd89992d907fba2ca670d25ac4380451fcd7e8ab515036"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-rendering8.rb
+++ b/Formula/gz-rendering8.rb
@@ -4,14 +4,7 @@ class GzRendering8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-rendering/releases/gz-rendering-8.2.3.tar.bz2"
   sha256 "a8ca484a57256d92e087893140309b8ac2dacfd5ea2f4c014eb8dc77f0705786"
   license "Apache-2.0"
-  revision 4
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "3f2abba2cb925c1038ea30ec06c4085eaea8edf3f1feb6457276e7a5b1397247"
-    sha256 arm64_sonoma:  "f56860397e7018d8691c99ff7fdefe2f25fb5a11572de13a0c5c937ea5c77692"
-    sha256 sonoma:        "9c2620c1ae3022d326c0b7fc2c27843b12adcb699a4b9f4f76a8480042cbeb4f"
-  end
+  revision 5
 
   # head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering8"
 

--- a/Formula/gz-rendering9.rb
+++ b/Formula/gz-rendering9.rb
@@ -4,14 +4,7 @@ class GzRendering9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-rendering/releases/gz-rendering-9.5.0.tar.bz2"
   sha256 "cb915b9333e0a9730f05d396efdcdbbb93002c3902181f82f1b4c88a76c47440"
   license "Apache-2.0"
-  revision 6
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "e9e808e9bae2de1916d130baa37ad70d654ea65d3c9f55cd398539edc1d47791"
-    sha256 arm64_sonoma:  "6901cce56a3d9e8ea5ee9f79157ae16f4057289ad725a479ae70a4e4c64978d1"
-    sha256 sonoma:        "0554f310880ef9df88c5bab72633df80440d18ef3e3afaceac48b99f11e9e8ab"
-  end
+  revision 7
 
   # head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering9"
 

--- a/Formula/gz-rotary-ogre2.3-vendor.rb
+++ b/Formula/gz-rotary-ogre2.3-vendor.rb
@@ -4,14 +4,7 @@ class GzRotaryOgre23Vendor < Formula
   url "https://github.com/OGRECave/ogre-next/archive/refs/tags/v2.3.3.tar.gz"
   sha256 "92ce7765d892d6424df3d8d4a56a8fc0b2f4f91c216b1b1d5b231caa9abaaa38"
   license "MIT"
-  revision 2
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, arm64_sequoia: "7422b54fc3933ff8b932cc201ea31832ef8e3ed36bc2eadc71de349a497fd04d"
-    sha256 cellar: :any, arm64_sonoma:  "a2fd5cba4837216844a81098b33dd88c6b531b30d272a36e185f561041023022"
-    sha256 cellar: :any, sonoma:        "ac5564e0a67bb68bc3357a67fb052464fbac8bc22565e107e54eae2c4f67a609"
-  end
+  revision 3
 
   # head "https://github.com/OGRECave/ogre-next.git", branch: "v2-3"
 

--- a/Formula/gz-sensors10.rb
+++ b/Formula/gz-sensors10.rb
@@ -4,15 +4,9 @@ class GzSensors10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-10.1.1.tar.bz2"
   sha256 "dee2adc768e64f3ddcdb96e6e480dd55135650d6547c61b621e27232b344827a"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors10"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, arm64_sequoia: "ced018496c2154a4e483fd154389f9592428e3ba12946ac54d431893d85b69be"
-    sha256 cellar: :any, arm64_sonoma:  "d9594854a39a0404240091bd4598956a746350469e7a7e185c75cef252afddc7"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-sensors8.rb
+++ b/Formula/gz-sensors8.rb
@@ -4,15 +4,9 @@ class GzSensors8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-8.2.2.tar.bz2"
   sha256 "9ddc16d5cab0a86f27771732f5cfcfde1efe7611f27da61176ea122273806c42"
   license "Apache-2.0"
-  revision 43
+  revision 44
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, arm64_sequoia: "c6396e6db79985427b71d1c537515dffc70ef45e488365ee3aff6b68d97fac5f"
-    sha256 cellar: :any, arm64_sonoma:  "727fd28c0e778b6b849b18958397747b3c9a6b33c9b1994b7fbad0cade5d26b5"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-sensors9.rb
+++ b/Formula/gz-sensors9.rb
@@ -4,15 +4,9 @@ class GzSensors9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sensors/releases/gz-sensors-9.2.0.tar.bz2"
   sha256 "af2ec9a453a830338e80e94954160030e81b3ff8f60853e7c5730cdd2950be85"
   license "Apache-2.0"
-  revision 47
+  revision 48
 
   head "https://github.com/gazebosim/gz-sensors.git", branch: "gz-sensors9"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, arm64_sequoia: "25a442b5dc369fa8c0e8d454f7f9424d6ed90d98e7ee45357165551b862546c7"
-    sha256 cellar: :any, arm64_sonoma:  "cafaa70a6b43dd5cb0c18541ab4ede9ab639afbb5f19fc71d19cbf0876bff684"
-  end
 
   depends_on "cmake" => [:build, :test]
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/gz-sim10.rb
+++ b/Formula/gz-sim10.rb
@@ -4,15 +4,9 @@ class GzSim10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-10.5.0.tar.bz2"
   sha256 "2f609f8130ee3e9ce9de0e8e94aa9aa92f0eb433ac256c84f38932f988edd4f0"
   license "Apache-2.0"
-  revision 12
+  revision 13
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim10"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "7040118b044f34e3a1b56e9ffcd9a3143f1fbc4cf6814e4a0240d7f853184f09"
-    sha256 arm64_sonoma:  "34a995d6adfa7b3bb8b93f0e343b4b0cddf4e8c3f4a196d76597a4609b1ae3aa"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build

--- a/Formula/gz-sim8.rb
+++ b/Formula/gz-sim8.rb
@@ -4,15 +4,9 @@ class GzSim8 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-8.15.0.tar.bz2"
   sha256 "f457478cc8b319be148aa1e7a3bc14042c333c8881c1f92ea6d498344fea891d"
   license "Apache-2.0"
-  revision 4
+  revision 5
 
   head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim8"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "02141fdc84fde9c47ae895a4a3db8214c3b7b4d0fb2116fc01c454366a50a4f3"
-    sha256 arm64_sonoma:  "a1bb611a5c4c57b7676d8648b67171df0f1687cc8e326cc345ff60506757106a"
-  end
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build

--- a/Formula/gz-sim9.rb
+++ b/Formula/gz-sim9.rb
@@ -4,13 +4,7 @@ class GzSim9 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-sim/releases/gz-sim-9.6.0.tar.bz2"
   sha256 "62733d759a8da115c05120af1f560b05c92e9863bd382a4dada813513c5c8cc4"
   license "Apache-2.0"
-  revision 4
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 arm64_sequoia: "bdd5193595ec67f4426a973f5780d668e194703d4599df5d1c482a8ad3d7d522"
-    sha256 arm64_sonoma:  "27b28cfc19a41872a277ca8e89e31baf6c6f3664e17bb6cbdb512499d3b16280"
-  end
+  revision 5
 
   # head "https://github.com/gazebosim/gz-sim.git", branch: "gz-sim9"
 

--- a/Formula/ogre2.3.rb
+++ b/Formula/ogre2.3.rb
@@ -4,19 +4,9 @@ class Ogre23 < Formula
   url "https://github.com/OGRECave/ogre-next/archive/refs/tags/v2.3.1.tar.gz"
   sha256 "38dd0d5ba5759ee47c71552c5dacf44dad5fe61868025dcbd5ea6a6bdb6bc8e4"
   license "MIT"
-  revision 2
+  revision 3
 
   # head "https://github.com/OGRECave/ogre-next.git", branch: "v2-3"
-
-  bottle do
-    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
-    sha256 cellar: :any, arm64_sequoia: "9e3d6499d30d18d1fb74fc6d4267dd6448ce34d3bb567f5a7b19471bf235cd8c"
-    sha256 cellar: :any, arm64_sonoma:  "be121e86ff8d7def125d8579583fbf32b9bcd475f2b2eee7f20948aa4afc6aee"
-    sha256 cellar: :any, sonoma:        "00e8a7721f3a33eb5f5df26c70a597e71ee06328949cecae7e85c79badf8a34f"
-    sha256 cellar: :any, ventura:       "a99ca4c5adc6c3455d9df29aa00c944f3dddb2ff64c176cb37efc759b8bc1498"
-    sha256 cellar: :any, monterey:      "58e4f7a6d4e1ae1a70b2f449801b4335deb378dc982f38f2bc3cfc6393a5e0b0"
-    sha256 cellar: :any, big_sur:       "2cd52cc99ea96660c7a83e2c5458c900f0abd4af3fdd7b69117ad87b407d0a2a"
-  end
 
   depends_on "cmake" => :build
   depends_on "gz-plugin2" => :test


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/3298.

Generated by https://build.osrfoundation.org/job/generic-release-homebrew_remove_dependent_bottles/46/