### PR TITLE
Jetty: drop ogre1.9

### DIFF
--- a/Formula/gz-rendering10.rb
+++ b/Formula/gz-rendering10.rb
@@ -4,7 +4,7 @@ class GzRendering10 < Formula
   url "https://osrf-distributions.s3.amazonaws.com/gz-rendering/releases/gz-rendering-10.0.2.tar.bz2"
   sha256 "6a4b71dad22a758494570b6e76344744106934ba56f5e58ad3f6bb9e7efb60e2"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   head "https://github.com/gazebosim/gz-rendering.git", branch: "gz-rendering10"
 
@@ -17,7 +17,6 @@ class GzRendering10 < Formula
   depends_on "gz-math9"
   depends_on "gz-plugin4"
   depends_on "gz-utils4"
-  depends_on "ogre1.9"
   depends_on "ogre2.3"
   depends_on "spdlog"
 
@@ -44,7 +43,7 @@ class GzRendering10 < Formula
     extend SystemCommand::Mixin
 
     # test plugins in subfolders
-    ["ogre", "ogre2"].each do |engine|
+    ["ogre2"].each do |engine|
       p = lib/"gz-rendering-10/engine-plugins/libgz-rendering-#{engine}.dylib"
       # Use gz-plugin --info command to check plugin linking
       cmd = formula_opt_libexec("gz-plugin4")/"gz/plugin4/gz-plugin"
@@ -64,13 +63,13 @@ class GzRendering10 < Formula
       int main(int _argc, char** _argv)
       {
         gz::rendering::RenderEngine *engine =
-            gz::rendering::engine("ogre");
+            gz::rendering::engine("ogre2");
         return engine == nullptr;
       }
     EOS
     (testpath/"CMakeLists.txt").write <<-EOS
       cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
-      find_package(gz-rendering REQUIRED COMPONENTS ogre ogre2)
+      find_package(gz-rendering REQUIRED COMPONENTS ogre2)
       add_executable(test_cmake test.cpp)
       target_link_libraries(test_cmake gz-rendering::gz-rendering)
     EOS


### PR DESCRIPTION
Fully removes dependency on freeimage. Part of #3298.

Keeping this in draft until January.

## testing

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_rendering10-install_bottle-homebrew-arm64&build=365)](https://build.osrfoundation.org/job/gz_rendering10-install_bottle-homebrew-arm64/365/) https://build.osrfoundation.org/job/gz_rendering10-install_bottle-homebrew-arm64/365/
* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_sensors10-install_bottle-homebrew-arm64&build=369)](https://build.osrfoundation.org/job/gz_sensors10-install_bottle-homebrew-arm64/369/) https://build.osrfoundation.org/job/gz_sensors10-install_bottle-homebrew-arm64/369/