### PR TITLE
Jetty: use ogre2.3 without freeimage

### DIFF
--- a/Aliases/gz-jetty-ogre2.3
+++ b/Aliases/gz-jetty-ogre2.3
@@ -1,1 +1,1 @@
-../Formula/ogre2.3-with-freeimage.rb
+../Formula/ogre2.3.rb

--- a/Formula/gz-rendering10.rb
+++ b/Formula/gz-rendering10.rb
@@ -4,7 +4,7 @@ class GzRendering10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-rendering/releases/gz-rendering-10.0.2.tar.bz2"
   sha256 "6a4b71dad22a758494570b6e76344744106934ba56f5e58ad3f6bb9e7efb60e2"
   license "Apache-2.0"
-  revision 2
+  revision 1
 
   head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering10"
 

--- a/Formula/gz-rendering10.rb
+++ b/Formula/gz-rendering10.rb
@@ -4,7 +4,7 @@ class GzRendering10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-rendering/releases/gz-rendering-10.0.2.tar.bz2"
   sha256 "6a4b71dad22a758494570b6e76344744106934ba56f5e58ad3f6bb9e7efb60e2"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering10"
 
@@ -12,14 +12,13 @@ class GzRendering10 < Formula
   depends_on "pkgconf" => [:build, :test]
 
   depends_on "fmt"
-  depends_on "freeimage"
   depends_on "gz-cmake5"
   depends_on "gz-common7"
   depends_on "gz-math9"
   depends_on "gz-plugin4"
   depends_on "gz-utils4"
   depends_on "ogre1.9"
-  depends_on "ogre2.3-with-freeimage"
+  depends_on "ogre2.3"
   depends_on "spdlog"
 
   conflicts_with "gz-rotary-rendering", because: "both install gz-rendering"

--- a/Formula/ogre2.3.rb
+++ b/Formula/ogre2.3.rb
@@ -6,6 +6,12 @@ class Ogre23 < Formula
   license "MIT"
   revision 1
 
+  bottle do
+    root_url "https://osrf-distributions.s3.amazonaws.com/bottles-simulation"
+    sha256 cellar: :any, arm64_sequoia: "4bd5e591f13730205c3b63cfc2328e0e6a4e33438e29f72dd26fb6a51fcacb78"
+    sha256 cellar: :any, arm64_sonoma:  "db3541dd1d318f0dcf37ddc5821cbfce69c29c6c80667aecc2310d9def5d4cb6"
+  end
+
   # head "https://github.com/OGRECave/ogre-next.git", branch: "v2-3"
 
   depends_on "cmake" => :build

--- a/Formula/ogre2.3.rb
+++ b/Formula/ogre2.3.rb
@@ -4,6 +4,7 @@ class Ogre23 < Formula
   url "https://github.com/OGRECave/ogre-next/archive/refs/tags/v2.3.3.tar.gz"
   sha256 "92ce7765d892d6424df3d8d4a56a8fc0b2f4f91c216b1b1d5b231caa9abaaa38"
   license "MIT"
+  revision 1
 
   # head "https://github.com/OGRECave/ogre-next.git", branch: "v2-3"
 


### PR DESCRIPTION
Part of #3298. Switches to ogre2.3 without freeimage and drops the direct `freeimage` dependency but keeps ogre1.9 for now.

## testing

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_rendering10-install_bottle-homebrew-arm64&build=364)](https://build.osrfoundation.org/job/gz_rendering10-install_bottle-homebrew-arm64/364/) https://build.osrfoundation.org/job/gz_rendering10-install_bottle-homebrew-arm64/364/
* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_sensors10-install_bottle-homebrew-arm64&build=368)](https://build.osrfoundation.org/job/gz_sensors10-install_bottle-homebrew-arm64/368/) https://build.osrfoundation.org/job/gz_sensors10-install_bottle-homebrew-arm64/368/